### PR TITLE
test: isolate live network coverage

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -54,18 +54,35 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .[dev]
       - name: Run tests
-        run: python -m pytest -q
+        run: python -m pytest -q -m "not network"
+
+  network:
+    name: pytest-network
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package with dev extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev]
+      - name: Run live network tests
+        run: python -m pytest -q -m network --run-network
 
   ci:
     name: ci
     if: always()
-    needs: [lint, test]
+    needs: [lint, test, network]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate job results
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
-            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} network=${{ needs.network.result }}"
             exit 1
           fi
           echo "All required jobs succeeded."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,4 +105,8 @@ title = "restgdf coverage report"
 [tool.pytest.ini_options]
 pythonpath = "."
 testpaths = "tests"
+addopts = "--strict-markers"
 asyncio_mode = "strict"
+markers = [
+    "network: tests that hit live external ArcGIS services",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+import pytest_asyncio
+from aiohttp import ClientSession
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-network",
+        action="store_true",
+        default=False,
+        help="run tests marked as requiring live network access",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-network"):
+        return
+
+    skip_network = pytest.mark.skip(
+        reason="network test; pass --run-network to include live-service checks",
+    )
+    for item in items:
+        if "network" in item.keywords:
+            item.add_marker(skip_network)
+
+
+@pytest_asyncio.fixture
+async def client_session():
+    async with ClientSession() as session:
+        yield session

--- a/tests/test_Directory.py
+++ b/tests/test_Directory.py
@@ -1,18 +1,18 @@
-import pytest
-from aiohttp import ClientSession
 from unittest.mock import AsyncMock, patch
+
+import pytest
 
 from restgdf.directory.directory import Directory
 
 
 @pytest.mark.asyncio
-async def test_directory():
-    async with ClientSession() as s:
-        directory = await Directory.from_url(
-            "https://maps1.vcgov.org/arcgis/rest/services",
-            session=s,
-        )
-        services = await directory.crawl()
+@pytest.mark.network
+async def test_directory(client_session):
+    directory = await Directory.from_url(
+        "https://maps1.vcgov.org/arcgis/rest/services",
+        session=client_session,
+    )
+    services = await directory.crawl()
     assert directory.services == services
     first_service_with_layers = None
     for service in services:

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -3,7 +3,6 @@ from typing import Optional
 from unittest.mock import patch
 
 import pytest
-from aiohttp import ClientSession
 from geopandas import GeoDataFrame
 from pytest import raises
 from shapely.geometry import Point
@@ -304,63 +303,65 @@ async def test_getgdf_falls_back_to_objectid_chunks_without_pagination():
 
 
 @pytest.mark.asyncio
-async def test_featurelayer():
-    async with ClientSession() as s:
-        # print("testing workflow")
-        with pytest.raises(ValueError):
-            await FeatureLayer.from_url(
-                "https://maps1.vcgov.org/arcgis/rest/services/Beaches/MapServer",
-                session=s,
-            )
-        with pytest.raises(ValueError):
-            await FeatureLayer.from_url(
-                "https://maps1.vcgov.org/arcgis/rest/services/Aerials/MapServer/4",
-                session=s,
-            )
-        beachurl = r"https://maps1.vcgov.org/arcgis/rest/services/Beaches/MapServer/6"
-        beaches = await FeatureLayer.from_url(
-            beachurl,
-            session=s,
-            where="City <> 'fgsfds'",
+@pytest.mark.network
+async def test_featurelayer(client_session):
+    with pytest.raises(ValueError):
+        await FeatureLayer.from_url(
+            "https://maps1.vcgov.org/arcgis/rest/services/Beaches/MapServer",
+            session=client_session,
         )
-        beaches_gdf = await beaches.getgdf()
-        assert len(await beaches.samplegdf(2)) == 2
-        assert len(await beaches.headgdf(2)) == 2
-        assert len(beaches_gdf) > 0
-
-        # test row_dict_generator
-        row_gen = beaches.row_dict_generator()
-        beaches_row_gen_count = 0
-        async for row in row_gen:
-            assert isinstance(row, dict)
-            beaches_row_gen_count += 1
-        assert beaches_row_gen_count == len(beaches_gdf)
-
-        assert all(
-            "fgsfds" in s for s in (beaches.wherestr, beaches.kwargs["data"]["where"])
+    with pytest.raises(ValueError):
+        await FeatureLayer.from_url(
+            "https://maps1.vcgov.org/arcgis/rest/services/Aerials/MapServer/4",
+            session=client_session,
         )
-        assert len(await beaches.getuniquevalues(("City", "Status"), sortby="City")) > 1
-        daytona = await beaches.where("City LIKE 'DAYTONA%'")
-        assert "Status" in daytona.fields
-        assert str(beaches) == f"Beach Access Points ({beachurl})"
+    beachurl = r"https://maps1.vcgov.org/arcgis/rest/services/Beaches/MapServer/6"
+    beaches = await FeatureLayer.from_url(
+        beachurl,
+        session=client_session,
+        where="City <> 'fgsfds'",
+    )
+    beaches_gdf = await beaches.getgdf()
+    assert len(await beaches.samplegdf(2)) == 2
+    assert len(await beaches.headgdf(2)) == 2
+    assert len(beaches_gdf) > 0
 
-        zipurl = "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_ZIP_Codes_2016/FeatureServer/0"
-        ziprest = await FeatureLayer.from_url(zipurl, where="STATE = 'OH'", session=s)
-        testkwargs = {k: v for k, v in ziprest.kwargs.items()}
-        assert "Cincinnati" in await ziprest.getuniquevalues("PO_NAME")
-        assert await ziprest.getuniquevalues(
-            "PO_NAME",
-        ) == await ziprest.getuniquevalues(
-            "PO_NAME",
-        )
-        assert (await ziprest.getvaluecounts("PO_NAME")).set_index("PO_NAME").to_dict()[
-            "PO_NAME_count"
-        ]["Cincinnati"] > 40
-        with raises(IndexError):
-            assert "Cincinnati" in await ziprest.getuniquevalues("zzzzzz")
-        with raises(IndexError):
-            assert len(await ziprest.getnestedcount(("PO_NAME", "ZIP"))) > 900
-        assert len(await ziprest.getnestedcount(("PO_NAME", "ZIP_CODE"))) > 900
-        assert ziprest.count > ziprest.metadata["maxRecordCount"]
-        assert len(await ziprest.getgdf()) > ziprest.metadata["maxRecordCount"]
-        assert ziprest.kwargs == testkwargs  # make sure nothing is altering kwargs
+    row_gen = beaches.row_dict_generator()
+    beaches_row_gen_count = 0
+    async for row in row_gen:
+        assert isinstance(row, dict)
+        beaches_row_gen_count += 1
+    assert beaches_row_gen_count == len(beaches_gdf)
+
+    assert all(
+        "fgsfds" in s for s in (beaches.wherestr, beaches.kwargs["data"]["where"])
+    )
+    assert len(await beaches.getuniquevalues(("City", "Status"), sortby="City")) > 1
+    daytona = await beaches.where("City LIKE 'DAYTONA%'")
+    assert "Status" in daytona.fields
+    assert str(beaches) == f"Beach Access Points ({beachurl})"
+
+    zipurl = "https://services.arcgis.com/P3ePLMYs2RVChkJx/ArcGIS/rest/services/USA_ZIP_Codes_2016/FeatureServer/0"
+    ziprest = await FeatureLayer.from_url(
+        zipurl,
+        where="STATE = 'OH'",
+        session=client_session,
+    )
+    testkwargs = {k: v for k, v in ziprest.kwargs.items()}
+    assert "Cincinnati" in await ziprest.getuniquevalues("PO_NAME")
+    assert await ziprest.getuniquevalues(
+        "PO_NAME",
+    ) == await ziprest.getuniquevalues(
+        "PO_NAME",
+    )
+    assert (await ziprest.getvaluecounts("PO_NAME")).set_index("PO_NAME").to_dict()[
+        "PO_NAME_count"
+    ]["Cincinnati"] > 40
+    with raises(IndexError):
+        assert "Cincinnati" in await ziprest.getuniquevalues("zzzzzz")
+    with raises(IndexError):
+        assert len(await ziprest.getnestedcount(("PO_NAME", "ZIP"))) > 900
+    assert len(await ziprest.getnestedcount(("PO_NAME", "ZIP_CODE"))) > 900
+    assert ziprest.count > ziprest.metadata["maxRecordCount"]
+    assert len(await ziprest.getgdf()) > ziprest.metadata["maxRecordCount"]
+    assert ziprest.kwargs == testkwargs  # make sure nothing is altering kwargs

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -2,7 +2,6 @@ import asyncio
 from unittest.mock import patch
 
 import pytest
-from aiohttp import ClientSession
 from pandas import DataFrame
 
 from restgdf.utils.utils import ends_with_num, where_var_in_list
@@ -102,9 +101,8 @@ def mock_uniquevalues_post(*args, **kwargs):
     "restgdf.utils.getinfo.ClientSession.get",
     side_effect=mock_session_get,
 )
-async def test_get_json_dict(mock_response):
-    async with ClientSession() as s:
-        assert await get_metadata("test", session=s) == TESTJSON
+async def test_get_json_dict(mock_response, client_session):
+    assert await get_metadata("test", session=client_session) == TESTJSON
 
 
 @pytest.mark.asyncio
@@ -112,12 +110,19 @@ async def test_get_json_dict(mock_response):
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=mock_session_post,
 )
-async def test_get_feature_count(mock_response):
-    async with ClientSession() as s:
-        assert await get_feature_count("test", session=s) == TESTJSON["count"]
-        assert await get_feature_count("test", session=s, data={"where": "test"})
-        assert await get_feature_count("test", session=s, data={"token": "test"})
-        assert await get_feature_count("test", session=s, data=None)
+async def test_get_feature_count(mock_response, client_session):
+    assert await get_feature_count("test", session=client_session) == TESTJSON["count"]
+    assert await get_feature_count(
+        "test",
+        session=client_session,
+        data={"where": "test"},
+    )
+    assert await get_feature_count(
+        "test",
+        session=client_session,
+        data={"token": "test"},
+    )
+    assert await get_feature_count("test", session=client_session, data=None)
 
 
 @patch(
@@ -137,13 +142,12 @@ def test_get_max_record_count(mock_response):
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=mock_session_post,
 )
-async def test_get_offset_range(mock_post, mock_get):
-    async with ClientSession() as s:
-        assert await get_offset_range("test", session=s) == range(
-            0,
-            TESTJSON["count"],
-            TESTJSON["maxRecordCount"],
-        )
+async def test_get_offset_range(mock_post, mock_get, client_session):
+    assert await get_offset_range("test", session=client_session) == range(
+        0,
+        TESTJSON["count"],
+        TESTJSON["maxRecordCount"],
+    )
 
 
 @pytest.mark.asyncio
@@ -151,13 +155,13 @@ async def test_get_offset_range(mock_post, mock_get):
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=mock_uniquevalues_post,
 )
-async def test_getuniquevalues_sorts_single_field(mock_response):
-    async with ClientSession() as s:
-        assert await getuniquevalues("test", "CITY", s, sortby="CITY") == [
-            "A",
-            "B",
-            "C",
-        ]
+async def test_getuniquevalues_sorts_single_field(mock_response, client_session):
+    assert await getuniquevalues(
+        "test",
+        "CITY",
+        client_session,
+        sortby="CITY",
+    ) == ["A", "B", "C"]
 
 
 def test_default_data():
@@ -273,9 +277,8 @@ def _make_mock_post(json_data):
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=_make_mock_post(FEATURES_SINGLE_JSON),
 )
-async def test_getuniquevalues_single_field(mock_response):
-    async with ClientSession() as s:
-        result = await getuniquevalues("test", "City", session=s)
+async def test_getuniquevalues_single_field(mock_response, client_session):
+    result = await getuniquevalues("test", "City", session=client_session)
     assert result == ["DAYTONA", "ORMOND"]
 
 
@@ -284,9 +287,8 @@ async def test_getuniquevalues_single_field(mock_response):
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=_make_mock_post(FEATURES_SINGLE_JSON),
 )
-async def test_getuniquevalues_single_element_tuple(mock_response):
-    async with ClientSession() as s:
-        result = await getuniquevalues("test", ("City",), session=s)
+async def test_getuniquevalues_single_element_tuple(mock_response, client_session):
+    result = await getuniquevalues("test", ("City",), session=client_session)
     assert result == ["DAYTONA", "ORMOND"]
 
 
@@ -295,10 +297,13 @@ async def test_getuniquevalues_single_element_tuple(mock_response):
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=_make_mock_post(FEATURES_MULTI_JSON),
 )
-async def test_getuniquevalues_multi_field(mock_response):
+async def test_getuniquevalues_multi_field(mock_response, client_session):
     """Protect the DataFrame(x).T pattern used for multi-field unique values."""
-    async with ClientSession() as s:
-        result = await getuniquevalues("test", ("City", "Status"), session=s)
+    result = await getuniquevalues(
+        "test",
+        ("City", "Status"),
+        session=client_session,
+    )
     assert isinstance(result, DataFrame)
     assert list(result.columns) == ["City", "Status"]
     assert len(result) == 2
@@ -311,10 +316,9 @@ async def test_getuniquevalues_multi_field(mock_response):
     "restgdf.utils.getinfo.ClientSession.post",
     side_effect=_make_mock_post(VALUECOUNTS_JSON),
 )
-async def test_getvaluecounts_mock(mock_response):
+async def test_getvaluecounts_mock(mock_response, client_session):
     """Protect the concat(DataFrame(x['attributes'], index=[0])...) pattern."""
-    async with ClientSession() as s:
-        result = await getvaluecounts("test", "City", session=s)
+    result = await getvaluecounts("test", "City", session=client_session)
     assert isinstance(result, DataFrame)
     assert "City" in result.columns
     assert "City_count" in result.columns


### PR DESCRIPTION
## Summary

Tightens the pytest setup so live ArcGIS checks stay covered without multiplying network flake across the full Python matrix.

## Changes

- adds `@pytest.mark.network` handling via `tests/conftest.py`
- adds a shared async `client_session` fixture for aiohttp-backed tests
- registers the `network` marker and enables `--strict-markers`
- marks the two live-service tests (`test_directory`, `test_featurelayer`) as network-only
- updates the 3.9-3.14 CI matrix to run `pytest -m "not network"`
- adds a single Python 3.14 `pytest-network` CI job that runs `pytest -m network --run-network`

## Validation

- `python -m pre_commit run --all-files`
- `python -m pytest -q` -> 28 passed, 2 skipped
- `python -m pytest -q -m network --run-network` -> 2 passed, 28 deselected