### PR TITLE
Fix non-paginated ArcGIS layers and coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         cache: pip
     - name: Install Python libraries
       run: |
-        pip install --user -r requirements.txt
+        pip install --user -r requirements.txt .[dev]
     - name: "Run coverage"
       run: |
         coverage run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-asyncio",
+    "setuptools>=61.0.0",
 ]
 
 doc = [

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -15,6 +15,7 @@ from restgdf.utils.getinfo import (
     get_feature_count,
     get_metadata,
     get_name,
+    get_object_id_field,
     getfields,
     getfields_df,
     getuniquevalues,
@@ -68,6 +69,7 @@ class FeatureLayer:
         self.name: str
         self.fields: tuple[str, ...]
         self.fieldtypes: DataFrame
+        self.object_id_field: str
         self.count: int
 
     async def prep(self):
@@ -85,6 +87,7 @@ class FeatureLayer:
         self.name = get_name(self.metadata)
         self.fields = getfields(self.metadata)
         self.fieldtypes = getfields_df(self.metadata)
+        self.object_id_field = get_object_id_field(self.metadata)
         self.count = await get_feature_count(self.url, self.session, **self.kwargs)
 
     @classmethod
@@ -96,21 +99,32 @@ class FeatureLayer:
 
     async def getoids(self) -> list[int]:
         """Get the object ids for the Rest object."""
-        return await self.getuniquevalues("OBJECTID")
+        object_id_field = getattr(self, "object_id_field", "OBJECTID")
+        return await self.getuniquevalues(object_id_field)
 
     async def samplegdf(self, n: int = 10) -> GeoDataFrame:
         """Get n random features as a GeoDataFrame."""
-        oids = await getuniquevalues(self.url, "OBJECTID", self.session, **self.kwargs)
+        oids = await getuniquevalues(
+            self.url,
+            self.object_id_field,
+            self.session,
+            **self.kwargs,
+        )
         sample_oids = random.sample(oids, min(n, len(oids)))
-        wherestr = where_var_in_list("OBJECTID", sample_oids)
+        wherestr = where_var_in_list(self.object_id_field, sample_oids)
         new_rest = await self.where(wherestr)
         return await new_rest.getgdf()
 
     async def headgdf(self, n: int = 10) -> GeoDataFrame:
         """Get the n first features as a GeoDataFrame."""
-        oids = await getuniquevalues(self.url, "OBJECTID", self.session, **self.kwargs)
+        oids = await getuniquevalues(
+            self.url,
+            self.object_id_field,
+            self.session,
+            **self.kwargs,
+        )
         head_oids = oids[:n]
-        wherestr = where_var_in_list("OBJECTID", head_oids)
+        wherestr = where_var_in_list(self.object_id_field, head_oids)
         new_rest = await self.where(wherestr)
         return await new_rest.getgdf()
 

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -11,26 +11,86 @@ from geopandas import GeoDataFrame, read_file
 from pandas import concat
 from pyogrio import list_drivers
 
-from restgdf.utils.getinfo import default_data, get_offset_range
+from restgdf.utils.getinfo import (
+    default_data,
+    default_headers,
+    get_feature_count,
+    get_max_record_count,
+    get_metadata,
+    get_object_ids,
+    supports_pagination,
+)
 from restgdf.utils.token import ArcGISTokenSession
+from restgdf.utils.utils import where_var_in_list
 
 supported_drivers = list_drivers()
+
+
+def combine_where_clauses(base_where: str | None, extra_where: str) -> str:
+    """Combine where clauses without changing the default all-records predicate."""
+    if base_where in (None, "", "1=1"):
+        return extra_where
+    return f"({base_where}) AND ({extra_where})"
+
+
+def chunk_values(values: list[int], chunk_size: int) -> list[list[int]]:
+    """Split values into evenly-sized chunks."""
+    return [values[i : i + chunk_size] for i in range(0, len(values), chunk_size)]
+
+
+async def get_query_data_batches(
+    url: str,
+    session: ClientSession | ArcGISTokenSession,
+    **kwargs,
+) -> list[dict]:
+    """Build query payloads for each request needed to read a layer."""
+    request_data = dict(kwargs.get("data") or {})
+    feature_count = await get_feature_count(url, session, **kwargs)
+    token = request_data.get("token")
+    metadata = await get_metadata(url, session, token=token)
+    max_record_count = get_max_record_count(metadata)
+
+    if feature_count <= max_record_count:
+        return [request_data]
+
+    if supports_pagination(metadata):
+        return [
+            {**request_data, "resultOffset": offset}
+            for offset in range(0, feature_count, max_record_count)
+        ]
+
+    object_id_field_name, object_ids = await get_object_ids(url, session, **kwargs)
+    base_where = request_data.get("where")
+    return [
+        {
+            **request_data,
+            "where": combine_where_clauses(
+                base_where,
+                where_var_in_list(object_id_field_name, object_id_chunk),
+            ),
+        }
+        for object_id_chunk in chunk_values(object_ids, max_record_count)
+    ]
 
 
 async def get_sub_gdf(
     url: str,
     session: ClientSession | ArcGISTokenSession,
-    offset: int,
+    query_data: dict,
     **kwargs,
 ) -> GeoDataFrame:
-    data = kwargs.pop("data", None) or {}
+    data = dict(query_data)
     gdfdriver = "ESRIJSON" if "ESRIJSON" in supported_drivers else "GeoJSON"
     if gdfdriver == "GeoJSON":
         data["f"] = "GeoJSON"
     kwargs = {k: v for k, v in kwargs.items() if k != "data"}
 
-    data["resultOffset"] = offset
-    response = await session.post(f"{url}/query", data=data, **kwargs)
+    response = await session.post(
+        f"{url}/query",
+        data=data,
+        headers=default_headers(kwargs.pop("headers", None)),
+        **kwargs,
+    )
     sub_gdf = read_file(
         await response.text(),
         # driver=gdfdriver,  # this line raises a warning when using pyogrio w/ ESRIJSON
@@ -44,8 +104,11 @@ async def get_gdf_list(
     session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> list[GeoDataFrame]:
-    offset_list = await get_offset_range(url, session, **kwargs)
-    tasks = [get_sub_gdf(url, session, offset, **kwargs) for offset in offset_list]
+    query_data_batches = await get_query_data_batches(url, session, **kwargs)
+    tasks = [
+        get_sub_gdf(url, session, query_data=query_data, **kwargs)
+        for query_data in query_data_batches
+    ]
     gdf_list = await gather(*tasks)
     return gdf_list
 
@@ -60,10 +123,10 @@ async def chunk_generator(
     This function retrieves GeoDataFrames in chunks based on the offset range
     and yields each GeoDataFrame as it is retrieved.
     """
-    offset_list = await get_offset_range(url, session, **kwargs)
+    query_data_batches = await get_query_data_batches(url, session, **kwargs)
     tasks = {
-        asyncio.create_task(get_sub_gdf(url, session, offset, **kwargs))
-        for offset in offset_list
+        asyncio.create_task(get_sub_gdf(url, session, query_data=query_data, **kwargs))
+        for query_data in query_data_batches
     }
     for sub_gdf_future in asyncio.as_completed(tasks):
         yield await sub_gdf_future

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -10,6 +10,10 @@ from pandas import DataFrame, concat
 from restgdf.utils.token import ArcGISTokenSession
 
 FIELDDOESNOTEXIST: IndexError = IndexError("Field does not exist")
+DEFAULT_METADATA_HEADERS = {
+    "Accept": "application/json,text/plain,*/*",
+    "User-Agent": "Mozilla/5.0",
+}
 
 DEFAULTDICT: dict = {
     "where": "1=1",
@@ -18,6 +22,11 @@ DEFAULTDICT: dict = {
     "returnCountOnly": False,
     "f": "json",
 }
+
+
+def default_headers(headers: dict | None = None) -> dict:
+    """Return request headers merged with ArcGIS-compatible defaults."""
+    return {**DEFAULT_METADATA_HEADERS, **(headers or {})}
 
 
 def default_data(
@@ -42,7 +51,12 @@ async def get_feature_count(
         if "token" in request_data:
             datadict["token"] = request_data["token"]
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
-    response = await session.post(f"{url}/query", data=datadict, **xkwargs)
+    response = await session.post(
+        f"{url}/query",
+        data=datadict,
+        headers=default_headers(xkwargs.pop("headers", None)),
+        **xkwargs,
+    )
     # the line above provides keyword arguments other than data dict
     # because data dict is manipulated for this function
     # (this allows the use of token authentication, for example)
@@ -65,8 +79,30 @@ async def get_metadata(
     data = {"f": "json"}
     if token is not None:
         data["token"] = token
-    response = await session.post(url, data=data)
+    response = await session.get(url, params=data, headers=default_headers())
     return await response.json(content_type=None)
+
+
+def supports_pagination(metadata: dict) -> bool:
+    """Return whether the layer supports resultOffset/resultRecordCount pagination."""
+    advanced_query_capabilities = metadata.get("advancedQueryCapabilities") or {}
+    if "supportsPagination" in advanced_query_capabilities:
+        return advanced_query_capabilities["supportsPagination"]
+    if "supportsPagination" in metadata:
+        return metadata["supportsPagination"]
+    return True
+
+
+def get_object_id_field(metadata: dict) -> str:
+    """Get the object id field name for a layer."""
+    oid_fields = [
+        field["name"]
+        for field in metadata.get("fields", [])
+        if field.get("type") == "esriFieldTypeOID"
+    ]
+    if len(oid_fields) != 1:
+        raise FIELDDOESNOTEXIST
+    return oid_fields[0]
 
 
 def get_max_record_count(metadata: dict) -> int:
@@ -92,6 +128,29 @@ async def get_offset_range(
     metadata = await get_metadata(url, session, token=token)
     max_record_count = get_max_record_count(metadata)
     return range(0, feature_count, max_record_count)
+
+
+async def get_object_ids(
+    url: str,
+    session: ClientSession | ArcGISTokenSession,
+    **kwargs,
+) -> tuple[str, list[int]]:
+    """Get the object id field name and matching object ids for a layer query."""
+    datadict: dict = {"where": "1=1", "returnIdsOnly": True, "f": "json"}
+    request_data = kwargs.get("data") or {}
+    if request_data:
+        datadict["where"] = request_data.get("where", "1=1")
+        if "token" in request_data:
+            datadict["token"] = request_data["token"]
+    xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
+    response = await session.post(
+        f"{url}/query",
+        data=datadict,
+        headers=default_headers(xkwargs.pop("headers", None)),
+        **xkwargs,
+    )
+    response_json = await response.json(content_type=None)
+    return response_json["objectIdFieldName"], response_json["objectIds"]
 
 
 def get_name(metadata: dict) -> str:
@@ -148,7 +207,12 @@ async def getuniquevalues(
 
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
 
-    response = await session.post(f"{url}/query", data=datadict, **xkwargs)
+    response = await session.post(
+        f"{url}/query",
+        data=datadict,
+        headers=default_headers(xkwargs.pop("headers", None)),
+        **xkwargs,
+    )
     metadata = await response.json(content_type=None)
 
     res_l: list | None = None
@@ -190,7 +254,12 @@ async def getvaluecounts(
         "groupByFieldsForStatistics": field,
         **data,
     }
-    response = await session.post(f"{url}/query", data=data, **kwargs)
+    response = await session.post(
+        f"{url}/query",
+        data=data,
+        headers=default_headers(kwargs.pop("headers", None)),
+        **kwargs,
+    )
     metadata = await response.json(content_type=None)
     features = metadata["features"]
     cc = concat(
@@ -227,7 +296,12 @@ async def nestedcount(
         "groupByFieldsForStatistics": ",".join(fields),
         **data,
     }
-    response = await session.post(f"{url}/query", data=data, **kwargs)
+    response = await session.post(
+        f"{url}/query",
+        data=data,
+        headers=default_headers(kwargs.pop("headers", None)),
+        **kwargs,
+    )
     metadata = await response.json(content_type=None)
     features = metadata["features"]
     cc = concat(

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -1,10 +1,15 @@
+import json
+from unittest.mock import patch
+
 import pytest
 from aiohttp import ClientSession
+from geopandas import GeoDataFrame
 from pytest import raises
-from unittest.mock import patch
+from shapely.geometry import Point
 
 from restgdf.featurelayer.featurelayer import FeatureLayer
 from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
+from restgdf.utils.utils import where_var_in_list
 
 
 class MockRequestContext:
@@ -25,6 +30,9 @@ class MockRequestContext:
 
     async def json(self, content_type: str | None = None):
         return self.payload
+
+    async def text(self):
+        return json.dumps(self.payload)
 
     def raise_for_status(self):
         return None
@@ -49,6 +57,52 @@ class MockArcGISSession:
                 },
             )
         return MockRequestContext({"ok": True})
+
+
+class MockFeatureLayerSession:
+    def __init__(self, metadata: dict, count: int, object_ids: list[int] | None = None):
+        self.metadata = metadata
+        self.count = count
+        self.object_ids = object_ids or list(range(1, count + 1))
+        self.post_calls: list[tuple[str, dict]] = []
+        self.get_calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, **kwargs):
+        copied_kwargs = {
+            **kwargs,
+            "params": dict(kwargs.get("params", {})),
+        }
+        self.get_calls.append((url, copied_kwargs))
+        return MockRequestContext(self.metadata)
+
+    def post(self, url: str, **kwargs):
+        copied_kwargs = {
+            **kwargs,
+            "data": dict(kwargs.get("data", {})),
+        }
+        self.post_calls.append((url, copied_kwargs))
+        data = copied_kwargs["data"]
+
+        if url.endswith("/query"):
+            if data.get("returnCountOnly"):
+                return MockRequestContext({"count": self.count})
+            if data.get("returnIdsOnly"):
+                return MockRequestContext(
+                    {
+                        "objectIdFieldName": "OBJECTID",
+                        "objectIds": self.object_ids,
+                    },
+                )
+            return MockRequestContext({"features": []})
+
+        return MockRequestContext(self.metadata)
+
+
+def _mock_feature_gdf():
+    return GeoDataFrame(
+        {"OBJECTID": [1], "geometry": [Point(0, 0)]},
+        crs="EPSG:4326",
+    )
 
 
 @pytest.mark.asyncio
@@ -161,6 +215,86 @@ async def test_getuniquevalues_cache_includes_sortby():
     assert first == ["CITY"]
     assert second == ["STATE"]
     assert mock_getuniquevalues.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_getgdf_avoids_result_offset_when_pagination_is_unsupported():
+    session = MockFeatureLayerSession(
+        metadata={
+            "name": "Unsupported Pagination Layer",
+            "type": "Feature Layer",
+            "fields": [{"name": "OBJECTID", "type": "esriFieldTypeOID"}],
+            "maxRecordCount": 100,
+            "advancedQueryCapabilities": {"supportsPagination": False},
+        },
+        count=3,
+    )
+
+    with patch(
+        "restgdf.utils.getgdf.read_file",
+        side_effect=lambda *args, **kwargs: _mock_feature_gdf(),
+    ):
+        layer = await FeatureLayer.from_url(
+            "https://example.com/arcgis/rest/services/Test/FeatureServer/0",
+            session=session,
+        )
+        await layer.getgdf()
+
+    feature_queries = [
+        call_kwargs["data"]
+        for url, call_kwargs in session.post_calls
+        if url.endswith("/query")
+        and not call_kwargs["data"].get("returnCountOnly")
+        and not call_kwargs["data"].get("returnIdsOnly")
+    ]
+
+    assert len(feature_queries) == 1
+    assert "resultOffset" not in feature_queries[0]
+
+
+@pytest.mark.asyncio
+async def test_getgdf_falls_back_to_objectid_chunks_without_pagination():
+    session = MockFeatureLayerSession(
+        metadata={
+            "name": "Unsupported Pagination Layer",
+            "type": "Feature Layer",
+            "fields": [{"name": "OBJECTID", "type": "esriFieldTypeOID"}],
+            "maxRecordCount": 2,
+            "advancedQueryCapabilities": {"supportsPagination": False},
+        },
+        count=5,
+        object_ids=[1, 2, 3, 4, 5],
+    )
+
+    with patch(
+        "restgdf.utils.getgdf.read_file",
+        side_effect=lambda *args, **kwargs: _mock_feature_gdf(),
+    ):
+        layer = await FeatureLayer.from_url(
+            "https://example.com/arcgis/rest/services/Test/FeatureServer/0",
+            session=session,
+        )
+        await layer.getgdf()
+
+    query_calls = [
+        call_kwargs["data"]
+        for url, call_kwargs in session.post_calls
+        if url.endswith("/query")
+    ]
+    feature_queries = [
+        data
+        for data in query_calls
+        if not data.get("returnCountOnly") and not data.get("returnIdsOnly")
+    ]
+
+    assert any(data.get("returnIdsOnly") for data in query_calls)
+    assert len(feature_queries) == 3
+    assert all("resultOffset" not in data for data in feature_queries)
+    assert {data["where"] for data in feature_queries} == {
+        where_var_in_list("OBJECTID", [1, 2]),
+        where_var_in_list("OBJECTID", [3, 4]),
+        where_var_in_list("OBJECTID", [5]),
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -56,6 +56,23 @@ def mock_session_post(*args, **kwargs):
     return future  # return the future
 
 
+def mock_session_get(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, json_data):
+            self.json_data = json_data
+            self.content_type = "application/json"
+
+        async def json(
+            self,
+            content_type: str = "application/json",
+        ):
+            return self.json_data
+
+    future = asyncio.Future()
+    future.set_result(MockResponse(TESTJSON))
+    return future
+
+
 def mock_uniquevalues_post(*args, **kwargs):
     class MockResponse:
         def __init__(self, json_data):
@@ -82,8 +99,8 @@ def mock_uniquevalues_post(*args, **kwargs):
 
 @pytest.mark.asyncio
 @patch(
-    "restgdf.utils.getinfo.ClientSession.post",
-    side_effect=mock_session_post,
+    "restgdf.utils.getinfo.ClientSession.get",
+    side_effect=mock_session_get,
 )
 async def test_get_json_dict(mock_response):
     async with ClientSession() as s:
@@ -113,10 +130,14 @@ def test_get_max_record_count(mock_response):
 
 @pytest.mark.asyncio
 @patch(
+    "restgdf.utils.getinfo.ClientSession.get",
+    side_effect=mock_session_get,
+)
+@patch(
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=mock_session_post,
 )
-async def test_get_offset_range(mock_response):
+async def test_get_offset_range(mock_post, mock_get):
     async with ClientSession() as s:
         assert await get_offset_range("test", session=s) == range(
             0,


### PR DESCRIPTION
## Summary
Fixes #16.
Related upstream/browser repro: joshuasundance-swca/geospatial-data-converter#5.
Also fixes the related coverage workflow failure from run 24634282181 / job 72026862652.

## Motivation
The failing ArcGIS layer (`https://maps.psc.wi.gov/server/rest/services/Electric/Paris_9801CE100/MapServer/37`) exposes two problems:

1. The layer reports `advancedQueryCapabilities.supportsPagination = false`, but `restgdf` always sent `resultOffset`, which caused the server to return `400 Pagination is not supported`.
2. This server also returned HTML/404 responses to plain `aiohttp` metadata and query requests unless they carried normal ArcGIS-compatible request headers, which prevented the live repro from loading end-to-end.

Separately, the coverage workflow was failing because `coverage-badge` imports `pkg_resources`, but the workflow environment did not guarantee `setuptools` was present when the badge step ran.

## What changed
### Pagination / layer loading
- Added regression tests first for the non-paginated layer cases (red/green TDD):
  - single-request reads must not send `resultOffset`
  - multi-request reads must fall back to `returnIdsOnly` + object-id chunk queries instead of offset pagination
- Reworked GeoDataFrame query batching so `restgdf` now:
  - omits `resultOffset` when the full result fits in one request
  - keeps existing offset pagination when the layer supports it
  - falls back to object-id chunk queries when pagination is unsupported
- Resolved the actual object-id field from metadata instead of assuming `OBJECTID`, so the fallback and helper methods work with services that use a different OID field name
- Switched metadata retrieval to a GET-based request path and applied compatible default headers to ArcGIS metadata/query requests so the live repro server returns JSON instead of HTML/404

### Coverage workflow
- Added `setuptools>=61.0.0` to the `dev` extra
- Updated the coverage workflow to install `.[dev]` alongside `requirements.txt`, ensuring `coverage-badge` has `pkg_resources` available under Python 3.14

## Validation
### Automated
- `./.venv/Scripts/python -m pytest -q` -> `30 passed`
- `./.venv/Scripts/python -m pre_commit run --all-files` -> passed

### Targeted regression checks
- `./.venv/Scripts/python -m pytest tests/test_FeatureLayer.py::test_getgdf_avoids_result_offset_when_pagination_is_unsupported tests/test_FeatureLayer.py::test_getgdf_falls_back_to_objectid_chunks_without_pagination -q` -> passed
- `./.venv/Scripts/python -m pytest tests/test_getinfo.py::test_get_json_dict tests/test_getinfo.py::test_get_offset_range -q` -> passed

### Live repro
Using `FeatureLayer.from_url(...).getgdf()` against:
- `https://maps.psc.wi.gov/server/rest/services/Electric/Paris_9801CE100/MapServer/37`

now succeeds and returns **94** features (`Electric Distribution Lines`) instead of failing.

## Notes
This PR intentionally keeps the changes scoped to the issue and the related workflow failure. It does not change unrelated API behavior beyond making ArcGIS requests robust against the live server behavior above.
