### PR TITLE
Stabilize row dict generator and auth handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,4 +69,6 @@ repos:
     rev: 1.7.5
     hooks:
     -   id: bandit
+        additional_dependencies:
+          - pbr
         args: ["-x", "tests/*.py"]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ so if you read a service with 100000 features but there's a limit of 1000 record
 
 these functions use asyncio to read all features from a service, not limited by max record count
 
-keyword arguments to `FeatureLayer.getgdf` are passed on to `requests.Session.post`; include query parameters like where str and token str in data dict
+keyword arguments to `FeatureLayer.getgdf` are passed on to `aiohttp.ClientSession.post`; include query parameters like `where` and `token` in the `data` dict when needed
 
-this enables enhanced control over queries and allow use of any valid authentication scheme (eg `requests_ntlm.HttpNtlmAuth`) with use of `requests.Session.auth` or `data={"token": str}`
+this enables enhanced control over queries and supports either direct `data={"token": "..."}` usage or a reusable `ArcGISTokenSession`
 
 # Usage
 
@@ -76,6 +76,37 @@ print(daytona_gdf.shape)
 print(oh_zipcodes_gdf.shape)
 # (1026, 8)
 ```
+
+## Token authentication
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from restgdf import AGOLUserPass, ArcGISTokenSession, FeatureLayer
+
+
+secured_url = "https://example.com/arcgis/rest/services/Secured/FeatureServer/0"
+
+
+async def main():
+    async with ClientSession() as base_session:
+        token_session = ArcGISTokenSession(
+            session=base_session,
+            credentials=AGOLUserPass(
+                username="my-username",
+                password="my-password",
+            ),
+        )
+        layer = await FeatureLayer.from_url(secured_url, session=token_session)
+        return await layer.getgdf()
+
+
+secured_gdf = asyncio.run(main())
+```
+
+If you already have a token, you can pass it with `token="..."` or `data={"token": "..."}`.
 
 # Documentation
 

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -1,0 +1,74 @@
+Authentication
+==============
+
+restgdf supports secured ArcGIS services in two common ways:
+
+1. Pass an existing ArcGIS token in the request ``data`` payload.
+2. Wrap an ``aiohttp.ClientSession`` in ``ArcGISTokenSession`` so tokens are requested and refreshed automatically.
+
+Direct token usage
+------------------
+
+If you already have a valid token, pass it directly when you create the layer:
+
+.. code-block:: python
+
+   import asyncio
+
+   from aiohttp import ClientSession
+
+   from restgdf import FeatureLayer
+
+
+   async def main():
+       async with ClientSession() as session:
+           layer = await FeatureLayer.from_url(
+               "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+               session=session,
+               token="my-token",
+           )
+           return await layer.getgdf()
+
+
+   secured_gdf = asyncio.run(main())
+
+You can also pass the same value via ``data={"token": "my-token"}`` if you prefer to keep all ArcGIS query params together.
+
+Automatic token management
+--------------------------
+
+Use ``ArcGISTokenSession`` when you want the session to mint and refresh ArcGIS Online tokens for you:
+
+.. code-block:: python
+
+   import asyncio
+
+   from aiohttp import ClientSession
+
+   from restgdf import AGOLUserPass, ArcGISTokenSession, FeatureLayer
+
+
+   async def main():
+       async with ClientSession() as base_session:
+           token_session = ArcGISTokenSession(
+               session=base_session,
+               credentials=AGOLUserPass(
+                   username="my-username",
+                   password="my-password",
+               ),
+           )
+           layer = await FeatureLayer.from_url(
+               "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+               session=token_session,
+           )
+           return await layer.getgdf()
+
+
+   secured_gdf = asyncio.run(main())
+
+Notes
+-----
+
+- ``ArcGISTokenSession`` delegates network I/O to the wrapped ``aiohttp.ClientSession``.
+- If you provide ``credentials``, the token is refreshed when it is missing or near expiry.
+- Existing request kwargs and ``data`` payloads still work; the token session only augments them with auth data.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,4 +41,4 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_rtd_theme'
-html_static_path = ['_static']
+html_static_path = ['_static'] if os.path.isdir('_static') else []

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Welcome to restgdf's documentation!
    :caption: Contents:
 
    restgdf
+   authentication
    utils
 
 Indices and tables

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -32,3 +32,11 @@ restgdf.utils.utils
    :members:
    :undoc-members:
    :show-inheritance:
+
+restgdf.utils.token
+-------------------
+
+.. automodule:: restgdf.utils.token
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/restgdf/__init__.py
+++ b/restgdf/__init__.py
@@ -1,10 +1,17 @@
 """A package for getting GeoDataFrames from ArcGIS FeatureLayers."""
 
-from restgdf.featurelayer.featurelayer import FeatureLayer
 from restgdf.directory.directory import Directory
+from restgdf.featurelayer.featurelayer import FeatureLayer
+from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
 from restgdf import utils
 
-__all__ = ["Directory", "FeatureLayer", "utils"]
+__all__ = [
+    "AGOLUserPass",
+    "ArcGISTokenSession",
+    "Directory",
+    "FeatureLayer",
+    "utils",
+]
 
 
 __version__ = "1.0.0"

--- a/restgdf/directory/directory.py
+++ b/restgdf/directory/directory.py
@@ -5,6 +5,7 @@ import aiohttp
 
 from restgdf.utils.getinfo import get_metadata
 from restgdf.utils.crawl import fetch_all_data
+from restgdf.utils.token import ArcGISTokenSession
 
 
 class Directory:
@@ -13,7 +14,7 @@ class Directory:
     def __init__(
         self,
         url: str,
-        session: aiohttp.ClientSession,
+        session: aiohttp.ClientSession | ArcGISTokenSession,
         token: str | None = None,
     ):
         """A class for interacting with ArcGIS Server directories."""
@@ -50,7 +51,7 @@ class Directory:
         return [
             layer
             for service in self.services
-            for layer in service["metadata"]["layers"]
+            for layer in service.get("metadata", {}).get("layers", [])
             if layer["type"] == layer_type
         ]
 

--- a/restgdf/directory/directory.py
+++ b/restgdf/directory/directory.py
@@ -21,7 +21,8 @@ class Directory:
         self.url = url
         self.session = session
         self.token = token
-        self.services: dict | None = None
+        self.services: list[dict] | None = None
+        self.services_with_feature_count: list[dict] | None = None
         self.metadata: dict | None = None
 
     async def prep(self):
@@ -34,13 +35,25 @@ class Directory:
         await self.prep()
         return self
 
-    async def crawl(self, return_feature_count: bool = False) -> dict:
+    async def crawl(self, return_feature_count: bool = False) -> list[dict]:
+        if return_feature_count:
+            if self.services_with_feature_count is None:
+                all_data = await fetch_all_data(
+                    self.session,
+                    self.url,
+                    self.token,
+                    return_feature_count=True,
+                )
+                self.services_with_feature_count = all_data["services"]
+            self.services = self.services_with_feature_count
+            return self.services_with_feature_count
+
         if self.services is None:
             all_data = await fetch_all_data(
                 self.session,
                 self.url,
                 self.token,
-                return_feature_count,
+                return_feature_count=False,
             )
             self.services = all_data["services"]
         return self.services

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import random
-from typing import AsyncIterable
+from collections.abc import AsyncIterable
 
 from aiohttp import ClientSession
 from geopandas import GeoDataFrame
@@ -22,6 +22,7 @@ from restgdf.utils.getinfo import (
     nestedcount,
     FIELDDOESNOTEXIST,
 )
+from restgdf.utils.token import ArcGISTokenSession
 from restgdf.utils.utils import where_var_in_list, ends_with_num
 
 
@@ -31,7 +32,7 @@ class FeatureLayer:
     def __init__(
         self,
         url: str,
-        session: ClientSession,
+        session: ClientSession | ArcGISTokenSession,
         where: str = "1=1",
         token: str | None = None,
         **kwargs,
@@ -45,12 +46,11 @@ class FeatureLayer:
         self.session = session
 
         self.wherestr = where
-        self.token = token
         self.kwargs = kwargs
         self.datadict = default_data(kwargs.pop("data", {}))
         self.datadict["where"] = self.wherestr
-        if self.token is not None:
-            self.datadict["token"] = self.token
+        if token is not None:
+            self.datadict["token"] = token
         self.kwargs["data"] = self.datadict
 
         self.uniquevalues: dict = {}
@@ -70,7 +70,7 @@ class FeatureLayer:
         self.metadata = await get_metadata(
             self.url,
             self.session,
-            token=self.token,
+            token=self.kwargs["data"].get("token"),
         )
         try:
             if not self.metadata["type"] == "Feature Layer":
@@ -180,14 +180,13 @@ class FeatureLayer:
             self.url,
             session=self.session,
             where=wherestr_plus,
-            token=self.token,
             **self.kwargs,
         )
 
     def __repr__(self) -> str:
         """Return a string representation of the Rest object."""
         kwargstr = ", ".join(f"{k}={v}" for k, v in self.kwargs.items())
-        return f"Rest({self.url}, {self.session}, {self.wherestr}, {self.token}, {kwargstr})"
+        return f"Rest({self.url}, {self.session}, {self.wherestr}, {kwargstr})"
 
     def __str__(self) -> str:
         """Return a string representation of the Rest object."""

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import random
+from typing import AsyncIterable
 
 from aiohttp import ClientSession
 from geopandas import GeoDataFrame
@@ -22,7 +23,6 @@ from restgdf.utils.getinfo import (
     FIELDDOESNOTEXIST,
 )
 from restgdf.utils.utils import where_var_in_list, ends_with_num
-from typing import AsyncIterable
 
 
 class FeatureLayer:

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -8,7 +8,7 @@ from aiohttp import ClientSession
 from geopandas import GeoDataFrame
 from pandas import DataFrame
 
-from restgdf.utils.getgdf import get_gdf
+from restgdf.utils.getgdf import get_gdf, row_dict_generator
 from restgdf.utils.getinfo import (
     default_data,
     get_feature_count,
@@ -22,6 +22,7 @@ from restgdf.utils.getinfo import (
     FIELDDOESNOTEXIST,
 )
 from restgdf.utils.utils import where_var_in_list, ends_with_num
+from typing import AsyncIterable
 
 
 class FeatureLayer:
@@ -113,6 +114,15 @@ class FeatureLayer:
         if self.gdf is None:
             self.gdf = await get_gdf(self.url, self.session, **self.kwargs)
         return self.gdf
+
+    async def row_dict_generator(
+        self,
+        **kwargs,
+    ) -> AsyncIterable[dict]:
+        """Asynchronously yield rows from a GeoDataFrame as dictionaries."""
+        _gen = row_dict_generator(self.url, self.session, **self.kwargs, **kwargs)
+        async for row in _gen:
+            yield row
 
     async def getuniquevalues(
         self,

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -50,10 +50,15 @@ class FeatureLayer:
         self.datadict = default_data(kwargs.pop("data", {}))
         self.datadict["where"] = self.wherestr
         if token is not None:
+            existing_token = self.datadict.get("token")
+            if existing_token is not None and existing_token != token:
+                raise ValueError(
+                    "Pass token either via token= or data['token'], not both with different values.",
+                )
             self.datadict["token"] = token
         self.kwargs["data"] = self.datadict
 
-        self.uniquevalues: dict = {}
+        self.uniquevalues: dict[tuple[str | tuple, str | None], list | DataFrame] = {}
         self.valuecounts: dict = {}
         self.nestedcount: dict = {}
 
@@ -91,7 +96,7 @@ class FeatureLayer:
 
     async def getoids(self) -> list[int]:
         """Get the object ids for the Rest object."""
-        return await self.getuniquevalues(self.url, "OBJECTID")
+        return await self.getuniquevalues("OBJECTID")
 
     async def samplegdf(self, n: int = 10) -> GeoDataFrame:
         """Get n random features as a GeoDataFrame."""
@@ -120,7 +125,13 @@ class FeatureLayer:
         **kwargs,
     ) -> AsyncIterable[dict]:
         """Asynchronously yield rows from a GeoDataFrame as dictionaries."""
-        _gen = row_dict_generator(self.url, self.session, **self.kwargs, **kwargs)
+        merged_kwargs = {**self.kwargs, **kwargs}
+        if "data" in self.kwargs or "data" in kwargs:
+            merged_kwargs["data"] = default_data(
+                kwargs.get("data"),
+                self.kwargs.get("data"),
+            )
+        _gen = row_dict_generator(self.url, self.session, **merged_kwargs)
         async for row in _gen:
             yield row
 
@@ -130,20 +141,21 @@ class FeatureLayer:
         sortby: str | None = None,
     ) -> list | DataFrame:
         """Get the unique values for a field."""
-        if fields not in self.uniquevalues:
+        cache_key = (fields, sortby)
+        if cache_key not in self.uniquevalues:
             if (isinstance(fields, str) and fields not in self.fields) or (
                 not isinstance(fields, str)
                 and any(field not in self.fields for field in fields)
             ):
                 raise FIELDDOESNOTEXIST
-            self.uniquevalues[fields] = await getuniquevalues(
+            self.uniquevalues[cache_key] = await getuniquevalues(
                 self.url,
                 fields,
                 self.session,
                 sortby,
                 **self.kwargs,
             )
-        return self.uniquevalues[fields]
+        return self.uniquevalues[cache_key]
 
     async def getvaluecounts(self, field: str) -> DataFrame:
         """Get the value counts for a field."""

--- a/restgdf/utils/crawl.py
+++ b/restgdf/utils/crawl.py
@@ -4,10 +4,11 @@ from typing import Optional
 import aiohttp
 
 from restgdf.utils.getinfo import service_metadata, get_metadata
+from restgdf.utils.token import ArcGISTokenSession
 
 
 async def fetch_all_data(
-    session: aiohttp.ClientSession,
+    session: aiohttp.ClientSession | ArcGISTokenSession,
     base_url: str,
     token: Optional[str] = None,
     return_feature_count: bool = False,

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -12,13 +12,14 @@ from pandas import concat
 from pyogrio import list_drivers
 
 from restgdf.utils.getinfo import default_data, get_offset_range
+from restgdf.utils.token import ArcGISTokenSession
 
 supported_drivers = list_drivers()
 
 
 async def get_sub_gdf(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     offset: int,
     **kwargs,
 ) -> GeoDataFrame:
@@ -40,7 +41,7 @@ async def get_sub_gdf(
 
 async def get_gdf_list(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> list[GeoDataFrame]:
     offset_list = await get_offset_range(url, session, **kwargs)
@@ -51,7 +52,7 @@ async def get_gdf_list(
 
 async def chunk_generator(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> AsyncGenerator[GeoDataFrame, None]:
     """
@@ -61,18 +62,16 @@ async def chunk_generator(
     """
     offset_list = await get_offset_range(url, session, **kwargs)
     tasks = {
-        asyncio.create_task(
-            get_sub_gdf(url, session, offset, **kwargs)
-        )
+        asyncio.create_task(get_sub_gdf(url, session, offset, **kwargs))
         for offset in offset_list
     }
-    for sub_gdf in asyncio.as_completed(tasks):
-        yield await sub_gdf
+    for sub_gdf_future in asyncio.as_completed(tasks):
+        yield await sub_gdf_future
 
 
 async def row_dict_generator(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> AsyncGenerator[dict, None]:
     async for sub_gdf in chunk_generator(url, session, **kwargs):
@@ -97,7 +96,7 @@ async def concat_gdfs(gdfs: list[GeoDataFrame]) -> GeoDataFrame:
 
 async def gdf_by_concat(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> GeoDataFrame:
     gdfs = await get_gdf_list(url, session, **kwargs)

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -23,7 +23,7 @@ async def get_sub_gdf(
     offset: int,
     **kwargs,
 ) -> GeoDataFrame:
-    data = kwargs.pop("data", {})
+    data = kwargs.pop("data", None) or {}
     gdfdriver = "ESRIJSON" if "ESRIJSON" in supported_drivers else "GeoJSON"
     if gdfdriver == "GeoJSON":
         data["f"] = "GeoJSON"
@@ -111,9 +111,14 @@ async def get_gdf(
     **kwargs,
 ) -> GeoDataFrame:
     session = session or ClientSession()
-    datadict = default_data(kwargs.pop("data", {}))
+    datadict = default_data(kwargs.pop("data", None) or {})
     if where is not None:
         datadict["where"] = where
     if token is not None:
+        existing_token = datadict.get("token")
+        if existing_token is not None and existing_token != token:
+            raise ValueError(
+                "Pass token either via token= or data['token'], not both with different values.",
+            )
         datadict["token"] = token
     return await gdf_by_concat(url, session, data=datadict, **kwargs)

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -3,7 +3,7 @@
 from asyncio import gather
 from functools import reduce
 from typing import Union
-
+import asyncio
 from collections.abc import AsyncGenerator
 
 from aiohttp import ClientSession
@@ -55,9 +55,30 @@ async def chunk_generator(
     session: ClientSession,
     **kwargs,
 ) -> AsyncGenerator[GeoDataFrame, None]:
+    """
+    Asynchronously yield GeoDataFrames from a FeatureLayer in chunks.
+    This function retrieves GeoDataFrames in chunks based on the offset range
+    and yields each GeoDataFrame as it is retrieved.
+    """
     offset_list = await get_offset_range(url, session, **kwargs)
-    for offset in offset_list:
-        yield await get_sub_gdf(url, session, offset, **kwargs)
+    tasks = {
+        asyncio.create_task(
+            get_sub_gdf(url, session, offset, **kwargs)
+        )
+        for offset in offset_list
+    }
+    for sub_gdf in asyncio.as_completed(tasks):
+        yield await sub_gdf
+
+
+async def row_dict_generator(
+    url: str,
+    session: ClientSession,
+    **kwargs,
+) -> AsyncGenerator[dict, None]:
+    async for sub_gdf in chunk_generator(url, session, **kwargs):
+        for _, row in sub_gdf.iterrows():
+            yield row.to_dict()
 
 
 async def concat_gdfs(gdfs: list[GeoDataFrame]) -> GeoDataFrame:

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -1,10 +1,10 @@
 """Get a GeoDataFrame from an ArcGIS FeatureLayer."""
 
+import asyncio
 from asyncio import gather
+from collections.abc import AsyncGenerator
 from functools import reduce
 from typing import Union
-import asyncio
-from collections.abc import AsyncGenerator
 
 from aiohttp import ClientSession
 from geopandas import GeoDataFrame, read_file
@@ -12,7 +12,6 @@ from pandas import concat
 from pyogrio import list_drivers
 
 from restgdf.utils.getinfo import default_data, get_offset_range
-
 
 supported_drivers = list_drivers()
 

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -36,10 +36,11 @@ async def get_feature_count(
 ) -> int:
     """Get the feature count for a layer."""
     datadict: dict = {"where": "1=1", "returnCountOnly": True, "f": "json"}
-    if "data" in kwargs:
-        datadict["where"] = kwargs["data"].get("where", "1=1")
-        if "token" in kwargs["data"]:
-            datadict["token"] = kwargs["data"]["token"]
+    request_data = kwargs.get("data") or {}
+    if request_data:
+        datadict["where"] = request_data.get("where", "1=1")
+        if "token" in request_data:
+            datadict["token"] = request_data["token"]
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
     response = await session.post(f"{url}/query", data=datadict, **xkwargs)
     # the line above provides keyword arguments other than data dict
@@ -62,7 +63,7 @@ async def get_metadata(
 ) -> dict:
     """Get the JSON dict for a layer."""
     data = {"f": "json"}
-    if token:
+    if token is not None:
         data["token"] = token
     response = await session.post(url, data=data)
     return await response.json(content_type=None)
@@ -87,7 +88,7 @@ async def get_offset_range(
 ) -> range:
     """Get the offset range for a layer."""
     feature_count = await get_feature_count(url, session, **kwargs)
-    token = kwargs.get("data", {}).get("token")
+    token = (kwargs.get("data") or {}).get("token")
     metadata = await get_metadata(url, session, token=token)
     max_record_count = get_max_record_count(metadata)
     return range(0, feature_count, max_record_count)
@@ -139,10 +140,11 @@ async def getuniquevalues(
         "returnDistinctValues": True,
         "outFields": fields if isinstance(fields, str) else ",".join(fields),
     }
-    if "data" in kwargs:
-        datadict["where"] = kwargs["data"].get("where", "1=1")
-        if "token" in kwargs["data"]:
-            datadict["token"] = kwargs["data"]["token"]
+    request_data = kwargs.get("data") or {}
+    if request_data:
+        datadict["where"] = request_data.get("where", "1=1")
+        if "token" in request_data:
+            datadict["token"] = request_data["token"]
 
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
 
@@ -154,8 +156,12 @@ async def getuniquevalues(
 
     if isinstance(fields, str):
         res_l = [x["attributes"][fields] for x in metadata["features"]]
+        if sortby and sortby == fields:
+            res_l = sorted(res_l)
     elif len(fields) == 1:
         res_l = [x["attributes"][fields[0]] for x in metadata["features"]]
+        if sortby and sortby == fields[0]:
+            res_l = sorted(res_l)
     else:
         res_df = concat(
             [DataFrame(x).T.reset_index(drop=True) for x in metadata["features"]],
@@ -174,7 +180,7 @@ async def getvaluecounts(
 ) -> DataFrame:
     """Get the value counts for a field."""
     statstr = f'[{{"statisticType":"count","onStatisticField":"{field}","outStatisticFieldName":"{field}_count"}}]'
-    data = kwargs.pop("data", {})
+    data = kwargs.pop("data", None) or {}
     data = {
         "where": "1=1",
         "f": "json",
@@ -211,7 +217,7 @@ async def nestedcount(
             "]",
         ),
     )
-    data = kwargs.pop("data", {})
+    data = kwargs.pop("data", None) or {}
     data = {
         "where": "1=1",
         "f": "json",
@@ -255,7 +261,7 @@ async def service_metadata(
                 feature_count = await get_feature_count(
                     layer_url,
                     session,
-                    data={"token": token} if token else None,
+                    **({"data": {"token": token}} if token is not None else {}),
                 )
             except KeyError:
                 feature_count = None

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -7,6 +7,8 @@ from re import compile, IGNORECASE
 from aiohttp import ClientSession
 from pandas import DataFrame, concat
 
+from restgdf.utils.token import ArcGISTokenSession
+
 FIELDDOESNOTEXIST: IndexError = IndexError("Field does not exist")
 
 DEFAULTDICT: dict = {
@@ -29,7 +31,7 @@ def default_data(
 
 async def get_feature_count(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> int:
     """Get the feature count for a layer."""
@@ -55,7 +57,7 @@ async def get_feature_count(
 
 async def get_metadata(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     token: str | None = None,
 ) -> dict:
     """Get the JSON dict for a layer."""
@@ -80,12 +82,13 @@ def get_max_record_count(metadata: dict) -> int:
 
 async def get_offset_range(
     url: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> range:
     """Get the offset range for a layer."""
     feature_count = await get_feature_count(url, session, **kwargs)
-    metadata = await get_metadata(url, session)
+    token = kwargs.get("data", {}).get("token")
+    metadata = await get_metadata(url, session, token=token)
     max_record_count = get_max_record_count(metadata)
     return range(0, feature_count, max_record_count)
 
@@ -124,7 +127,7 @@ def getfields_df(layer_metadata: dict) -> DataFrame:
 async def getuniquevalues(
     url: str,
     fields: tuple | str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     sortby: str | None = None,
     **kwargs,
 ) -> list | DataFrame:
@@ -166,7 +169,7 @@ async def getuniquevalues(
 async def getvaluecounts(
     url: str,
     field: str,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> DataFrame:
     """Get the value counts for a field."""
@@ -194,7 +197,7 @@ async def getvaluecounts(
 async def nestedcount(
     url: str,
     fields,
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> DataFrame:
     """Get the nested value counts for a field."""
@@ -236,7 +239,7 @@ async def nestedcount(
 
 
 async def service_metadata(
-    session: ClientSession,
+    session: ClientSession | ArcGISTokenSession,
     service_url: str,
     token: str | None = None,
     return_feature_count: bool = False,
@@ -245,11 +248,15 @@ async def service_metadata(
     _service_metadata = await get_metadata(service_url, session, token=token)
 
     async def _comprehensive_metadata(layer_url: str) -> dict:
-        metadata = await get_metadata(layer_url, session)
+        metadata = await get_metadata(layer_url, session, token=token)
         metadata["url"] = layer_url
         if return_feature_count and metadata["type"] == "Feature Layer":
             try:
-                feature_count = await get_feature_count(layer_url, session)
+                feature_count = await get_feature_count(
+                    layer_url,
+                    session,
+                    data={"token": token} if token else None,
+                )
             except KeyError:
                 feature_count = None
             metadata["feature_count"] = feature_count  # type: ignore

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -73,7 +73,7 @@ class ArcGISTokenSession:
     def update_dict(self, input_dict: dict | None = None) -> dict:
         """Return a request payload/query dict merged with the active token."""
         output_dict = dict(input_dict or {})
-        if self.token:
+        if self.token and "token" not in output_dict:
             output_dict["token"] = self.token
         return output_dict
 
@@ -117,7 +117,13 @@ class ArcGISTokenSession:
     ) -> aiohttp.ClientResponse:
         """Make a GET request to the specified URL with the token."""
         await self.update_token_if_needed()
-        request_headers = self.update_headers(headers)
+        request_headers = (
+            self.update_headers(
+                headers,
+            )
+            if "token" not in (params or {})
+            else dict(headers or {})
+        )
         request_params = self.update_dict(params)
         return await self.session.get(
             url,
@@ -135,7 +141,13 @@ class ArcGISTokenSession:
     ) -> aiohttp.ClientResponse:
         """Make a POST request to the specified URL with the token."""
         await self.update_token_if_needed()
-        request_headers = self.update_headers(headers)
+        request_headers = (
+            self.update_headers(
+                headers,
+            )
+            if "token" not in (data or {})
+            else dict(headers or {})
+        )
         request_data = self.update_dict(data)
         return await self.session.post(
             url,

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+
+import aiohttp
+import requests
+
+
+@dataclass(frozen=True)
+class AGOLUserPass:
+    """ArcGIS Online credentials used to mint short-lived tokens."""
+
+    username: str
+    password: str
+
+
+def get_token(username: str, password: str) -> dict:
+    """Synchronously request an ArcGIS Online token."""
+    url = "https://www.arcgis.com/sharing/rest/generateToken"
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    data = {
+        "f": "json",
+        "client": "requestip",
+        "username": username,
+        "password": password,
+    }
+    return requests.post(url, headers=headers, data=data, timeout=30).json()
+
+
+@dataclass
+class ArcGISTokenSession:
+    """
+    Wrap an aiohttp session with ArcGIS token refresh behavior.
+
+    The wrapped session still performs the actual requests; this helper only
+    injects auth headers/body params and refreshes tokens when needed.
+    """
+
+    session: aiohttp.ClientSession
+    credentials: AGOLUserPass | None = None
+    token_url: str = "https://www.arcgis.com/sharing/rest/generateToken"
+    token_refresh_threshold: int = 60
+    token: str | None = None
+    expires: int | float | None = None
+
+    @property
+    def token_request_payload(self) -> dict:
+        """Return the payload for the token request."""
+        if self.credentials is None:
+            raise ValueError("Credentials are required to generate a token.")
+        return {
+            "f": "json",
+            "client": "requestip",
+            "username": self.credentials.username,
+            "password": self.credentials.password,
+        }
+
+    @property
+    def auth_headers(self) -> dict[str, str]:
+        """Return authentication headers with the token if available."""
+        headers: dict[str, str] = {}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        return headers
+
+    def update_headers(self, headers: dict | None = None) -> dict:
+        """Return headers merged with the active token."""
+        request_headers = dict(headers or {})
+        request_headers.update(self.auth_headers)
+        return request_headers
+
+    def update_dict(self, input_dict: dict | None = None) -> dict:
+        """Return a request payload/query dict merged with the active token."""
+        output_dict = dict(input_dict or {})
+        if self.token:
+            output_dict["token"] = self.token
+        return output_dict
+
+    async def update_token(self) -> None:
+        """Update the token by making a request to the token URL."""
+        async with self.session.post(
+            self.token_url,
+            data=self.token_request_payload,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        ) as resp:
+            resp.raise_for_status()
+            data = await resp.json()
+        self.token = data["token"]
+        self.expires = data["expires"]
+
+    def token_needs_update(self) -> bool:
+        """Check if the token needs to be updated."""
+        if self.credentials is None:
+            return False
+        if not self.token or not self.expires:
+            return True
+        expires_at = self.expires / 1000 if self.expires > 1e11 else self.expires
+        expires_dt = datetime.datetime.fromtimestamp(
+            expires_at,
+            tz=datetime.timezone.utc,
+        )
+        now_dt = datetime.datetime.now(datetime.timezone.utc)
+        return (expires_dt - now_dt).total_seconds() < self.token_refresh_threshold
+
+    async def update_token_if_needed(self) -> None:
+        """Ensure the token is valid and refresh if necessary."""
+        if self.token_needs_update():
+            await self.update_token()
+
+    async def get(
+        self,
+        url: str,
+        params: dict | None = None,
+        headers: dict | None = None,
+        **kwargs,
+    ) -> aiohttp.ClientResponse:
+        """Make a GET request to the specified URL with the token."""
+        await self.update_token_if_needed()
+        request_headers = self.update_headers(headers)
+        request_params = self.update_dict(params)
+        return await self.session.get(
+            url,
+            params=request_params,
+            headers=request_headers,
+            **kwargs,
+        )
+
+    async def post(
+        self,
+        url: str,
+        data: dict | None = None,
+        headers: dict | None = None,
+        **kwargs,
+    ) -> aiohttp.ClientResponse:
+        """Make a POST request to the specified URL with the token."""
+        await self.update_token_if_needed()
+        request_headers = self.update_headers(headers)
+        request_data = self.update_dict(data)
+        return await self.session.post(
+            url,
+            data=request_data,
+            headers=request_headers,
+            **kwargs,
+        )
+
+    async def __aenter__(self) -> ArcGISTokenSession:
+        """Enter the runtime context related to this object."""
+        await self.update_token_if_needed()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        """Exit the runtime context related to this object."""
+        return None

--- a/restgdf/utils/utils.py
+++ b/restgdf/utils/utils.py
@@ -9,7 +9,9 @@ def ends_with_num(url: str) -> bool:
     return bool(ends_with_num_pat.search(url))
 
 
-def where_var_in_list(var: str, vals: Iterable[str]) -> str:
+def where_var_in_list(var: str, vals: Iterable[str | int | float]) -> str:
     """Return a where clause for a variable in a list of values."""
-    vals_str = ", ".join(f"'{val}'" for val in vals)
+    vals_str = ", ".join(
+        f"'{val}'" if isinstance(val, str) else str(val) for val in vals
+    )
     return f"{var} In ({vals_str})"

--- a/tests/test_Directory.py
+++ b/tests/test_Directory.py
@@ -1,5 +1,6 @@
 import pytest
 from aiohttp import ClientSession
+from unittest.mock import AsyncMock, patch
 
 from restgdf.directory.directory import Directory
 
@@ -28,3 +29,23 @@ async def test_directory():
     assert len(directory.metadata) > 0
     assert len(directory.rasters()) > 0
     assert len(directory.feature_layers()) > 0
+
+
+@pytest.mark.asyncio
+async def test_directory_crawl_caches_feature_count_variant_separately():
+    directory = Directory("https://example.com/arcgis/rest/services", session=object())
+    without_count = {"services": [{"name": "base"}]}
+    with_count = {
+        "services": [{"name": "with-count", "metadata": {"feature_count": 1}}],
+    }
+
+    with patch(
+        "restgdf.directory.directory.fetch_all_data",
+        new=AsyncMock(side_effect=[without_count, with_count]),
+    ) as mock_fetch:
+        first = await directory.crawl(return_feature_count=False)
+        second = await directory.crawl(return_feature_count=True)
+
+    assert first == without_count["services"]
+    assert second == with_count["services"]
+    assert mock_fetch.await_count == 2

--- a/tests/test_Directory.py
+++ b/tests/test_Directory.py
@@ -19,7 +19,10 @@ async def test_directory():
         if service_layers:
             first_service_with_layers = service
             break
-    first_service_layers = first_service_with_layers.get("metadata", {}).get("layers", [])
+    first_service_layers = first_service_with_layers.get("metadata", {}).get(
+        "layers",
+        [],
+    )
     assert len(first_service_layers) > 0
     assert isinstance(first_service_layers[0], dict)
     assert len(directory.metadata) > 0

--- a/tests/test_Directory.py
+++ b/tests/test_Directory.py
@@ -13,7 +13,13 @@ async def test_directory():
         )
         services = await directory.crawl()
     assert directory.services == services
-    first_service_layers = services[0]["metadata"]["layers"]
+    first_service_with_layers = None
+    for service in services:
+        service_layers = service.get("metadata", {}).get("layers", [])
+        if service_layers:
+            first_service_with_layers = service
+            break
+    first_service_layers = first_service_with_layers.get("metadata", {}).get("layers", [])
     assert len(first_service_layers) > 0
     assert isinstance(first_service_layers[0], dict)
     assert len(directory.metadata) > 0

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -28,11 +28,20 @@ async def test_featurelayer():
         assert len(await beaches.samplegdf(2)) == 2
         assert len(await beaches.headgdf(2)) == 2
         assert len(beaches_gdf) > 0
+
+        # test row_dict_generator
+        row_gen = beaches.row_dict_generator()
+        beaches_row_gen_count = 0
+        async for row in row_gen:
+            assert isinstance(row, dict)
+            beaches_row_gen_count += 1
+        assert beaches_row_gen_count == len(beaches_gdf)
+
         assert all(
             "fgsfds" in s for s in (beaches.wherestr, beaches.kwargs["data"]["where"])
         )
         assert (
-            len(await beaches.getuniquevalues(("City", "Status"), sortby="City")) > 10
+            len(await beaches.getuniquevalues(("City", "Status"), sortby="City")) > 1
         )
         daytona = await beaches.where("City LIKE 'DAYTONA%'")
         assert "Status" in daytona.fields

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -1,6 +1,7 @@
 import pytest
 from aiohttp import ClientSession
 from pytest import raises
+
 from restgdf.featurelayer.featurelayer import FeatureLayer
 
 

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -1,6 +1,7 @@
 import pytest
 from aiohttp import ClientSession
 from pytest import raises
+from unittest.mock import patch
 
 from restgdf.featurelayer.featurelayer import FeatureLayer
 from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
@@ -83,6 +84,83 @@ def test_featurelayer_accepts_legacy_token_kwarg():
     )
 
     assert layer.kwargs["data"]["token"] == "legacy-token"
+
+
+def test_featurelayer_rejects_conflicting_token_sources():
+    with pytest.raises(ValueError):
+        FeatureLayer(
+            "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+            session=MockArcGISSession(),
+            token="legacy-token",
+            data={"token": "other-token"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_getoids_uses_objectid_field():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ["OBJECTID"]
+
+    async def fake_getuniquevalues(fields, sortby=None):
+        assert fields == "OBJECTID"
+        assert sortby is None
+        return [1, 2, 3]
+
+    layer.getuniquevalues = fake_getuniquevalues
+
+    assert await layer.getoids() == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_row_dict_generator_merges_data_kwargs():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+        where="CITY = 'DAYTONA'",
+        token="saved-token",
+    )
+
+    async def fake_row_dict_generator(url, session, **kwargs):
+        assert kwargs["data"]["where"] == "CITY = 'DAYTONA'"
+        assert kwargs["data"]["token"] == "saved-token"
+        assert kwargs["data"]["outFields"] == "CITY"
+        yield {"ok": True}
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.row_dict_generator",
+        side_effect=fake_row_dict_generator,
+    ):
+        rows = [
+            row async for row in layer.row_dict_generator(data={"outFields": "CITY"})
+        ]
+
+    assert rows == [{"ok": True}]
+
+
+@pytest.mark.asyncio
+async def test_getuniquevalues_cache_includes_sortby():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY", "STATE")
+
+    async def fake_getuniquevalues(url, fields, session, sortby=None, **kwargs):
+        return [sortby]
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.getuniquevalues",
+        side_effect=fake_getuniquevalues,
+    ) as mock_getuniquevalues:
+        first = await layer.getuniquevalues(("CITY", "STATE"), sortby="CITY")
+        second = await layer.getuniquevalues(("CITY", "STATE"), sortby="STATE")
+
+    assert first == ["CITY"]
+    assert second == ["STATE"]
+    assert mock_getuniquevalues.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -3,6 +3,86 @@ from aiohttp import ClientSession
 from pytest import raises
 
 from restgdf.featurelayer.featurelayer import FeatureLayer
+from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
+
+
+class MockRequestContext:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def __await__(self):
+        async def _response():
+            return self
+
+        return _response().__await__()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return None
+
+    async def json(self, content_type: str | None = None):
+        return self.payload
+
+    def raise_for_status(self):
+        return None
+
+
+class MockArcGISSession:
+    def __init__(self):
+        self.get_calls: list[tuple[str, dict]] = []
+        self.post_calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return MockRequestContext({"ok": True})
+
+    def post(self, url: str, **kwargs):
+        self.post_calls.append((url, kwargs))
+        if url.endswith("generateToken"):
+            return MockRequestContext(
+                {
+                    "token": "generated-token",
+                    "expires": 32503680000000,
+                },
+            )
+        return MockRequestContext({"ok": True})
+
+
+@pytest.mark.asyncio
+async def test_arcgistokensession():
+    session = MockArcGISSession()
+    token_session = ArcGISTokenSession(
+        session=session,
+        credentials=AGOLUserPass(username="user", password="password"),
+    )
+
+    post_response = await token_session.post(
+        "https://example.com/query",
+        data={"where": "1=1"},
+    )
+    get_response = await token_session.get(
+        "https://example.com/items",
+        params={"f": "json"},
+    )
+
+    assert await post_response.json() == {"ok": True}
+    assert await get_response.json() == {"ok": True}
+    assert token_session.token == "generated-token"
+    assert session.post_calls[0][0].endswith("generateToken")
+    assert session.post_calls[1][1]["data"]["token"] == "generated-token"
+    assert session.get_calls[0][1]["params"]["token"] == "generated-token"
+
+
+def test_featurelayer_accepts_legacy_token_kwarg():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+        token="legacy-token",
+    )
+
+    assert layer.kwargs["data"]["token"] == "legacy-token"
 
 
 @pytest.mark.asyncio
@@ -41,9 +121,7 @@ async def test_featurelayer():
         assert all(
             "fgsfds" in s for s in (beaches.wherestr, beaches.kwargs["data"]["where"])
         )
-        assert (
-            len(await beaches.getuniquevalues(("City", "Status"), sortby="City")) > 1
-        )
+        assert len(await beaches.getuniquevalues(("City", "Status"), sortby="City")) > 1
         daytona = await beaches.where("City LIKE 'DAYTONA%'")
         assert "Status" in daytona.fields
         assert str(beaches) == f"Beach Access Points ({beachurl})"

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -9,6 +9,7 @@ from restgdf.utils.getinfo import (
     DEFAULTDICT,
     default_data,
     get_feature_count,
+    getuniquevalues,
     get_metadata,
     get_max_record_count,
     get_offset_range,
@@ -50,6 +51,30 @@ def mock_session_post(*args, **kwargs):
     return future  # return the future
 
 
+def mock_uniquevalues_post(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data):
+            self.json_data = json_data
+            self.content_type = "application/json"
+
+        async def json(self, content_type: str = "application/json"):
+            return self.json_data
+
+    future = asyncio.Future()
+    future.set_result(
+        MockResponse(
+            {
+                "features": [
+                    {"attributes": {"CITY": "C"}},
+                    {"attributes": {"CITY": "A"}},
+                    {"attributes": {"CITY": "B"}},
+                ],
+            },
+        ),
+    )
+    return future
+
+
 @pytest.mark.asyncio
 @patch(
     "restgdf.utils.getinfo.ClientSession.post",
@@ -70,6 +95,7 @@ async def test_get_feature_count(mock_response):
         assert await get_feature_count("test", session=s) == TESTJSON["count"]
         assert await get_feature_count("test", session=s, data={"where": "test"})
         assert await get_feature_count("test", session=s, data={"token": "test"})
+        assert await get_feature_count("test", session=s, data=None)
 
 
 @patch(
@@ -92,6 +118,20 @@ async def test_get_offset_range(mock_response):
             TESTJSON["count"],
             TESTJSON["maxRecordCount"],
         )
+
+
+@pytest.mark.asyncio
+@patch(
+    "restgdf.utils.getinfo.ClientSession.post",
+    side_effect=mock_uniquevalues_post,
+)
+async def test_getuniquevalues_sorts_single_field(mock_response):
+    async with ClientSession() as s:
+        assert await getuniquevalues("test", "CITY", s, sortby="CITY") == [
+            "A",
+            "B",
+            "C",
+        ]
 
 
 def test_default_data():

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -19,6 +19,7 @@ TESTJSON = {"count": 500, "maxRecordCount": 100}
 
 def test_wherevarinlist():
     assert where_var_in_list("STATE", ["FL", "GA"]) == "STATE In ('FL', 'GA')"
+    assert where_var_in_list("OBJECTID", [1, 2]) == "OBJECTID In (1, 2)"
 
 
 # def mock_session_post(*args, **kwargs):


### PR DESCRIPTION
## Summary
- stabilize the row dict generator and token-backed session work
- document and expose token auth support
- harden value propagation, caching, and kwargs/data edge cases found during audit

## Validation
- pre-commit run --all-files
- pytest -q
- sphinx build for docs