### PR TITLE
Add comprehensive test coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
+from __future__ import annotations
+
 import pytest
 import pytest_asyncio
 from aiohttp import ClientSession
+from geopandas import GeoDataFrame
+from shapely.geometry import Point
 
 
 def pytest_addoption(parser):
@@ -28,3 +32,30 @@ def pytest_collection_modifyitems(config, items):
 async def client_session():
     async with ClientSession() as session:
         yield session
+
+
+@pytest.fixture
+def feature_layer_metadata():
+    return {
+        "name": "Test Layer",
+        "type": "Feature Layer",
+        "fields": [
+            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+            {"name": "CITY", "type": "esriFieldTypeString"},
+            {"name": "STATUS", "type": "esriFieldTypeString"},
+        ],
+        "maxRecordCount": 2,
+        "advancedQueryCapabilities": {"supportsPagination": True},
+    }
+
+
+@pytest.fixture
+def sample_feature_gdf():
+    return GeoDataFrame(
+        {
+            "OBJECTID": [1, 2],
+            "CITY": ["DAYTONA", "ORMOND"],
+            "geometry": [Point(0, 0), Point(1, 1)],
+        },
+        crs="EPSG:4326",
+    )

--- a/tests/test_Directory.py
+++ b/tests/test_Directory.py
@@ -49,3 +49,81 @@ async def test_directory_crawl_caches_feature_count_variant_separately():
     assert first == without_count["services"]
     assert second == with_count["services"]
     assert mock_fetch.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_directory_prep_stores_metadata():
+    session = object()
+    metadata = {"currentVersion": 11.3}
+    directory = Directory(
+        "https://example.com/arcgis/rest/services",
+        session=session,
+        token="secret-token",
+    )
+
+    with patch(
+        "restgdf.directory.directory.get_metadata",
+        new=AsyncMock(return_value=metadata),
+    ) as mock_get_metadata:
+        await directory.prep()
+
+    assert directory.metadata == metadata
+    mock_get_metadata.assert_awaited_once_with(
+        "https://example.com/arcgis/rest/services",
+        session,
+        "secret-token",
+    )
+
+
+@pytest.mark.asyncio
+async def test_directory_from_url_calls_prep():
+    with patch.object(Directory, "prep", new=AsyncMock()) as mock_prep:
+        directory = await Directory.from_url(
+            "https://example.com/arcgis/rest/services",
+            session=object(),
+        )
+
+    assert isinstance(directory, Directory)
+    mock_prep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_directory_crawl_reuses_cached_services():
+    directory = Directory("https://example.com/arcgis/rest/services", session=object())
+    cached_services = [{"name": "cached"}]
+    directory.services = cached_services
+
+    with patch(
+        "restgdf.directory.directory.fetch_all_data",
+        new=AsyncMock(),
+    ) as mock_fetch:
+        result = await directory.crawl()
+
+    assert result is cached_services
+    mock_fetch.assert_not_awaited()
+
+
+def test_filter_directory_layers_requires_crawl():
+    directory = Directory("https://example.com/arcgis/rest/services", session=object())
+
+    with pytest.raises(ValueError, match="call \\.crawl"):
+        directory.filter_directory_layers("Feature Layer")
+
+
+def test_filter_directory_layers_selects_matching_types():
+    directory = Directory("https://example.com/arcgis/rest/services", session=object())
+    directory.services = [
+        {
+            "metadata": {
+                "layers": [
+                    {"id": 0, "type": "Feature Layer"},
+                    {"id": 1, "type": "Raster Layer"},
+                ],
+            },
+        },
+        {"metadata": {}},
+        {},
+    ]
+
+    assert directory.feature_layers() == [{"id": 0, "type": "Feature Layer"}]
+    assert directory.rasters() == [{"id": 1, "type": "Raster Layer"}]

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -1,6 +1,6 @@
 import json
 from typing import Optional
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from geopandas import GeoDataFrame
@@ -135,6 +135,14 @@ async def test_arcgistokensession():
     assert session.get_calls[0][1]["params"]["token"] == "generated-token"
 
 
+def test_featurelayer_requires_url_to_end_with_numeric_layer_id():
+    with pytest.raises(ValueError, match="must end with a number"):
+        FeatureLayer(
+            "https://example.com/arcgis/rest/services/Secured/FeatureServer",
+            session=MockArcGISSession(),
+        )
+
+
 def test_featurelayer_accepts_legacy_token_kwarg():
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
@@ -171,6 +179,125 @@ async def test_getoids_uses_objectid_field():
     layer.getuniquevalues = fake_getuniquevalues
 
     assert await layer.getoids() == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_prep_populates_metadata_fields(feature_layer_metadata):
+    session = MockFeatureLayerSession(metadata=feature_layer_metadata, count=7)
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=session,
+        token="saved-token",
+    )
+
+    await layer.prep()
+
+    assert layer.metadata == feature_layer_metadata
+    assert layer.name == "Test Layer"
+    assert layer.fields == ["OBJECTID", "CITY", "STATUS"]
+    assert layer.object_id_field == "OBJECTID"
+    assert layer.count == 7
+    assert session.get_calls[0][1]["params"]["token"] == "saved-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("metadata", [{"type": "Map Server"}, {}])
+async def test_featurelayer_prep_rejects_non_feature_layers(metadata):
+    session = MockFeatureLayerSession(metadata=metadata, count=0)
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=session,
+    )
+
+    with pytest.raises(ValueError, match="FeatureLayer"):
+        await layer.prep()
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_from_url_calls_prep():
+    with patch.object(FeatureLayer, "prep", new=AsyncMock()) as mock_prep:
+        layer = await FeatureLayer.from_url(
+            "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+            session=MockArcGISSession(),
+        )
+
+    assert isinstance(layer, FeatureLayer)
+    mock_prep.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_samplegdf_uses_random_subset():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.object_id_field = "OBJECTID"
+    layer.fields = ("OBJECTID",)
+
+    sampled_layer = AsyncMock()
+    sampled_layer.getgdf = AsyncMock(return_value="sampled-gdf")
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.getuniquevalues",
+        new=AsyncMock(return_value=[1, 2, 3]),
+    ), patch(
+        "restgdf.featurelayer.featurelayer.random.sample",
+        return_value=[3, 1],
+    ) as mock_sample, patch.object(
+        layer,
+        "where",
+        new=AsyncMock(return_value=sampled_layer),
+    ) as mock_where:
+        result = await layer.samplegdf(10)
+
+    assert result == "sampled-gdf"
+    mock_sample.assert_called_once_with([1, 2, 3], 3)
+    mock_where.assert_awaited_once_with(where_var_in_list("OBJECTID", [3, 1]))
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_headgdf_uses_first_ids():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.object_id_field = "OBJECTID"
+    layer.fields = ("OBJECTID",)
+
+    head_layer = AsyncMock()
+    head_layer.getgdf = AsyncMock(return_value="head-gdf")
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.getuniquevalues",
+        new=AsyncMock(return_value=[1, 2, 3, 4]),
+    ), patch.object(
+        layer,
+        "where",
+        new=AsyncMock(return_value=head_layer),
+    ) as mock_where:
+        result = await layer.headgdf(2)
+
+    assert result == "head-gdf"
+    mock_where.assert_awaited_once_with(where_var_in_list("OBJECTID", [1, 2]))
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_getgdf_caches_result(sample_feature_gdf):
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.get_gdf",
+        new=AsyncMock(return_value=sample_feature_gdf),
+    ) as mock_get_gdf:
+        first = await layer.getgdf()
+        second = await layer.getgdf()
+
+    assert first.equals(sample_feature_gdf)
+    assert second.equals(sample_feature_gdf)
+    mock_get_gdf.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -220,6 +347,129 @@ async def test_getuniquevalues_cache_includes_sortby():
     assert first == ["CITY"]
     assert second == ["STATE"]
     assert mock_getuniquevalues.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_getuniquevalues_rejects_unknown_fields():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY", "STATE")
+
+    with pytest.raises(IndexError):
+        await layer.getuniquevalues("ZIP")
+
+    with pytest.raises(IndexError):
+        await layer.getuniquevalues(("CITY", "ZIP"))
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_getvaluecounts_caches_and_validates_fields():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY", "STATE")
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.getvaluecounts",
+        new=AsyncMock(return_value="counts"),
+    ) as mock_getvaluecounts:
+        first = await layer.getvaluecounts("CITY")
+        second = await layer.getvaluecounts("CITY")
+
+    assert first == second == "counts"
+    mock_getvaluecounts.assert_awaited_once()
+
+    with pytest.raises(IndexError):
+        await layer.getvaluecounts("ZIP")
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_getnestedcount_caches_and_validates_fields():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY", "STATE")
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.nestedcount",
+        new=AsyncMock(return_value="nested"),
+    ) as mock_nestedcount:
+        first = await layer.getnestedcount(("CITY", "STATE"))
+        second = await layer.getnestedcount(("CITY", "STATE"))
+
+    assert first == second == "nested"
+    mock_nestedcount.assert_awaited_once()
+
+    with pytest.raises(IndexError):
+        await layer.getnestedcount(("CITY", "ZIP"))
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_where_combines_filters_and_preserves_kwargs():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+        where="CITY = 'DAYTONA'",
+        token="saved-token",
+    )
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.FeatureLayer.from_url",
+        new=AsyncMock(return_value="filtered-layer"),
+    ) as mock_from_url:
+        result = await layer.where("STATUS = 'Open'")
+
+    assert result == "filtered-layer"
+    mock_from_url.assert_awaited_once_with(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=layer.session,
+        where="CITY = 'DAYTONA' AND STATUS = 'Open'",
+        data=layer.kwargs["data"],
+    )
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_where_leaves_default_where_unwrapped():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.FeatureLayer.from_url",
+        new=AsyncMock(return_value="filtered-layer"),
+    ) as mock_from_url:
+        await layer.where("STATUS = 'Open'")
+
+    mock_from_url.assert_awaited_once_with(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=layer.session,
+        where="STATUS = 'Open'",
+        data=layer.kwargs["data"],
+    )
+
+
+def test_featurelayer_repr_and_str():
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+        where="CITY = 'DAYTONA'",
+        token="saved-token",
+    )
+    layer.name = "Beach Access Points"
+
+    representation = repr(layer)
+
+    assert "Rest(" in representation
+    assert "CITY = 'DAYTONA'" in representation
+    assert str(layer) == (
+        "Beach Access Points "
+        "(https://example.com/arcgis/rest/services/Secured/FeatureServer/0)"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+
+from restgdf.utils.crawl import fetch_all_data
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_collects_services_and_folder_services():
+    base_url = "https://example.com/arcgis/rest/services"
+    session = object()
+    metadata_by_url = {
+        base_url: {
+            "services": [{"name": "Root/Parcels", "type": "FeatureServer"}],
+            "folders": ["Utilities"],
+        },
+        f"{base_url}/Utilities": {
+            "services": [{"name": "Utilities/Storm", "type": "MapServer"}],
+        },
+    }
+
+    async def fake_get_metadata(url, session, token=None):
+        return metadata_by_url[url]
+
+    async def fake_service_metadata(
+        session,
+        service_url,
+        token,
+        return_feature_count=False,
+    ):
+        return {
+            "service_url": service_url,
+            "return_feature_count": return_feature_count,
+            "token": token,
+        }
+
+    with patch(
+        "restgdf.utils.crawl.get_metadata",
+        side_effect=fake_get_metadata,
+    ) as mock_get_metadata, patch(
+        "restgdf.utils.crawl.service_metadata",
+        side_effect=fake_service_metadata,
+    ) as mock_service_metadata:
+        result = await fetch_all_data(
+            session,
+            base_url,
+            token="abc123",
+            return_feature_count=True,
+        )
+
+    assert result["metadata"]["url"] == base_url
+    assert result["services"] == [
+        {
+            "name": "Root/Parcels",
+            "url": f"{base_url}/Root/Parcels/FeatureServer",
+            "metadata": {
+                "service_url": f"{base_url}/Root/Parcels/FeatureServer",
+                "return_feature_count": True,
+                "token": "abc123",
+            },
+        },
+        {
+            "name": "Utilities/Storm",
+            "url": f"{base_url}/Utilities/Storm/MapServer",
+            "metadata": {
+                "service_url": f"{base_url}/Utilities/Storm/MapServer",
+                "return_feature_count": True,
+                "token": "abc123",
+            },
+        },
+    ]
+    assert mock_get_metadata.await_args_list == [
+        call(base_url, session, "abc123"),
+        call(f"{base_url}/Utilities", session, "abc123"),
+    ]
+    assert mock_service_metadata.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_returns_base_metadata_error():
+    error = RuntimeError("boom")
+
+    with patch(
+        "restgdf.utils.crawl.get_metadata",
+        new=AsyncMock(side_effect=error),
+    ):
+        result = await fetch_all_data(object(), "https://example.com/services")
+
+    assert result == {"error": error}
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_returns_folder_metadata_error():
+    base_url = "https://example.com/arcgis/rest/services"
+    error = RuntimeError("folder failure")
+
+    async def fake_get_metadata(url, session, token=None):
+        if url == base_url:
+            return {"services": [], "folders": ["Utilities"]}
+        raise error
+
+    with patch(
+        "restgdf.utils.crawl.get_metadata",
+        side_effect=fake_get_metadata,
+    ):
+        result = await fetch_all_data(object(), base_url)
+
+    assert result == {"error": error}
+
+
+@pytest.mark.asyncio
+async def test_fetch_all_data_wraps_service_metadata_failures():
+    base_url = "https://example.com/arcgis/rest/services"
+
+    with patch(
+        "restgdf.utils.crawl.get_metadata",
+        new=AsyncMock(
+            side_effect=[
+                {
+                    "services": [{"name": "Root/Parcels", "type": "FeatureServer"}],
+                    "folders": [],
+                },
+            ],
+        ),
+    ), patch(
+        "restgdf.utils.crawl.service_metadata",
+        new=AsyncMock(side_effect=KeyError("missing")),
+    ):
+        result = await fetch_all_data(object(), base_url)
+
+    assert isinstance(result["services"][0]["metadata"]["error"], KeyError)

--- a/tests/test_getgdf.py
+++ b/tests/test_getgdf.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from geopandas import GeoDataFrame
+
+from restgdf.utils.getgdf import (
+    chunk_generator,
+    chunk_values,
+    combine_where_clauses,
+    get_gdf,
+    get_gdf_list,
+    get_query_data_batches,
+    get_sub_gdf,
+    row_dict_generator,
+)
+
+
+class RecordingSession:
+    def __init__(self, response_text: str = "{}"):
+        self.response_text = response_text
+        self.post_calls: list[tuple[str, dict]] = []
+
+    async def post(self, url: str, **kwargs):
+        self.post_calls.append((url, kwargs))
+
+        class Response:
+            def __init__(self, text_payload: str):
+                self._text_payload = text_payload
+
+            async def text(self):
+                return self._text_payload
+
+        return Response(self.response_text)
+
+
+@pytest.mark.parametrize(
+    ("base_where", "extra_where", "expected"),
+    [
+        (None, "OBJECTID In (1, 2)", "OBJECTID In (1, 2)"),
+        ("", "OBJECTID In (1, 2)", "OBJECTID In (1, 2)"),
+        ("1=1", "OBJECTID In (1, 2)", "OBJECTID In (1, 2)"),
+        (
+            "CITY = 'DAYTONA'",
+            "OBJECTID In (1, 2)",
+            "(CITY = 'DAYTONA') AND (OBJECTID In (1, 2))",
+        ),
+    ],
+)
+def test_combine_where_clauses(base_where, extra_where, expected):
+    assert combine_where_clauses(base_where, extra_where) == expected
+
+
+def test_chunk_values_splits_evenly():
+    assert chunk_values([1, 2, 3, 4, 5], 2) == [[1, 2], [3, 4], [5]]
+
+
+@pytest.mark.asyncio
+async def test_get_query_data_batches_returns_single_request_when_under_limit():
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=2),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value={"maxRecordCount": 5}),
+    ):
+        result = await get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "CITY = 'DAYTONA'", "token": "abc"},
+        )
+
+    assert result == [{"where": "CITY = 'DAYTONA'", "token": "abc"}]
+
+
+@pytest.mark.asyncio
+async def test_get_query_data_batches_uses_result_offsets_when_supported():
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=5),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(
+            return_value={
+                "maxRecordCount": 2,
+                "advancedQueryCapabilities": {"supportsPagination": True},
+            },
+        ),
+    ):
+        result = await get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "CITY = 'DAYTONA'"},
+        )
+
+    assert result == [
+        {"where": "CITY = 'DAYTONA'", "resultOffset": 0},
+        {"where": "CITY = 'DAYTONA'", "resultOffset": 2},
+        {"where": "CITY = 'DAYTONA'", "resultOffset": 4},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_query_data_batches_chunks_object_ids_when_pagination_disabled():
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=5),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(
+            return_value={
+                "maxRecordCount": 2,
+                "advancedQueryCapabilities": {"supportsPagination": False},
+            },
+        ),
+    ), patch(
+        "restgdf.utils.getgdf.get_object_ids",
+        new=AsyncMock(return_value=("OBJECTID", [1, 2, 3, 4, 5])),
+    ):
+        result = await get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "CITY = 'DAYTONA'"},
+        )
+
+    assert result == [
+        {"where": "(CITY = 'DAYTONA') AND (OBJECTID In (1, 2))"},
+        {"where": "(CITY = 'DAYTONA') AND (OBJECTID In (3, 4))"},
+        {"where": "(CITY = 'DAYTONA') AND (OBJECTID In (5))"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_sub_gdf_uses_geojson_driver_when_esrijson_missing(
+    sample_feature_gdf,
+):
+    session = RecordingSession(response_text='{"features": []}')
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        return_value=sample_feature_gdf,
+    ) as mock_read_file:
+        result = await get_sub_gdf(
+            "https://example.com/layer/0",
+            session,
+            query_data={"where": "1=1"},
+            data={"ignored": True},
+            headers={"X-Test": "yes"},
+            timeout=12,
+        )
+
+    assert result.equals(sample_feature_gdf)
+    assert session.post_calls == [
+        (
+            "https://example.com/layer/0/query",
+            {
+                "data": {"where": "1=1", "f": "GeoJSON"},
+                "headers": {
+                    "Accept": "application/json,text/plain,*/*",
+                    "User-Agent": "Mozilla/5.0",
+                    "X-Test": "yes",
+                },
+                "timeout": 12,
+            },
+        ),
+    ]
+    mock_read_file.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_gdf_list_builds_tasks_from_batches(sample_feature_gdf):
+    session = object()
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}, {"where": "OBJECTID > 5"}]),
+    ), patch(
+        "restgdf.utils.getgdf.get_sub_gdf",
+        new=AsyncMock(side_effect=[sample_feature_gdf, sample_feature_gdf.iloc[[0]]]),
+    ) as mock_get_sub_gdf:
+        result = await get_gdf_list("https://example.com/layer/0", session)
+
+    assert len(result) == 2
+    assert mock_get_sub_gdf.await_args_list == [
+        call(
+            "https://example.com/layer/0",
+            session,
+            query_data={"where": "1=1"},
+        ),
+        call(
+            "https://example.com/layer/0",
+            session,
+            query_data={"where": "OBJECTID > 5"},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_chunk_generator_yields_each_chunk(sample_feature_gdf):
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}, {"where": "OBJECTID > 5"}]),
+    ), patch(
+        "restgdf.utils.getgdf.get_sub_gdf",
+        new=AsyncMock(side_effect=[sample_feature_gdf, sample_feature_gdf.iloc[[0]]]),
+    ):
+        chunks = [
+            chunk
+            async for chunk in chunk_generator("https://example.com/layer/0", object())
+        ]
+
+    assert len(chunks) == 2
+    assert all(isinstance(chunk, GeoDataFrame) for chunk in chunks)
+
+
+@pytest.mark.asyncio
+async def test_row_dict_generator_yields_rows(sample_feature_gdf):
+    with patch(
+        "restgdf.utils.getgdf.chunk_generator",
+        return_value=None,
+    ) as mock_chunk_generator:
+
+        async def fake_chunk_generator(*args, **kwargs):
+            yield sample_feature_gdf.iloc[[0]]
+            yield sample_feature_gdf.iloc[[1]]
+
+        mock_chunk_generator.side_effect = fake_chunk_generator
+        rows = [
+            row
+            async for row in row_dict_generator("https://example.com/layer/0", object())
+        ]
+
+    assert [row["CITY"] for row in rows] == ["DAYTONA", "ORMOND"]
+
+
+@pytest.mark.asyncio
+async def test_get_gdf_forwards_token_and_detects_conflicts():
+    session = object()
+    with patch(
+        "restgdf.utils.getgdf.gdf_by_concat",
+        new=AsyncMock(return_value="sentinel"),
+    ) as mock_gdf_by_concat:
+        result = await get_gdf(
+            "https://example.com/layer/0",
+            session=session,
+            where="CITY = 'DAYTONA'",
+            token="abc",
+        )
+
+    assert result == "sentinel"
+    mock_gdf_by_concat.assert_awaited_once_with(
+        "https://example.com/layer/0",
+        session,
+        data={
+            "where": "CITY = 'DAYTONA'",
+            "outFields": "*",
+            "returnGeometry": True,
+            "returnCountOnly": False,
+            "f": "json",
+            "token": "abc",
+        },
+    )
+
+    with pytest.raises(ValueError):
+        await get_gdf(
+            "https://example.com/layer/0",
+            session=object(),
+            token="abc",
+            data={"token": "different"},
+        )

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from pandas import DataFrame
@@ -7,8 +7,11 @@ from pandas import DataFrame
 from restgdf.utils.utils import ends_with_num, where_var_in_list
 from restgdf.utils.getinfo import (
     DEFAULTDICT,
+    default_headers,
     default_data,
     get_feature_count,
+    get_object_id_field,
+    get_object_ids,
     getuniquevalues,
     get_metadata,
     get_max_record_count,
@@ -16,6 +19,9 @@ from restgdf.utils.getinfo import (
     get_offset_range,
     getfields,
     getfields_df,
+    nestedcount,
+    service_metadata,
+    supports_pagination,
     getvaluecounts,
 )
 
@@ -180,6 +186,47 @@ def test_default_data():
         assert default_data(indict) == outdict
 
 
+def test_default_headers():
+    assert default_headers({"X-Test": "yes"}) == {
+        "Accept": "application/json,text/plain,*/*",
+        "User-Agent": "Mozilla/5.0",
+        "X-Test": "yes",
+    }
+
+
+def test_supports_pagination_prefers_advanced_query_capabilities():
+    assert (
+        supports_pagination(
+            {"advancedQueryCapabilities": {"supportsPagination": False}},
+        )
+        is False
+    )
+    assert supports_pagination({"supportsPagination": False}) is False
+    assert supports_pagination({}) is True
+
+
+def test_get_object_id_field():
+    assert (
+        get_object_id_field(
+            {"fields": [{"name": "OBJECTID", "type": "esriFieldTypeOID"}]},
+        )
+        == "OBJECTID"
+    )
+
+    with pytest.raises(IndexError):
+        get_object_id_field({"fields": []})
+
+    with pytest.raises(IndexError):
+        get_object_id_field(
+            {
+                "fields": [
+                    {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+                    {"name": "ALTID", "type": "esriFieldTypeOID"},
+                ],
+            },
+        )
+
+
 # ---------------------------------------------------------------------------
 # Pure-function regression tests (upgrade baseline)
 # These cover functions previously only exercised by live-network tests.
@@ -314,6 +361,26 @@ async def test_getuniquevalues_multi_field(mock_response, client_session):
 @pytest.mark.asyncio
 @patch(
     "restgdf.utils.getinfo.ClientSession.post",
+    side_effect=_make_mock_post(FEATURES_MULTI_JSON),
+)
+async def test_getuniquevalues_multi_field_sorts_dataframe(
+    mock_response,
+    client_session,
+):
+    result = await getuniquevalues(
+        "test",
+        ("City", "Status"),
+        session=client_session,
+        sortby="City",
+    )
+
+    assert result.iloc[0]["City"] == "DAYTONA"
+    assert result.iloc[1]["City"] == "ORMOND"
+
+
+@pytest.mark.asyncio
+@patch(
+    "restgdf.utils.getinfo.ClientSession.post",
     side_effect=_make_mock_post(VALUECOUNTS_JSON),
 )
 async def test_getvaluecounts_mock(mock_response, client_session):
@@ -325,3 +392,139 @@ async def test_getvaluecounts_mock(mock_response, client_session):
     # sorted descending by count
     assert result.iloc[0]["City"] == "DAYTONA"
     assert result.iloc[0]["City_count"] == 5
+
+
+@pytest.mark.asyncio
+@patch(
+    "restgdf.utils.getinfo.ClientSession.post",
+    side_effect=_make_mock_post(
+        {
+            "objectIdFieldName": "OBJECTID",
+            "objectIds": [1, 2, 3],
+        },
+    ),
+)
+async def test_get_object_ids_passes_through_where_and_token(
+    mock_response,
+    client_session,
+):
+    field_name, object_ids = await get_object_ids(
+        "test",
+        client_session,
+        data={"where": "CITY = 'DAYTONA'", "token": "abc123"},
+        headers={"X-Test": "yes"},
+    )
+
+    assert field_name == "OBJECTID"
+    assert object_ids == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+@patch(
+    "restgdf.utils.getinfo.ClientSession.post",
+    side_effect=_make_mock_post(
+        {
+            "features": [
+                {
+                    "attributes": {
+                        "City": "DAYTONA",
+                        "Status": "Open",
+                        "City_count": 2,
+                        "Status_count": 2,
+                    },
+                },
+                {
+                    "attributes": {
+                        "City": "DAYTONA",
+                        "Status": "Closed",
+                        "City_count": 1,
+                        "Status_count": 1,
+                    },
+                },
+                {
+                    "attributes": {
+                        "City": "ORMOND",
+                        "Status": "Closed",
+                        "City_count": 1,
+                        "Status_count": 1,
+                    },
+                },
+            ],
+        },
+    ),
+)
+async def test_nestedcount_shapes_output(mock_response, client_session):
+    result = await nestedcount(
+        "test",
+        ("City", "Status"),
+        client_session,
+    )
+
+    assert list(result.columns) == ["City", "Status", "Count"]
+    assert result.iloc[0]["City"] == "DAYTONA"
+    assert result.iloc[0]["Count"] >= result.iloc[1]["Count"]
+
+
+@pytest.mark.asyncio
+async def test_service_metadata_fetches_layers_and_feature_counts():
+    metadata_by_url = {
+        "https://example.com/service": {
+            "layers": [{"id": 0}, {"id": 1}],
+        },
+        "https://example.com/service/0": {
+            "type": "Feature Layer",
+            "name": "Parcels",
+        },
+        "https://example.com/service/1": {
+            "type": "Raster Layer",
+            "name": "Imagery",
+        },
+    }
+
+    async def fake_get_metadata(url, session, token=None):
+        return dict(metadata_by_url[url])
+
+    async def fake_get_feature_count(url, session, **kwargs):
+        return 12
+
+    with patch(
+        "restgdf.utils.getinfo.get_metadata",
+        side_effect=fake_get_metadata,
+    ), patch(
+        "restgdf.utils.getinfo.get_feature_count",
+        side_effect=fake_get_feature_count,
+    ) as mock_get_feature_count:
+        result = await service_metadata(
+            object(),
+            "https://example.com/service",
+            token="abc123",
+            return_feature_count=True,
+        )
+
+    assert result["layers"][0]["url"] == "https://example.com/service/0"
+    assert result["layers"][0]["feature_count"] == 12
+    assert "feature_count" not in result["layers"][1]
+    mock_get_feature_count.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_service_metadata_sets_feature_count_none_when_count_lookup_fails():
+    async def fake_get_metadata(url, session, token=None):
+        if url.endswith("/0"):
+            return {"type": "Feature Layer"}
+        return {"layers": [{"id": 0}]}
+
+    with patch(
+        "restgdf.utils.getinfo.get_metadata",
+        side_effect=fake_get_metadata,
+    ), patch(
+        "restgdf.utils.getinfo.get_feature_count",
+        new=AsyncMock(side_effect=KeyError("count")),
+    ):
+        result = await service_metadata(
+            object(),
+            "https://example.com/service",
+            return_feature_count=True,
+        )
+
+    assert result["layers"][0]["feature_count"] is None

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession, get_token
+
+
+class MockRequestContext:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def __await__(self):
+        async def _response():
+            return self
+
+        return _response().__await__()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return None
+
+    async def json(self):
+        return self.payload
+
+    def raise_for_status(self):
+        return None
+
+
+class RecordingTokenSession:
+    def __init__(self):
+        self.get_calls: list[tuple[str, dict]] = []
+        self.post_calls: list[tuple[str, dict]] = []
+
+    def get(self, url: str, **kwargs):
+        self.get_calls.append((url, kwargs))
+        return MockRequestContext({"ok": True})
+
+    def post(self, url: str, **kwargs):
+        self.post_calls.append((url, kwargs))
+        if url.endswith("generateToken"):
+            return MockRequestContext(
+                {
+                    "token": "generated-token",
+                    "expires": 32503680000000,
+                },
+            )
+        return MockRequestContext({"ok": True})
+
+
+def test_get_token_uses_requests_post():
+    response = Mock()
+    response.json.return_value = {"token": "sync-token"}
+
+    with patch("restgdf.utils.token.requests.post", return_value=response) as mock_post:
+        result = get_token("user", "password")
+
+    assert result == {"token": "sync-token"}
+    mock_post.assert_called_once_with(
+        "https://www.arcgis.com/sharing/rest/generateToken",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data={
+            "f": "json",
+            "client": "requestip",
+            "username": "user",
+            "password": "password",
+        },
+        timeout=30,
+    )
+
+
+def test_token_request_payload_requires_credentials():
+    token_session = ArcGISTokenSession(session=RecordingTokenSession())
+
+    with pytest.raises(ValueError):
+        _ = token_session.token_request_payload
+
+
+def test_update_headers_and_dict_respect_existing_values():
+    token_session = ArcGISTokenSession(
+        session=RecordingTokenSession(),
+        token="abc123",
+        expires=32503680000000,
+    )
+
+    assert token_session.auth_headers == {"Authorization": "Bearer abc123"}
+    assert token_session.update_headers({"X-Test": "yes"}) == {
+        "X-Test": "yes",
+        "Authorization": "Bearer abc123",
+    }
+    assert token_session.update_dict({"where": "1=1"}) == {
+        "where": "1=1",
+        "token": "abc123",
+    }
+    assert token_session.update_dict({"token": "explicit"}) == {"token": "explicit"}
+
+
+def test_token_needs_update_branching():
+    token_session = ArcGISTokenSession(session=RecordingTokenSession())
+    assert token_session.token_needs_update() is False
+
+    token_session = ArcGISTokenSession(
+        session=RecordingTokenSession(),
+        credentials=AGOLUserPass("user", "password"),
+    )
+    assert token_session.token_needs_update() is True
+
+    future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        minutes=5,
+    )
+    token_session.token = "abc123"
+    token_session.expires = future.timestamp()
+    assert token_session.token_needs_update() is False
+
+    soon = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        seconds=30,
+    )
+    token_session.expires = soon.timestamp() * 1000
+    assert token_session.token_needs_update() is True
+
+
+@pytest.mark.asyncio
+async def test_update_token_if_needed_only_refreshes_when_required():
+    token_session = ArcGISTokenSession(
+        session=RecordingTokenSession(),
+        credentials=AGOLUserPass("user", "password"),
+        token="abc123",
+        expires=32503680000000,
+    )
+
+    with patch.object(
+        token_session,
+        "update_token",
+        new=AsyncMock(),
+    ) as mock_update_token, patch.object(
+        token_session,
+        "token_needs_update",
+        return_value=False,
+    ):
+        await token_session.update_token_if_needed()
+
+    mock_update_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_arcgistokensession_refreshes_and_injects_auth():
+    session = RecordingTokenSession()
+    token_session = ArcGISTokenSession(
+        session=session,
+        credentials=AGOLUserPass(username="user", password="password"),
+    )
+
+    post_response = await token_session.post(
+        "https://example.com/query",
+        data={"where": "1=1"},
+    )
+    get_response = await token_session.get(
+        "https://example.com/items",
+        params={"f": "json"},
+    )
+
+    assert await post_response.json() == {"ok": True}
+    assert await get_response.json() == {"ok": True}
+    assert token_session.token == "generated-token"
+    assert session.post_calls[0][0].endswith("generateToken")
+    assert session.post_calls[1][1]["data"]["token"] == "generated-token"
+    assert session.get_calls[0][1]["params"]["token"] == "generated-token"
+
+
+@pytest.mark.asyncio
+async def test_arcgistokensession_context_manager_updates_token():
+    token_session = ArcGISTokenSession(
+        session=RecordingTokenSession(),
+        credentials=AGOLUserPass("user", "password"),
+    )
+
+    async with token_session as active_session:
+        assert active_session is token_session
+        assert active_session.token == "generated-token"
+
+    assert await token_session.__aexit__(None, None, None) is None
+
+
+@pytest.mark.asyncio
+async def test_arcgistokensession_respects_explicit_token_in_request():
+    session = RecordingTokenSession()
+    token_session = ArcGISTokenSession(
+        session=session,
+        credentials=AGOLUserPass("user", "password"),
+    )
+
+    await token_session.post(
+        "https://example.com/query",
+        data={"token": "explicit", "where": "1=1"},
+        headers={"X-Test": "yes"},
+    )
+    await token_session.get(
+        "https://example.com/items",
+        params={"token": "explicit"},
+        headers={"X-Test": "yes"},
+    )
+
+    assert session.post_calls[-1][1]["headers"] == {"X-Test": "yes"}
+    assert session.post_calls[-1][1]["data"]["token"] == "explicit"
+    assert session.get_calls[-1][1]["headers"] == {"X-Test": "yes"}
+    assert session.get_calls[-1][1]["params"]["token"] == "explicit"


### PR DESCRIPTION
## Summary
- expand unit coverage for Directory, FeatureLayer, crawl, getgdf, getinfo, and token helpers
- add shared fixtures for async and GeoDataFrame-based tests
- cover caching, pagination, object-id batching, token refresh, metadata parsing, and error branches

## Validation
- .venv\\Scripts\\python -m pytest -q
- .venv\\Scripts\\python -m coverage run -m pytest -q && .venv\\Scripts\\python -m coverage report -m
- .venv\\Scripts\\python -m pre_commit run --all-files