### PR TITLE
feat!: integrate pydantic 2.13.3 and release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to restgdf are documented here. This project follows
+[Semantic Versioning](https://semver.org/).
+
+## [2.0.0]
+
+**Major release — pydantic 2.13 integration.** See
+[`MIGRATION.md`](./MIGRATION.md) for a complete breaking-changes table and
+migration recipes.
+
+### Breaking
+
+- Public return and attribute shapes changed from plain `dict` /
+  `TypedDict` to pydantic `BaseModel` classes:
+  - `FeatureLayer.metadata` → `LayerMetadata`
+  - `Directory.metadata` → `LayerMetadata`
+  - `Directory.services`, `Directory.services_with_feature_count`,
+    and `Directory.crawl(...)` → `list[CrawlServiceEntry]`
+  - `get_metadata(...)` → `LayerMetadata`
+  - `safe_crawl(...)` → `CrawlReport`
+- `AGOLUserPass.password` is now `pydantic.SecretStr`; call
+  `.get_secret_value()` at the HTTP-POST boundary.
+- `restgdf._types.*` TypedDicts are replaced by lazy aliases that
+  re-export the new pydantic models and emit `DeprecationWarning` on
+  import. The shim will be removed in 3.x.
+
+### Added
+
+- `LayerMetadata`, `ServiceInfo`, `FieldSpec`, `Feature`,
+  `FeaturesResponse`, `CountResponse`, `ObjectIdsResponse`,
+  `TokenResponse`, `ErrorInfo`, `ErrorResponse`, `CrawlReport`,
+  `CrawlServiceEntry`, `CrawlError` — pydantic response models.
+- `AGOLUserPass`, `TokenSessionConfig` — pydantic credentials / session
+  config models.
+- `Settings`, `get_settings` — process-wide runtime configuration backed
+  by `RESTGDF_*` environment variables (`CHUNK_SIZE`, `TIMEOUT_SECONDS`,
+  `USER_AGENT`, `LOG_LEVEL`, `TOKEN_URL`, `REFRESH_THRESHOLD`,
+  `DEFAULT_HEADERS_JSON`).
+- `RestgdfResponseError` — typed error raised when a strict-tier
+  response fails validation; carries `model_name`, `context`, and `raw`
+  payload attributes.
+- `restgdf.compat.as_dict` / `restgdf.compat.as_json_dict` — migration
+  helpers that convert any returned model (or passthrough any non-model)
+  to a plain dict.
+- `restgdf.schema_drift` logger — opt-in observability for vendor
+  variance; `NullHandler` by default.
+- `Directory.report` — the full `CrawlReport` (services, errors,
+  root metadata) from the most recent `.crawl()` call.
+
+### Dependencies
+
+- Added `pydantic>=2.13.3,<3`.
+
+## [1.x]
+
+Earlier releases were not formally tracked here. See the Git tag history
+and PyPI release notes for pre-2.0 changes.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,370 @@
+# Migrating from restgdf 1.x to 2.0
+
+restgdf 2.0 replaces the dict / `TypedDict` public surface with
+[pydantic 2.13](https://docs.pydantic.dev/) `BaseModel` classes. This means
+every response and config object you consumed in 1.x is now a typed model:
+attribute access instead of dict indexing, runtime validation instead of
+silent `KeyError`, and structured drift logging instead of opaque failures.
+
+This guide lists every breaking change, the migration aids shipped with 2.0,
+and the new capabilities you can opt into.
+
+## Contents
+
+- [Why 2.0](#why-20)
+- [Breaking changes](#breaking-changes)
+- [Migration aids](#migration-aids)
+- [New capabilities](#new-capabilities)
+- [Environment variables](#environment-variables)
+- [Drift logger](#drift-logger)
+- [`Settings` usage](#settings-usage)
+- [`SecretStr` credentials](#secretstr-credentials)
+- [Troubleshooting](#troubleshooting)
+
+## Why 2.0
+
+Real-world ArcGIS REST responses vary between vendor versions, deployments,
+and service types. In 1.x these variances surfaced as `KeyError` /
+`IndexError` deep in call stacks, or silently passed through as partially
+valid dicts. 2.0 fixes that:
+
+- **Pydantic-validated envelopes** catch malformed responses at the
+  boundary and raise a typed `RestgdfResponseError` that carries the raw
+  payload and request context.
+- **Permissive models** (`LayerMetadata`, `ServiceInfo`, `FieldSpec`, crawl
+  models) accept unknown extra keys and tolerate missing optional fields;
+  drift is reported through a dedicated `restgdf.schema_drift` logger
+  instead of crashing.
+- **Strict models** (`CountResponse`, `ObjectIdsResponse`, `TokenResponse`,
+  `ErrorResponse`) keep their fail-fast contract on operation-critical
+  payloads.
+- **Typed credentials** — passwords are `pydantic.SecretStr`, redacted
+  from `repr()` / logs.
+
+## Breaking changes
+
+Every change below is a public-API shape change from 1.x.
+
+| What changed | 1.x (dict) | 2.0 (model) |
+|---|---|---|
+| `FeatureLayer.metadata` | `dict` | `LayerMetadata` |
+| `Directory.metadata` | `dict` | `LayerMetadata` |
+| `Directory.services` | `list[dict]` | `list[CrawlServiceEntry]` |
+| `Directory.services_with_feature_count` | `list[dict]` | `list[CrawlServiceEntry]` |
+| `Directory.crawl(...)` return value | `list[dict]` | `list[CrawlServiceEntry]` |
+| `Directory.report` | *(did not exist)* | `Optional[CrawlReport]` |
+| `get_metadata(...)` | returns `dict` | returns `LayerMetadata` |
+| `get_feature_count(...)` | returns `int` (unvalidated) | returns `int` (validated via `CountResponse`) |
+| `get_object_ids(...)` | returns `tuple[str, list[int]]` (unvalidated) | returns `tuple[str, list[int]]` (validated via `ObjectIdsResponse`) |
+| `safe_crawl(...)` | returns `dict` | returns `CrawlReport` |
+| `fetch_all_data(...)` | returns raw `dict` (short-circuits on error) | unchanged signature, but internally validates; see `safe_crawl` for the typed report |
+| `AGOLUserPass.password` | plain `str` | `pydantic.SecretStr` (call `.get_secret_value()` at the HTTP boundary) |
+| `ArcGISTokenSession` config | ad-hoc dataclass | backed by `TokenSessionConfig` (pydantic) |
+| `restgdf._types.*` | `TypedDict` aliases | re-exported pydantic models, emit `DeprecationWarning` on import |
+
+### Code rewrites
+
+Dict indexing → attribute access. The examples below are representative,
+not exhaustive.
+
+**`FeatureLayer.metadata`**
+```python
+# 1.x
+layer_name = fl.metadata["name"]
+fields = fl.metadata["fields"]
+max_record_count = fl.metadata["maxRecordCount"]
+
+# 2.0
+layer_name = fl.metadata.name
+fields = fl.metadata.fields                 # list[FieldSpec] | None
+max_record_count = fl.metadata.max_record_count
+```
+
+**`Directory.services`**
+```python
+# 1.x
+for svc in directory.services:
+    print(svc["name"], svc["url"])
+
+# 2.0
+for svc in directory.services:              # list[CrawlServiceEntry]
+    print(svc.name, svc.url)
+    if svc.metadata is not None:            # LayerMetadata | None
+        print(svc.metadata.max_record_count)
+```
+
+**`AGOLUserPass`**
+```python
+# 1.x
+creds = AGOLUserPass(username="alice", password="hunter2")
+token_form["password"] = creds.password
+
+# 2.0
+creds = AGOLUserPass(username="alice", password="hunter2")
+token_form["password"] = creds.password.get_secret_value()
+```
+
+**`get_metadata`**
+```python
+# 1.x
+md = await get_metadata(url, session)
+service_type = md.get("type")
+
+# 2.0
+md = await get_metadata(url, session)       # LayerMetadata
+service_type = md.type                      # str | None
+```
+
+### ArcGIS camelCase round-trip
+
+Models accept either camelCase (native ArcGIS) or snake_case input via
+`pydantic.AliasChoices`. To emit camelCase for an ArcGIS round-trip, use
+`model.model_dump(by_alias=True)`. To get Python-native snake_case keys,
+use `model.model_dump()` or the `restgdf.compat.as_dict` helper.
+
+## Migration aids
+
+### `restgdf.compat.as_dict(obj)`
+
+Wrap any returned model to get a plain Python dict. Non-model values
+(plain dicts, `None`, primitives) pass through unchanged, so you can
+sprinkle it through transitional code without type checks:
+
+```python
+from restgdf.compat import as_dict
+
+for entry in directory.services:
+    row = as_dict(entry)                    # dict whether model or legacy
+    save(row["name"], row.get("url"))
+```
+
+`as_dict` uses `model_dump(mode="python", by_alias=False)` — snake_case
+keys, nested models recursively converted.
+
+### `restgdf.compat.as_json_dict(obj)`
+
+Like `as_dict`, but `mode="json"` so every value is JSON-serializable
+(`SecretStr` → `"**********"` placeholder, `datetime` → ISO string).
+Handy for structured logging:
+
+```python
+from restgdf.compat import as_json_dict
+
+logger.info("crawl_result", extra={"payload": as_json_dict(report)})
+```
+
+### Deprecated `restgdf._types` aliases
+
+`from restgdf._types import LayerMetadata` still works; it now returns
+the pydantic class and emits a `DeprecationWarning`:
+
+```python
+import warnings
+
+warnings.filterwarnings("default", category=DeprecationWarning)
+from restgdf._types import LayerMetadata   # DeprecationWarning
+```
+
+Switch the import to `from restgdf import LayerMetadata`. The shim will
+be removed in 3.x.
+
+## New capabilities
+
+### Typed response errors
+
+Strict-tier envelopes raise `RestgdfResponseError` on validation failure,
+carrying the raw payload and context:
+
+```python
+from restgdf import RestgdfResponseError, get_feature_count
+
+try:
+    count = await get_feature_count(url, session)
+except RestgdfResponseError as exc:
+    logger.error(
+        "ArcGIS returned malformed count envelope",
+        extra={
+            "model": exc.model_name,       # "CountResponse"
+            "context": exc.context,        # the request URL
+            "raw": exc.raw,                # the decoded body
+        },
+    )
+    raise
+```
+
+### Schema-drift observability
+
+Permissive models never raise on vendor variance; instead they log one
+record per `(model_name, path, kind, value_type)` tuple through
+`restgdf.schema_drift`. The logger is installed with a `NullHandler` by
+default — opt in by attaching a handler (see below).
+
+### Pydantic round-trip
+
+You can validate, inspect, and re-emit any response payload:
+
+```python
+from restgdf import LayerMetadata
+
+md = LayerMetadata.model_validate(raw_dict)
+native = md.model_dump(by_alias=True)   # camelCase, ArcGIS-compatible
+python = md.model_dump()                # snake_case, Python-native
+```
+
+### Centralized `Settings` / `get_settings()`
+
+See the [`Settings` usage](#settings-usage) section below.
+
+### `SecretStr` on credential passwords
+
+See the [`SecretStr` credentials](#secretstr-credentials) section below.
+
+## Environment variables
+
+All settings are overridable via `RESTGDF_*` env vars. Unset vars use
+the documented default.
+
+| Variable | Field | Type | Default |
+|---|---|---|---|
+| `RESTGDF_CHUNK_SIZE` | `chunk_size` | int (>0) | `100` |
+| `RESTGDF_TIMEOUT_SECONDS` | `timeout_seconds` | float (>0) | `30.0` |
+| `RESTGDF_USER_AGENT` | `user_agent` | str (non-empty) | `"restgdf/<version>"` |
+| `RESTGDF_LOG_LEVEL` | `log_level` | one of `CRITICAL`/`ERROR`/`WARNING`/`INFO`/`DEBUG`/`NOTSET` | `"WARNING"` |
+| `RESTGDF_TOKEN_URL` | `token_url` | `http(s)://` URL | `https://www.arcgis.com/sharing/rest/generateToken` |
+| `RESTGDF_REFRESH_THRESHOLD` | `refresh_threshold_seconds` | int (≥0) | `60` |
+| `RESTGDF_DEFAULT_HEADERS_JSON` | `default_headers_json` | JSON dict string | `None` |
+
+Malformed values raise `RestgdfResponseError` at first access.
+
+## Drift logger
+
+`restgdf.schema_drift` is the single logger name. It is silent by
+default — install a handler to see what ArcGIS deployments are sending
+you:
+
+```python
+import logging
+
+drift_logger = logging.getLogger("restgdf.schema_drift")
+drift_logger.setLevel(logging.DEBUG)
+drift_logger.addHandler(logging.StreamHandler())
+
+# Now any permissive model drift is visible:
+# WARNING restgdf.schema_drift: LayerMetadata.max_record_count missing at <url>
+# DEBUG   restgdf.schema_drift: LayerMetadata unknown extra 'foo' at <url>
+```
+
+Log levels:
+
+- **WARNING** — a field `restgdf` actually consumes is missing or has the
+  wrong shape. Library behavior is preserved (defaults to `None`), but
+  operators likely want to see this.
+- **DEBUG** — an unknown-extra key is present. Purely informational.
+
+Drift events are deduped per process via `(model_name, path, kind,
+value_type)` so repeated calls against the same drifty server don't
+spam the log.
+
+## `Settings` usage
+
+`Settings` is a frozen pydantic `BaseModel`. `get_settings()` returns a
+process-cached instance; tests can reset the cache to pick up environment
+changes:
+
+```python
+import os
+from restgdf import Settings, get_settings
+from restgdf._models._settings import reset_settings_cache
+
+# Default: read from os.environ.
+settings = get_settings()
+print(settings.chunk_size, settings.user_agent)
+
+# Programmatic override.
+settings = Settings(chunk_size=250, user_agent="my-app/1.0")
+
+# In tests, mutate env then reset the cache.
+os.environ["RESTGDF_CHUNK_SIZE"] = "500"
+reset_settings_cache()
+assert get_settings().chunk_size == 500
+
+# Bypass the real environment entirely:
+settings = Settings.from_env({"RESTGDF_TOKEN_URL": "http://internal/arcgis"})
+```
+
+## `SecretStr` credentials
+
+`AGOLUserPass.password` is a `pydantic.SecretStr`: its literal value is
+never in `repr()` or `str()`, so it is safe for log records, tracebacks,
+and error reports.
+
+```python
+from restgdf import AGOLUserPass
+
+creds = AGOLUserPass(username="alice", password="hunter2")
+print(creds)
+# username='alice' password=SecretStr('**********') ...
+
+# Unwrap only at the HTTP-POST boundary.
+password_str = creds.password.get_secret_value()
+```
+
+Do not store or log the unwrapped value.
+
+## Troubleshooting
+
+### `AttributeError: 'LayerMetadata' object has no attribute 'get'`
+
+You're calling `.get(...)` on what used to be a dict. Switch to attribute
+access:
+
+```python
+# old
+name = md.get("name", "unknown")
+
+# new
+name = md.name or "unknown"
+```
+
+Or wrap it: `as_dict(md).get("name", "unknown")`.
+
+### `TypeError: 'LayerMetadata' object is not subscriptable`
+
+Indexing (`md["name"]`) is gone. Use `md.name`, or `as_dict(md)["name"]`
+during a transitional window.
+
+### `RestgdfResponseError: Settings validation failed`
+
+A `RESTGDF_*` env var is malformed (for example, `RESTGDF_CHUNK_SIZE=0`
+fails `gt=0`). Check `exc.raw` for the offending values and `exc.context`
+for the origin (`"Settings.from_env"`).
+
+### `RestgdfResponseError` from `get_feature_count` / `get_object_ids` / `update_token`
+
+The ArcGIS server returned a payload that did not match the strict
+envelope (often an HTML error page or an `{"error": {...}}` body).
+`exc.model_name` identifies the expected envelope, `exc.context` holds
+the request URL, and `exc.raw` holds the decoded body for triage.
+
+### Silencing the deprecation warnings
+
+During migration you may want to suppress the `restgdf._types.*`
+`DeprecationWarning` without papering over others:
+
+```python
+import warnings
+
+warnings.filterwarnings(
+    "ignore",
+    message=r"restgdf\._types\..* is deprecated",
+    category=DeprecationWarning,
+)
+```
+
+Remove the filter once all imports are updated.
+
+### `SecretStr` string coercion
+
+`str(creds.password)` returns `"**********"`, not the password. If some
+library expects a plain `str`, unwrap explicitly with
+`creds.password.get_secret_value()`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,35 @@ improved esri rest io for geopandas
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 ![Known Vulnerabilities](https://snyk.io/test/github/joshuasundance-swca/restgdf/badge.svg)
 
+## What's new in 2.0
+
+restgdf 2.0 is a **major release** built on [pydantic 2.13](https://docs.pydantic.dev/).
+See [`MIGRATION.md`](./MIGRATION.md) for the full breaking-changes table and
+code-rewrite recipes.
+
+- **Typed responses.** `FeatureLayer.metadata`, `Directory.metadata` /
+  `.services` / `.report`, and helpers like `get_metadata`, `safe_crawl`
+  now return pydantic models instead of raw dicts.
+- **Validated envelopes.** `get_feature_count`, `get_object_ids`, and
+  token refresh surface malformed ArcGIS payloads as a typed
+  `RestgdfResponseError` (with `model_name`, `context`, `raw`).
+- **Schema-drift observability.** Vendor variance in permissive payloads
+  (metadata, crawl) is logged through the opt-in `restgdf.schema_drift`
+  logger instead of silently `KeyError`-ing.
+- **Redacted credentials.** `AGOLUserPass.password` is a
+  `pydantic.SecretStr` so passwords are never in `repr()` or logs.
+- **Centralized settings.** `Settings` / `get_settings()` reads
+  `RESTGDF_*` environment variables (chunk size, timeout, user agent,
+  token URL, refresh threshold, etc.).
+- **Migration helpers.** `restgdf.compat.as_dict` and `as_json_dict`
+  convert any returned model back to a plain dict during a transitional
+  upgrade window.
+- **Deprecated shim.** `restgdf._types.*` still imports the legacy
+  `TypedDict` names, but they now re-export the pydantic classes and
+  emit `DeprecationWarning`. The shim will be removed in 3.x.
+- **Dependency bump.** `pydantic>=2.13.3,<3` is a new required
+  dependency.
+
 `gpd.read_file(url, driver="ESRIJSON")` does not account for max record count limitations
 
 so if you read a service with 100000 features but there's a limit of 1000 records per query, then your gdf will only have 1000 features
@@ -108,6 +137,34 @@ secured_gdf = asyncio.run(main())
 ```
 
 If you already have a token, you can pass it with `token="..."` or `data={"token": "..."}`.
+
+## Typed responses
+
+Every response is a pydantic model. Attribute access replaces dict
+indexing, and `model_dump(by_alias=True)` round-trips back to ArcGIS
+camelCase:
+
+```python
+import asyncio
+
+from aiohttp import ClientSession
+
+from restgdf import FeatureLayer
+
+
+async def main():
+    async with ClientSession() as session:
+        fl = await FeatureLayer.from_url(beaches_url, session=session)
+        md = fl.metadata                      # restgdf.LayerMetadata
+        return md.name, md.max_record_count, md.model_dump(by_alias=True)
+
+
+name, max_record_count, arcgis_dict = asyncio.run(main())
+```
+
+Need a plain dict during a transitional migration? Use
+`restgdf.compat.as_dict(md)`. See [`MIGRATION.md`](./MIGRATION.md) for
+the full 1.x → 2.0 rewrite table.
 
 # Documentation
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ napoleon_use_ivar = True
 project = 'restgdf'
 copyright = '2023, Joshua Sundance Bailey'
 author = 'Joshua Sundance Bailey'
-release = '1.0.0'
+release = '2.0.0'
 # Package supports Python 3.9+; repo tooling/CI/docs build targets Python 3.14.
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,8 +11,10 @@ Welcome to restgdf's documentation!
    :caption: Contents:
 
    restgdf
+   models
    authentication
    utils
+   migration
 
 Indices and tables
 ==================

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,54 @@
+Migration from 1.x to 2.0
+=========================
+
+restgdf 2.0 is a major release built on pydantic 2.13. The full
+breaking-changes table, migration recipes, and troubleshooting guide
+live in ``MIGRATION.md`` at the root of the repository:
+
+  https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md
+
+Highlights
+----------
+
+- ``FeatureLayer.metadata`` and ``Directory.metadata`` are
+  :class:`~restgdf.LayerMetadata` (pydantic ``BaseModel``) instead of
+  plain ``dict``. Use attribute access::
+
+      fl.metadata.name              # was fl.metadata["name"]
+      fl.metadata.max_record_count  # was fl.metadata["maxRecordCount"]
+
+- ``Directory.services`` and ``Directory.crawl(...)`` return
+  ``list[CrawlServiceEntry]``. ``Directory.report`` is the full
+  :class:`~restgdf.CrawlReport` (services + errors + root metadata)
+  from the most recent crawl.
+
+- Strict envelopes (:class:`~restgdf.CountResponse`,
+  :class:`~restgdf.ObjectIdsResponse`,
+  :class:`~restgdf.TokenResponse`) surface malformed payloads as
+  :class:`~restgdf.RestgdfResponseError` with ``model_name``,
+  ``context``, and ``raw`` attributes.
+
+- :class:`~restgdf.AGOLUserPass` stores ``password`` as
+  ``pydantic.SecretStr``. Call ``creds.password.get_secret_value()``
+  only at the HTTP-POST boundary.
+
+- The ``restgdf.schema_drift`` logger is silent by default; attach a
+  handler to observe vendor variance in permissive payloads.
+
+- :class:`~restgdf.Settings` / :func:`~restgdf.get_settings` centralize
+  runtime configuration; override via ``RESTGDF_*`` environment
+  variables.
+
+- ``restgdf._types`` is a deprecated shim that re-exports the new
+  pydantic models and emits ``DeprecationWarning``. It will be removed
+  in 3.x.
+
+Migration helpers
+-----------------
+
+``restgdf.compat.as_dict(model)`` and
+``restgdf.compat.as_json_dict(model)`` convert a pydantic model back to
+a plain dict for consumers that need the 1.x shape during a transitional
+window. Non-model inputs pass through unchanged.
+
+See :doc:`models` for the full typed surface.

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,0 +1,116 @@
+Pydantic models
+===============
+
+restgdf 2.0 exposes every ArcGIS response and config object as a
+pydantic ``BaseModel``. These classes are the single source of truth
+for payload shape and are re-exported from ``restgdf`` directly.
+
+Response envelopes
+------------------
+
+.. autoclass:: restgdf.LayerMetadata
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.ServiceInfo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.FieldSpec
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.Feature
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.FeaturesResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.CountResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.ObjectIdsResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.TokenResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.ErrorInfo
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.ErrorResponse
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Crawl models
+------------
+
+.. autoclass:: restgdf.CrawlReport
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.CrawlServiceEntry
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.CrawlError
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Credentials and session config
+------------------------------
+
+.. autoclass:: restgdf.AGOLUserPass
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autoclass:: restgdf.TokenSessionConfig
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Runtime settings
+----------------
+
+.. autoclass:: restgdf.Settings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. autofunction:: restgdf.get_settings
+
+Errors
+------
+
+.. autoclass:: restgdf.RestgdfResponseError
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Migration helpers
+-----------------
+
+.. automodule:: restgdf.compat
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ exclude = ["tests*"]
 
 [project]
 name = "restgdf"
-version = "1.0.0"
+version = "2.0.0"
 description = "improved esri rest io for geopandas"
 authors = [{ name = "Joshua Sundance Bailey" }]
 readme = "README.md"
@@ -16,6 +16,7 @@ dependencies = [
     "aiohttp",
     "geopandas",
     "pandas",
+    "pydantic>=2.13.3,<3",
     "pyogrio",
     "requests",
 ]
@@ -54,7 +55,7 @@ doc = [
 ]
 
 [tool.bumpver]
-current_version = "1.0.0"
+current_version = "2.0.0"
 version_pattern = "MAJOR.MINOR.PATCH"
 commit_message = "Bump version {old_version} -> {new_version}"
 commit = true
@@ -118,7 +119,7 @@ markers = [
 [tool.mypy]
 
 [[tool.mypy.overrides]]
-module = ["restgdf._types", "restgdf._client.*"]
+module = ["restgdf._client.*", "restgdf._models.*", "restgdf.compat"]
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 disallow_untyped_calls = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "geopandas",
     "pandas",
     "pydantic>=2.13.3,<3",
+    "eval_type_backport; python_version < '3.10'",
     "pyogrio",
     "requests",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ aiosignal==1.4.0
     # via aiohttp
 alabaster==1.0.0
     # via sphinx
+annotated-types==0.7.0
+    # via pydantic
 attrs==26.1.0
     # via aiohttp
 babel==2.18.0
@@ -103,6 +105,10 @@ propcache==0.4.1
     # via
     #   aiohttp
     #   yarl
+pydantic==2.13.3
+    # via restgdf (pyproject.toml)
+pydantic-core==2.46.3
+    # via pydantic
 pygments==2.20.0
     # via
     #   pytest
@@ -160,6 +166,13 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 toml==0.10.2
     # via bumpver
+typing-extensions==4.15.0
+    # via
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
 tzdata==2026.1
     # via pandas
 urllib3==2.6.3

--- a/restgdf/__init__.py
+++ b/restgdf/__init__.py
@@ -1,17 +1,55 @@
 """A package for getting GeoDataFrames from ArcGIS FeatureLayers."""
 
+from restgdf import compat, utils
+from restgdf._models import (
+    AGOLUserPass,
+    CountResponse,
+    CrawlError,
+    CrawlReport,
+    CrawlServiceEntry,
+    ErrorInfo,
+    ErrorResponse,
+    Feature,
+    FeaturesResponse,
+    FieldSpec,
+    LayerMetadata,
+    ObjectIdsResponse,
+    RestgdfResponseError,
+    ServiceInfo,
+    Settings,
+    TokenResponse,
+    TokenSessionConfig,
+    get_settings,
+)
 from restgdf.directory.directory import Directory
 from restgdf.featurelayer.featurelayer import FeatureLayer
-from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
-from restgdf import utils
+from restgdf.utils.token import ArcGISTokenSession
 
 __all__ = [
     "AGOLUserPass",
     "ArcGISTokenSession",
+    "CountResponse",
+    "CrawlError",
+    "CrawlReport",
+    "CrawlServiceEntry",
     "Directory",
+    "ErrorInfo",
+    "ErrorResponse",
+    "Feature",
     "FeatureLayer",
+    "FeaturesResponse",
+    "FieldSpec",
+    "LayerMetadata",
+    "ObjectIdsResponse",
+    "RestgdfResponseError",
+    "ServiceInfo",
+    "Settings",
+    "TokenResponse",
+    "TokenSessionConfig",
+    "compat",
+    "get_settings",
     "utils",
 ]
 
 
-__version__ = "1.0.0"
+__version__ = "2.0.0"

--- a/restgdf/_logging.py
+++ b/restgdf/_logging.py
@@ -1,0 +1,35 @@
+"""Logging scaffolding for the pydantic-powered schema-drift pipeline.
+
+Usage
+-----
+Library code that wants to record ArcGIS response variance should call
+:func:`get_drift_logger` rather than instantiating its own logger. The
+returned logger is shared by every slice and attaches a :class:`NullHandler`
+so library users opt in to output (``logging.getLogger("restgdf.schema_drift")
+.addHandler(logging.StreamHandler())`` or equivalent).
+
+The logger name ``restgdf.schema_drift`` is part of the restgdf 2.x public
+contract. Tests assert against it via ``caplog``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+SCHEMA_DRIFT_LOGGER_NAME = "restgdf.schema_drift"
+
+
+def get_drift_logger() -> logging.Logger:
+    """Return the restgdf schema-drift logger.
+
+    The logger is created lazily on first access and is guaranteed to have
+    a :class:`~logging.NullHandler` attached so libraries importing restgdf
+    do not emit warnings to the root logger by default.
+    """
+    logger = logging.getLogger(SCHEMA_DRIFT_LOGGER_NAME)
+    if not any(isinstance(h, logging.NullHandler) for h in logger.handlers):
+        logger.addHandler(logging.NullHandler())
+    return logger
+
+
+__all__ = ["SCHEMA_DRIFT_LOGGER_NAME", "get_drift_logger"]

--- a/restgdf/_models/__init__.py
+++ b/restgdf/_models/__init__.py
@@ -1,0 +1,59 @@
+"""Pydantic 2.x response/config models for restgdf 2.x.
+
+This subpackage is the single source of truth for runtime-validated data
+shapes. It grew out of the TypedDicts previously declared in
+:mod:`restgdf._types`; those names are now deprecated aliases that re-export
+from here.
+
+Submodules are added slice-by-slice per the v2.0.0 integration plan:
+
+* :mod:`restgdf._models._drift` — shared response-validation adapter and
+  deduped drift logging.
+* :mod:`restgdf._models.responses` — ArcGIS payload envelopes
+  (``LayerMetadata``, ``CountResponse``, etc.).
+* :mod:`restgdf._models.crawl` — crawl-report models.
+* :mod:`restgdf._models.credentials` — ``AGOLUserPass`` and
+  ``TokenSessionConfig``.
+* :mod:`restgdf._models.settings` — process-level runtime settings.
+"""
+
+from __future__ import annotations
+
+from restgdf._models._errors import RestgdfResponseError
+from restgdf._models._settings import Settings, get_settings, reset_settings_cache
+from restgdf._models.crawl import CrawlError, CrawlReport, CrawlServiceEntry
+from restgdf._models.credentials import AGOLUserPass, TokenSessionConfig
+from restgdf._models.responses import (
+    CountResponse,
+    ErrorInfo,
+    ErrorResponse,
+    Feature,
+    FeaturesResponse,
+    FieldSpec,
+    LayerMetadata,
+    ObjectIdsResponse,
+    ServiceInfo,
+    TokenResponse,
+)
+
+__all__ = [
+    "AGOLUserPass",
+    "CountResponse",
+    "CrawlError",
+    "CrawlReport",
+    "CrawlServiceEntry",
+    "ErrorInfo",
+    "ErrorResponse",
+    "Feature",
+    "FeaturesResponse",
+    "FieldSpec",
+    "LayerMetadata",
+    "ObjectIdsResponse",
+    "RestgdfResponseError",
+    "ServiceInfo",
+    "Settings",
+    "TokenResponse",
+    "TokenSessionConfig",
+    "get_settings",
+    "reset_settings_cache",
+]

--- a/restgdf/_models/_drift.py
+++ b/restgdf/_models/_drift.py
@@ -1,0 +1,209 @@
+"""Shared drift adapter for pydantic response parsing.
+
+This module defines the two response-model tiers used across the library:
+
+* :class:`PermissiveModel` — ``extra="allow"``, accepts any payload, logs
+  drift. Used for metadata, service, folder, and crawl shapes where ArcGIS
+  vendor variance is expected.
+* :class:`StrictModel` — ``extra="ignore"``, raises
+  :class:`~restgdf._models.RestgdfResponseError` on validation failure.
+  Used for operation-critical envelopes (count, object-ids, token,
+  error envelope, feature response envelope).
+
+The :func:`_parse_response` adapter is the single call-site that every
+parser uses to convert a raw dict into a validated model. It dedupes
+drift log records on ``(model_name, path, kind, value_type)`` so a
+pathological server does not spam the log.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from restgdf._logging import get_drift_logger
+from restgdf._models._errors import RestgdfResponseError
+
+_DriftKey = tuple[str, str, str, str]
+
+_seen_drift: set[_DriftKey] = set()
+
+
+def reset_drift_cache() -> None:
+    """Clear the per-process drift dedupe cache.
+
+    Tests that exercise drift-log assertions should call this in a
+    fixture so each test sees a fresh dedupe state.
+    """
+    _seen_drift.clear()
+
+
+class PermissiveModel(BaseModel):
+    """Base for ArcGIS payloads where vendor variance is expected.
+
+    Extra keys are kept on the model (``extra="allow"``) and consumed
+    fields are declared as ``Optional`` so missing-field drift never
+    raises. The :func:`_parse_response` adapter additionally catches
+    :class:`~pydantic.ValidationError` on fields that fail type coercion,
+    logs the offending field as drift, and returns a partially-filled
+    instance instead of raising.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class StrictModel(BaseModel):
+    """Base for operation-critical ArcGIS envelopes.
+
+    Validation failures are wrapped in
+    :class:`~restgdf._models.RestgdfResponseError` with the original
+    payload and request context attached so operators can triage ArcGIS
+    vendor incidents.
+    """
+
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
+
+
+_M = TypeVar("_M", bound=BaseModel)
+
+
+def _known_keys(model_cls: type[BaseModel]) -> set[str]:
+    """Return the set of attribute names and aliases the model declares."""
+    names: set[str] = set()
+    for name, info in model_cls.model_fields.items():
+        names.add(name)
+        if info.alias:
+            names.add(info.alias)
+        choices = info.validation_alias
+        if choices is not None:
+            try:
+                for choice in choices.choices:
+                    if isinstance(choice, str):
+                        names.add(choice)
+            except AttributeError:
+                pass
+    return names
+
+
+def _log_drift(
+    *,
+    model_name: str,
+    path: str,
+    kind: str,
+    sample: Any,
+    level: int,
+) -> None:
+    """Emit a deduped drift log record.
+
+    Dedupe key is ``(model_name, path, kind, type(sample).__name__)`` so
+    repeated occurrences of the same drift against the same model do not
+    spam the log; semantically-distinct drift (different field or
+    different observed type) still logs.
+    """
+    sample_type = type(sample).__name__
+    key: _DriftKey = (model_name, path, kind, sample_type)
+    if key in _seen_drift:
+        return
+    _seen_drift.add(key)
+    logger = get_drift_logger()
+    logger.log(
+        level,
+        "schema drift on %s: field=%r kind=%s observed_type=%s sample=%r",
+        model_name,
+        path,
+        kind,
+        sample_type,
+        sample,
+    )
+
+
+def _parse_response(
+    model_cls: type[_M],
+    raw: Any,
+    *,
+    context: str,
+) -> _M:
+    """Validate ``raw`` against ``model_cls`` honoring the tier contract.
+
+    Parameters
+    ----------
+    model_cls
+        A :class:`PermissiveModel` or :class:`StrictModel` subclass.
+    raw
+        The JSON-decoded payload. For permissive parsing non-mapping
+        input is treated as an empty mapping with drift logged; strict
+        parsing raises :class:`RestgdfResponseError` unchanged.
+    context
+        Operator-visible identifier (URL, helper name) surfaced on any
+        :class:`RestgdfResponseError` raised by strict parsing.
+    """
+    is_strict = issubclass(model_cls, StrictModel)
+    if is_strict:
+        try:
+            instance: _M = model_cls.model_validate(raw)
+            return instance
+        except ValidationError as exc:
+            raise RestgdfResponseError(
+                f"{model_cls.__name__} validation failed: {exc.errors()!r}",
+                model_name=model_cls.__name__,
+                context=context,
+                raw=raw,
+            ) from exc
+
+    cleaned: dict[str, Any] = dict(raw) if isinstance(raw, dict) else {}
+    if not isinstance(raw, dict):
+        _log_drift(
+            model_name=model_cls.__name__,
+            path="<root>",
+            kind="not_a_mapping",
+            sample=raw,
+            level=logging.WARNING,
+        )
+
+    try:
+        instance = model_cls.model_validate(cleaned)
+    except ValidationError as exc:
+        # Strip failing fields, log each as drift, and revalidate.
+        for error in exc.errors():
+            loc = error.get("loc", ())
+            if not loc:
+                continue
+            top = loc[0]
+            if not isinstance(top, str) or top not in cleaned:
+                continue
+            _log_drift(
+                model_name=model_cls.__name__,
+                path=".".join(str(p) for p in loc),
+                kind="bad_type",
+                sample=cleaned[top],
+                level=logging.DEBUG,
+            )
+            cleaned.pop(top, None)
+        instance = model_cls.model_validate(cleaned)
+
+    # Detect unknown extras (keys present in raw but not declared on model).
+    if isinstance(raw, dict):
+        known = _known_keys(model_cls)
+        for extra_key, extra_val in raw.items():
+            if extra_key in known:
+                continue
+            _log_drift(
+                model_name=model_cls.__name__,
+                path=extra_key,
+                kind="unknown_extra",
+                sample=extra_val,
+                level=logging.DEBUG,
+            )
+
+    result: _M = instance
+    return result
+
+
+__all__ = [
+    "PermissiveModel",
+    "StrictModel",
+    "_parse_response",
+    "reset_drift_cache",
+]

--- a/restgdf/_models/_errors.py
+++ b/restgdf/_models/_errors.py
@@ -1,0 +1,46 @@
+"""Typed runtime errors raised by validated ArcGIS response parsing.
+
+:class:`RestgdfResponseError` is the single exception type raised when a
+response fails strict-tier validation. Permissive (metadata/crawl) models
+never raise; they emit structured drift log records instead (see
+:mod:`restgdf._models._drift` in a later slice).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class RestgdfResponseError(ValueError):
+    """Raised when a strict-tier ArcGIS response fails validation.
+
+    Attributes
+    ----------
+    model_name
+        The pydantic model class name that rejected the payload (for example
+        ``"CountResponse"``).
+    context
+        A short identifier describing *where* the response came from
+        (for example the request URL or a helper name). Used by operators
+        triaging ArcGIS vendor variance.
+    raw
+        The raw JSON-decoded payload that failed validation. Kept on the
+        exception so callers can log or re-raise without re-reading the
+        response body.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        model_name: str,
+        context: str,
+        raw: Any,
+    ) -> None:
+        super().__init__(message)
+        self.model_name = model_name
+        self.context = context
+        self.raw = raw
+
+
+__all__ = ["RestgdfResponseError"]

--- a/restgdf/_models/_settings.py
+++ b/restgdf/_models/_settings.py
@@ -1,0 +1,212 @@
+"""Process-level runtime settings for restgdf.
+
+A single :class:`Settings` pydantic model centralizes every runtime knob
+(HTTP timeouts, user-agent, chunk size, token-session defaults, drift-logger
+level). The library does **not** depend on ``pydantic-settings`` — that
+package requires Python 3.10+ and restgdf supports 3.9. Instead,
+:meth:`Settings.from_env` reads ``os.environ`` (or a caller-supplied mapping,
+for tests) and safely coerces each value.
+
+Values are resolved lazily via :func:`get_settings`, which caches a single
+``Settings`` instance per process. Tests and long-lived processes that need
+to reconfigure at runtime call :func:`reset_settings_cache` to drop the
+cached instance; the next :func:`get_settings` call re-reads the environment.
+
+This module only provides the infrastructure. Consumer migration (wiring
+``get_settings()`` into the HTTP helpers and token session) happens in
+later slices so it does not conflict with parallel work.
+"""
+
+from __future__ import annotations
+
+import functools
+import os
+from collections.abc import Mapping
+from typing import Any, Callable
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+from restgdf._models._errors import RestgdfResponseError
+
+
+def _default_user_agent() -> str:
+    """Return ``"restgdf/<version>"`` without forcing ``restgdf`` at import."""
+    from restgdf import __version__
+
+    return f"restgdf/{__version__}"
+
+
+_VALID_LOG_LEVELS = frozenset(
+    {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"},
+)
+
+
+class Settings(BaseModel):
+    """Validated runtime configuration for restgdf.
+
+    The model is **frozen**: treat a ``Settings`` instance as immutable. To
+    change runtime configuration, mutate the environment (or pass an explicit
+    mapping), then call :func:`reset_settings_cache` and re-fetch via
+    :func:`get_settings`.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
+
+    chunk_size: int = Field(
+        default=100,
+        gt=0,
+        description=(
+            "Default batch size for object-id chunking in feature queries. "
+            "ArcGIS services advertise their own ``maxRecordCount``; this "
+            "value is the library-level fallback."
+        ),
+    )
+    timeout_seconds: float = Field(
+        default=30.0,
+        gt=0,
+        description="Default HTTP request timeout (seconds).",
+    )
+    user_agent: str = Field(
+        default_factory=_default_user_agent,
+        min_length=1,
+        description="User-Agent header sent on ArcGIS REST requests.",
+    )
+    log_level: str = Field(
+        default="WARNING",
+        description=(
+            "Log level applied to the ``restgdf.schema_drift`` logger when "
+            "consumers opt in."
+        ),
+    )
+    token_url: str = Field(
+        default="https://www.arcgis.com/sharing/rest/generateToken",
+        description="Default ArcGIS ``generateToken`` endpoint.",
+    )
+    refresh_threshold_seconds: int = Field(
+        default=60,
+        ge=0,
+        description=(
+            "Default token-refresh threshold for "
+            ":class:`~restgdf.utils.token.ArcGISTokenSession`."
+        ),
+    )
+    default_headers_json: str | None = Field(
+        default=None,
+        description=(
+            "Optional JSON-encoded dict merged into default request "
+            "headers. Consumers parse this string at the HTTP boundary."
+        ),
+    )
+
+    @field_validator("log_level")
+    @classmethod
+    def _normalize_log_level(cls, value: str) -> str:
+        upper = value.upper()
+        if upper not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                f"log_level must be one of {sorted(_VALID_LOG_LEVELS)!r}",
+            )
+        return upper
+
+    @field_validator("token_url")
+    @classmethod
+    def _check_token_url_scheme(cls, value: str) -> str:
+        if not value.startswith(("http://", "https://")):
+            raise ValueError(
+                "token_url must start with 'http://' or 'https://'",
+            )
+        return value
+
+    @classmethod
+    def from_env(
+        cls,
+        env: Mapping[str, str] | None = None,
+    ) -> Settings:
+        """Build :class:`Settings` from environment variables.
+
+        Parameters
+        ----------
+        env
+            Mapping of env-var name to value. Defaults to ``os.environ``.
+            Pass an explicit dict (including ``{}``) to bypass the real
+            environment — primarily useful for tests.
+
+        Raises
+        ------
+        RestgdfResponseError
+            If any ``RESTGDF_*`` variable contains a malformed value (bad
+            cast or failed pydantic validation). The original exception is
+            chained via ``__cause__``.
+        """
+        source: Mapping[str, str] = os.environ if env is None else env
+        kwargs: dict[str, Any] = {}
+
+        def _coerce(
+            env_key: str,
+            field_name: str,
+            caster: Callable[[str], Any],
+        ) -> None:
+            raw = source.get(env_key)
+            if raw is None:
+                return
+            try:
+                kwargs[field_name] = caster(raw)
+            except (TypeError, ValueError) as exc:
+                raise RestgdfResponseError(
+                    f"invalid value for {env_key}: {raw!r} ({exc})",
+                    model_name=cls.__name__,
+                    context=env_key,
+                    raw=raw,
+                ) from exc
+
+        _coerce("RESTGDF_CHUNK_SIZE", "chunk_size", int)
+        _coerce("RESTGDF_TIMEOUT_SECONDS", "timeout_seconds", float)
+        _coerce("RESTGDF_REFRESH_THRESHOLD", "refresh_threshold_seconds", int)
+
+        for env_key, field_name in (
+            ("RESTGDF_USER_AGENT", "user_agent"),
+            ("RESTGDF_LOG_LEVEL", "log_level"),
+            ("RESTGDF_TOKEN_URL", "token_url"),
+            ("RESTGDF_DEFAULT_HEADERS_JSON", "default_headers_json"),
+        ):
+            raw = source.get(env_key)
+            if raw is not None:
+                kwargs[field_name] = raw
+
+        try:
+            return cls(**kwargs)
+        except ValidationError as exc:
+            raise RestgdfResponseError(
+                f"Settings validation failed: {exc.errors()!r}",
+                model_name=cls.__name__,
+                context="Settings.from_env",
+                raw=dict(kwargs),
+            ) from exc
+
+
+@functools.lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    """Return the process-wide cached :class:`Settings` instance."""
+    return Settings.from_env()
+
+
+def reset_settings_cache() -> None:
+    """Clear the :func:`get_settings` cache.
+
+    Useful for tests (force a re-read of ``os.environ``) and for
+    long-running processes that change configuration at runtime.
+    """
+    get_settings.cache_clear()
+
+
+__all__ = [
+    "Settings",
+    "get_settings",
+    "reset_settings_cache",
+]

--- a/restgdf/_models/crawl.py
+++ b/restgdf/_models/crawl.py
@@ -1,0 +1,92 @@
+"""S-4: Pydantic models for :func:`restgdf.utils.crawl.safe_crawl` output.
+
+``safe_crawl`` aggregates results of a directory crawl and, unlike
+``fetch_all_data``, never short-circuits on the first failure. Its return
+value is a :class:`CrawlReport` containing:
+
+* :attr:`CrawlReport.services` — a list of :class:`CrawlServiceEntry`
+  (one per successfully-discovered service).
+* :attr:`CrawlReport.errors` — a list of :class:`CrawlError` capturing
+  every recoverable failure, tagged by ``stage``.
+* :attr:`CrawlReport.metadata` — the parsed root
+  :class:`~restgdf._models.responses.LayerMetadata` (absent when the root
+  ``get_metadata`` call itself failed).
+
+All three models are :class:`~restgdf._models._drift.PermissiveModel`
+subclasses: ArcGIS servers may emit extra keys at any of these levels,
+and missing fields must never raise. :class:`CrawlError` declares
+``arbitrary_types_allowed=True`` so that the original
+:class:`BaseException` that caused the failure can be preserved under
+``exception`` for callers that want to re-raise; the default
+:meth:`~pydantic.BaseModel.model_dump` output excludes it so the report
+stays JSON-serializable.
+"""
+
+from __future__ import annotations
+
+
+from pydantic import ConfigDict, Field
+
+from restgdf._models._drift import PermissiveModel
+from restgdf._models.responses import LayerMetadata
+
+
+class CrawlError(PermissiveModel):
+    """A single failure captured during :func:`safe_crawl`.
+
+    ``stage`` identifies where the failure occurred. Standard stages
+    emitted by ``safe_crawl`` are:
+
+    * ``"base_metadata"`` — the root ``get_metadata`` call failed.
+    * ``"folder_metadata"`` — a per-folder ``get_metadata`` call failed.
+    * ``"service_metadata"`` — a per-service ``service_metadata`` call
+      failed.
+
+    ``exception`` preserves the original :class:`BaseException` so
+    callers can re-raise; it is excluded from the default
+    :meth:`~pydantic.BaseModel.model_dump` output for JSON safety.
+    """
+
+    model_config = ConfigDict(
+        extra="allow",
+        populate_by_name=True,
+        arbitrary_types_allowed=True,
+    )
+
+    stage: str | None = None
+    url: str | None = None
+    message: str | None = None
+    exception: BaseException | None = Field(default=None, exclude=True)
+
+
+class CrawlServiceEntry(PermissiveModel):
+    """A service entry in :attr:`CrawlReport.services`.
+
+    ``metadata`` is the :class:`~restgdf._models.responses.LayerMetadata`
+    returned by ``service_metadata`` for this service. It is ``None``
+    when the ``service_metadata`` call failed; in that case a
+    corresponding :class:`CrawlError` is recorded in
+    :attr:`CrawlReport.errors`.
+    """
+
+    name: str | None = None
+    url: str | None = None
+    type: str | None = None
+    metadata: LayerMetadata | None = None
+
+
+class CrawlReport(PermissiveModel):
+    """Aggregated result of a directory crawl.
+
+    Unlike the legacy ``fetch_all_data`` return shape (which
+    short-circuits to ``{"error": exc}`` on the first failure),
+    :class:`CrawlReport` always returns partial successes alongside
+    captured errors.
+    """
+
+    services: list[CrawlServiceEntry] = Field(default_factory=list)
+    errors: list[CrawlError] = Field(default_factory=list)
+    metadata: LayerMetadata | None = None
+
+
+__all__ = ["CrawlError", "CrawlReport", "CrawlServiceEntry"]

--- a/restgdf/_models/credentials.py
+++ b/restgdf/_models/credentials.py
@@ -1,0 +1,73 @@
+"""Credentials and token-session configuration models.
+
+Two pydantic models live here:
+
+* :class:`AGOLUserPass` — ArcGIS Online / Enterprise username + password
+  credentials. The password field is a :class:`pydantic.SecretStr` so it
+  is redacted from ``str()`` / ``repr()`` / logs; the literal value is
+  available via ``creds.password.get_secret_value()`` and is only
+  dereferenced at the HTTP-POST boundary in
+  :mod:`restgdf.utils.token`.
+
+* :class:`TokenSessionConfig` — validated configuration for
+  :class:`restgdf.utils.token.ArcGISTokenSession`. Centralizes the
+  ``token_url``/``refresh_threshold``/``verify_ssl`` knobs so validation
+  logic is not scattered across the dataclass.
+
+Both models are ``StrictModel`` subclasses — invalid config is an
+operator-visible bug, not schema drift.
+"""
+
+from __future__ import annotations
+
+
+from pydantic import Field, SecretStr, field_validator
+
+from restgdf._models._drift import StrictModel
+
+
+class AGOLUserPass(StrictModel):
+    """ArcGIS Online / Enterprise credentials used to mint tokens.
+
+    ``password`` is stored as :class:`pydantic.SecretStr`. Call
+    ``creds.password.get_secret_value()`` only at the HTTP-POST
+    boundary; never store or log the unwrapped value.
+    """
+
+    username: str = Field(..., min_length=1)
+    password: SecretStr
+    referer: str | None = None
+    expiration: int = 60  # minutes; ArcGIS ``generateToken`` default
+
+
+class TokenSessionConfig(StrictModel):
+    """Validated configuration for :class:`ArcGISTokenSession`.
+
+    ``token_url`` is intentionally a plain :class:`str` with a custom
+    validator rather than :class:`pydantic.AnyHttpUrl`. ArcGIS Enterprise
+    deployments commonly run plain HTTP on internal networks, and
+    ``AnyHttpUrl`` normalizes/rejects real-world URLs (for example it
+    appends trailing slashes and may reject edge cases). Accepting any
+    ``http://`` or ``https://`` string matches the behavior ArcGIS
+    clients need.
+    """
+
+    token_url: str
+    credentials: AGOLUserPass
+    refresh_threshold_seconds: int = 60
+    verify_ssl: bool = True
+
+    @field_validator("token_url")
+    @classmethod
+    def _check_token_url_scheme(cls, value: str) -> str:
+        if not isinstance(value, str) or not value.startswith(
+            ("http://", "https://"),
+        ):
+            raise ValueError(
+                "token_url must start with 'http://' or 'https://' "
+                "(ArcGIS Enterprise frequently uses http on internal networks)",
+            )
+        return value
+
+
+__all__ = ["AGOLUserPass", "TokenSessionConfig"]

--- a/restgdf/_models/responses.py
+++ b/restgdf/_models/responses.py
@@ -1,0 +1,240 @@
+"""Pydantic response-envelope models.
+
+Runtime-validated ArcGIS payloads consumed by restgdf, split into two
+tiers by design (see :mod:`restgdf._models._drift`):
+
+* Permissive: :class:`FieldSpec`, :class:`ErrorInfo`, :class:`Feature`,
+  :class:`LayerMetadata`, :class:`ServiceInfo`.
+* Strict: :class:`ErrorResponse`.
+
+Subsequent slices (query envelopes, crawl, credentials) add more models
+alongside these in this module.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import AliasChoices, Field, field_validator
+
+from restgdf._models._drift import PermissiveModel, StrictModel
+
+
+class FieldSpec(PermissiveModel):
+    """A field descriptor entry in a layer's ``fields`` list.
+
+    Real ArcGIS servers emit an open-ended set of keys here
+    (``sqlType``, ``defaultValue``, ``modelName``, ...). Permissive tier
+    preserves them via ``extra="allow"`` while declaring the handful of
+    keys restgdf actually consumes.
+    """
+
+    name: str | None = None
+    type: str | None = None
+    alias: str | None = None
+    length: int | None = None
+    domain: dict | None = None
+    nullable: bool | None = None
+    editable: bool | None = None
+
+
+class ErrorInfo(PermissiveModel):
+    """Inner error payload: ``{"code": int, "message": str, ...}``.
+
+    ArcGIS error payloads routinely carry diagnostic extras
+    (``messageCode``, ``errorCode``, ``details``) that restgdf does not
+    need but should not strip away.
+    """
+
+    code: int | None = None
+    message: str | None = None
+    details: list[str] | None = None
+
+
+class ErrorResponse(StrictModel):
+    """Top-level JSON error envelope: ``{"error": {...}}``.
+
+    Strict tier: callers branching on ``isinstance(obj, ErrorResponse)``
+    need the ``error`` key to actually be present. Missing-key drift on
+    this envelope indicates a protocol-level bug, not vendor variance.
+    """
+
+    error: ErrorInfo = Field(...)
+
+
+class Feature(PermissiveModel):
+    """A single feature in :attr:`FeaturesResponse.features`.
+
+    ``attributes`` is declared as a dict but not typed further — ArcGIS
+    layer schemas are dynamic. ``geometry`` is optional because non-
+    spatial tables and ``returnGeometry=false`` queries omit it.
+    """
+
+    attributes: dict[str, Any] | None = None
+    geometry: dict[str, Any] | None = None
+
+
+class LayerMetadata(PermissiveModel):
+    """Polymorphic ArcGIS REST metadata envelope.
+
+    The same endpoint family (``GET <url>?f=json``) returns per-layer
+    metadata (``name``, ``fields``, ``maxRecordCount``, ...), service
+    roots (``services``, ``folders``), sub-layer descriptors (``id``),
+    and restgdf-enriched payloads (``url``, ``feature_count``). All
+    variants parse into this single permissive model; missing fields
+    default to ``None`` rather than raise.
+
+    Field aliases accept either camelCase (native ArcGIS) or snake_case
+    (Python-native) input via :class:`~pydantic.AliasChoices`, and
+    ``model_dump(by_alias=True)`` round-trips back to camelCase so
+    downstream serialization stays ArcGIS-compatible.
+    """
+
+    name: str | None = None
+    id: int | None = None
+    type: str | None = None
+    fields: list[FieldSpec] | None = None
+    max_record_count: int | None = Field(
+        default=None,
+        alias="maxRecordCount",
+        validation_alias=AliasChoices("maxRecordCount", "max_record_count"),
+    )
+    supports_pagination: bool | None = Field(
+        default=None,
+        alias="supportsPagination",
+        validation_alias=AliasChoices("supportsPagination", "supports_pagination"),
+    )
+    advanced_query_capabilities: dict[str, Any] | None = Field(
+        default=None,
+        alias="advancedQueryCapabilities",
+        validation_alias=AliasChoices(
+            "advancedQueryCapabilities",
+            "advanced_query_capabilities",
+        ),
+    )
+    layers: list[LayerMetadata] | None = None
+    services: list[dict[str, Any]] | None = None
+    folders: list[str] | None = None
+    url: str | None = None
+    feature_count: int | None = None
+
+
+class ServiceInfo(PermissiveModel):
+    """Root ``GET <services_root>?f=json`` envelope.
+
+    A narrower permissive view over the subset of keys a services-root
+    crawl consumes (``services`` and ``folders``). Unlike
+    :class:`LayerMetadata`, this model does not enrich nested ``services``
+    entries into typed objects — the crawl report keeps them as raw
+    dicts so per-service merge keys (``name``, ``type``) survive
+    unchanged.
+    """
+
+    services: list[dict[str, Any]] | None = None
+    folders: list[str] | None = None
+    layers: list[LayerMetadata] | None = None
+    url: str | None = None
+
+
+LayerMetadata.model_rebuild()
+
+
+class CountResponse(StrictModel):
+    """Envelope for ``?returnCountOnly=true`` query results.
+
+    Strict tier: ArcGIS *always* returns ``count`` for this query shape,
+    so a missing/ill-typed key signals a protocol-level incident (for
+    example an HTML error page bodied as JSON). :func:`_parse_response`
+    surfaces those as :class:`RestgdfResponseError`.
+    """
+
+    count: int = Field(...)
+
+
+class ObjectIdsResponse(StrictModel):
+    """Envelope for ``?returnIdsOnly=true`` query results.
+
+    Strict tier. The response is operation-critical: chunked pagination
+    in :mod:`restgdf.utils.getgdf` requires both the OID field name and
+    the full id list. A zero-row match produces
+    ``{"objectIdFieldName": "OBJECTID", "objectIds": null}`` in the
+    wild; the ``object_ids`` validator below coerces that ``None`` to an
+    empty list so consumers can unconditionally iterate.
+    """
+
+    object_id_field_name: str = Field(
+        ...,
+        alias="objectIdFieldName",
+        validation_alias=AliasChoices("objectIdFieldName", "object_id_field_name"),
+    )
+    object_ids: list[int] = Field(
+        default_factory=list,
+        alias="objectIds",
+        validation_alias=AliasChoices("objectIds", "object_ids"),
+    )
+
+    @field_validator("object_ids", mode="before")
+    @classmethod
+    def _coerce_null_to_empty(cls, value: Any) -> Any:
+        if value is None:
+            return []
+        return value
+
+
+class FeaturesResponse(PermissiveModel):
+    """Envelope for ``?f=json`` feature queries.
+
+    Permissive tier: only the envelope keys restgdf consumes are
+    declared. ``features`` is kept as a ``list[dict]`` rather than
+    ``list[Feature]`` on purpose — validating every feature of a large
+    batch with pydantic would be expensive and returns no value to the
+    downstream GeoPandas reader, which consumes raw ArcGIS JSON. Callers
+    that need typed features can validate them explicitly via
+    :class:`Feature`.
+    """
+
+    object_id_field_name: str | None = Field(
+        default=None,
+        alias="objectIdFieldName",
+        validation_alias=AliasChoices("objectIdFieldName", "object_id_field_name"),
+    )
+    features: list[dict[str, Any]] = Field(default_factory=list)
+    exceeded_transfer_limit: bool | None = Field(
+        default=None,
+        alias="exceededTransferLimit",
+        validation_alias=AliasChoices(
+            "exceededTransferLimit",
+            "exceeded_transfer_limit",
+        ),
+    )
+
+
+class TokenResponse(StrictModel):
+    """Envelope for ArcGIS ``/generateToken`` responses.
+
+    Strict tier: token refresh is operation-critical; a missing
+    ``token`` or ``expires`` key means a token cannot be used and any
+    downstream request will fail authentication. ArcGIS also returns
+    error envelopes through this same endpoint (``{"error": {...}}``);
+    those fail validation here and surface as
+    :class:`RestgdfResponseError`, leaving the original payload on
+    ``exc.raw`` for operator triage.
+    """
+
+    token: str = Field(...)
+    expires: int = Field(...)
+    ssl: bool | None = None
+
+
+__all__ = [
+    "CountResponse",
+    "ErrorInfo",
+    "ErrorResponse",
+    "Feature",
+    "FeaturesResponse",
+    "FieldSpec",
+    "LayerMetadata",
+    "ObjectIdsResponse",
+    "ServiceInfo",
+    "TokenResponse",
+]

--- a/restgdf/_types.py
+++ b/restgdf/_types.py
@@ -1,210 +1,76 @@
-"""Typed response contracts for ArcGIS REST payloads consumed by restgdf.
+"""Deprecated typing aliases for the pre-v2.0.0 TypedDict public surface.
 
-These :class:`~typing.TypedDict` definitions describe the shapes returned
-by ArcGIS REST endpoints and consumed by the parsers in
-:mod:`restgdf.utils._metadata`, :mod:`restgdf.utils._query`, and the
-orchestrators in :mod:`restgdf.utils.getinfo`.
+.. deprecated:: 2.0.0
+   The :class:`~typing.TypedDict` definitions that used to live here are
+   replaced by the runtime-validated pydantic models in
+   :mod:`restgdf._models.responses` and :mod:`restgdf._models.crawl`.
+   Importing any name from ``restgdf._types`` emits a
+   :class:`DeprecationWarning` and returns the corresponding
+   :class:`pydantic.BaseModel`.
 
-Design notes
-------------
-* ArcGIS responses are loosely-shaped JSON: many keys are optional and
-  vary by layer/server version. To match reality without losing useful
-  static guarantees, each TypedDict splits into a ``*Required`` base with
-  keys the parsers will index unconditionally, and a subclass
-  (``total=False``) that adds known-optional keys the parsers touch via
-  ``.get(...)``.
-* TypedDicts are ordinary :class:`dict` instances at runtime. Parsers
-  keep using ``mapping[key]`` / ``mapping.get(key)`` access; the types
-  are purely advisory for static analysis.
-* ``from __future__ import annotations`` is REQUIRED here for Python 3.9
-  runtime compatibility with PEP 604 / 585 syntax used in other modules.
+   Migration:
+
+   ===========================================  =========================================================
+   Legacy ``restgdf._types`` name               v2.x replacement
+   ===========================================  =========================================================
+   ``FieldSpec``                                :class:`restgdf.FieldSpec`
+   ``LayerMetadata``                            :class:`restgdf.LayerMetadata`
+   ``ServiceInfo``                              :class:`restgdf.ServiceInfo`
+   ``CountResponse``                            :class:`restgdf.CountResponse`
+   ``ObjectIdsResponse``                        :class:`restgdf.ObjectIdsResponse`
+   ``Feature``                                  :class:`restgdf.Feature`
+   ``FeaturesResponse``                         :class:`restgdf.FeaturesResponse`
+   ``ErrorInfo``                                :class:`restgdf.ErrorInfo`
+   ``ErrorResponse``                            :class:`restgdf.ErrorResponse`
+   ``CrawlError``                               :class:`restgdf.CrawlError`
+   ``CrawlServiceEntry``                        :class:`restgdf.CrawlServiceEntry`
+   ``CrawlReport``                              :class:`restgdf.CrawlReport`
+   ===========================================  =========================================================
+
+   This shim will be removed in 3.x.
 """
 
 from __future__ import annotations
 
-from typing import TypedDict
+import importlib
+import warnings
+from typing import Any
+
+# Map legacy TypedDict name -> (submodule, attribute) in the new public API.
+# We import these lazily in __getattr__ so that accessing any public name
+# triggers the module-level DeprecationWarning exactly once per access and
+# so that the names do not live in this module's __dict__ (which would
+# bypass __getattr__).
+_REPLACEMENTS: dict[str, tuple[str, str]] = {
+    "FieldSpec": ("restgdf._models.responses", "FieldSpec"),
+    "LayerMetadata": ("restgdf._models.responses", "LayerMetadata"),
+    "ServiceInfo": ("restgdf._models.responses", "ServiceInfo"),
+    "CountResponse": ("restgdf._models.responses", "CountResponse"),
+    "ObjectIdsResponse": ("restgdf._models.responses", "ObjectIdsResponse"),
+    "Feature": ("restgdf._models.responses", "Feature"),
+    "FeaturesResponse": ("restgdf._models.responses", "FeaturesResponse"),
+    "ErrorInfo": ("restgdf._models.responses", "ErrorInfo"),
+    "ErrorResponse": ("restgdf._models.responses", "ErrorResponse"),
+    "CrawlError": ("restgdf._models.crawl", "CrawlError"),
+    "CrawlServiceEntry": ("restgdf._models.crawl", "CrawlServiceEntry"),
+    "CrawlReport": ("restgdf._models.crawl", "CrawlReport"),
+}
 
 
-class _FieldSpecRequired(TypedDict):
-    name: str
-    type: str
+def __getattr__(name: str) -> Any:
+    if name in _REPLACEMENTS:
+        warnings.warn(
+            (
+                f"restgdf._types.{name} is deprecated; "
+                f"import {name} from restgdf (pydantic model) instead. "
+                "restgdf._types will be removed in 3.x."
+            ),
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        module_name, attr = _REPLACEMENTS[name]
+        return getattr(importlib.import_module(module_name), attr)
+    raise AttributeError(f"module 'restgdf._types' has no attribute {name!r}")
 
 
-class FieldSpec(_FieldSpecRequired, total=False):
-    """A field descriptor in a layer's ``fields`` list."""
-
-    alias: str
-    length: int
-    domain: dict | None
-    nullable: bool
-    editable: bool
-
-
-class _LayerMetadataRequired(TypedDict):
-    """Keys parsers index directly.
-
-    In practice ArcGIS may omit any key on an error response; parsers
-    that require a key handle the missing case explicitly (``get_name``
-    raises ``FIELDDOESNOTEXIST``). Keeping the required base empty keeps
-    the type permissive enough for polymorphic ArcGIS endpoints (service
-    root, folder root, layer root) while still documenting common keys
-    in the subclass below.
-    """
-
-
-class LayerMetadata(_LayerMetadataRequired, total=False):
-    """JSON payload returned by ``GET <layer_url>?f=json`` (or service root).
-
-    ArcGIS REST endpoints are polymorphic: the same endpoint family may
-    return per-layer metadata, service-level summaries (with ``services``
-    and ``folders``), or sub-layer descriptors (with ``id``). All the
-    optional keys below model those variants in a single shape so that
-    parsers and orchestrators can accept any ArcGIS JSON response.
-    """
-
-    name: str
-    id: int
-    type: str
-    fields: list[FieldSpec]
-    maxRecordCount: int
-    supportsPagination: bool
-    advancedQueryCapabilities: dict
-    layers: list[LayerMetadata]
-    services: list[dict]
-    folders: list[str]
-    url: str
-    feature_count: int | None
-
-
-class _ServiceInfoRequired(TypedDict):
-    pass
-
-
-class ServiceInfo(_ServiceInfoRequired, total=False):
-    """JSON payload returned by ``GET <services_root>?f=json``."""
-
-    services: list[dict]
-    folders: list[str]
-    layers: list[LayerMetadata]
-    url: str
-
-
-class CountResponse(TypedDict):
-    """JSON payload returned by ``?returnCountOnly=true`` queries."""
-
-    count: int
-
-
-class ObjectIdsResponse(TypedDict):
-    """JSON payload returned by ``?returnIdsOnly=true`` queries."""
-
-    objectIdFieldName: str
-    objectIds: list[int]
-
-
-class _FeatureRequired(TypedDict):
-    attributes: dict
-
-
-class Feature(_FeatureRequired, total=False):
-    """A single feature in a ``FeaturesResponse.features`` list."""
-
-    geometry: dict
-
-
-class FeaturesResponse(TypedDict, total=False):
-    """JSON payload for ``?f=json`` feature queries."""
-
-    features: list[Feature]
-    fields: list[FieldSpec]
-    objectIdFieldName: str
-
-
-class _ErrorInfoRequired(TypedDict):
-    code: int
-    message: str
-
-
-class ErrorInfo(_ErrorInfoRequired, total=False):
-    details: list[str]
-
-
-class ErrorResponse(TypedDict):
-    """JSON payload returned by ArcGIS when a request fails.
-
-    Note: not every ArcGIS error surfaces through this shape; some are
-    raised as aiohttp exceptions. Consumers that want to detect the JSON
-    error envelope should test ``"error" in response``.
-    """
-
-    error: ErrorInfo
-
-
-class _CrawlErrorRequired(TypedDict):
-    stage: str
-    url: str
-    message: str
-
-
-class CrawlError(_CrawlErrorRequired, total=False):
-    """A single failure captured during :func:`restgdf.utils.crawl.safe_crawl`.
-
-    ``stage`` identifies where the failure occurred: ``"base_metadata"``
-    for the root ``get_metadata`` call, ``"folder_metadata"`` for a
-    per-folder ``get_metadata`` call, and ``"service_metadata"`` for a
-    per-service ``service_metadata`` call. ``url`` is the URL whose
-    request failed and ``message`` is ``str(exception)`` so the report
-    stays JSON-serializable. The original exception is preserved under
-    the optional ``exception`` key for callers that want to re-raise.
-    """
-
-    exception: BaseException
-
-
-class _CrawlServiceEntryRequired(TypedDict):
-    name: str
-    url: str
-
-
-class CrawlServiceEntry(_CrawlServiceEntryRequired, total=False):
-    """A service entry in :attr:`CrawlReport.services`.
-
-    ``metadata`` is the :class:`LayerMetadata` returned by
-    ``service_metadata`` for this service. It is absent when the
-    ``service_metadata`` call failed; in that case a corresponding
-    :class:`CrawlError` is recorded in :attr:`CrawlReport.errors`.
-    """
-
-    metadata: LayerMetadata
-
-
-class _CrawlReportRequired(TypedDict):
-    services: list[CrawlServiceEntry]
-    errors: list[CrawlError]
-
-
-class CrawlReport(_CrawlReportRequired, total=False):
-    """Aggregated result of a directory crawl.
-
-    Unlike the legacy ``fetch_all_data`` return shape (which short-circuits
-    to ``{"error": exc}`` on the first failure), :class:`CrawlReport`
-    always returns partial successes alongside captured errors.
-    """
-
-    metadata: LayerMetadata
-
-
-__all__ = [
-    "CountResponse",
-    "CrawlError",
-    "CrawlReport",
-    "CrawlServiceEntry",
-    "ErrorInfo",
-    "ErrorResponse",
-    "Feature",
-    "FeaturesResponse",
-    "FieldSpec",
-    "LayerMetadata",
-    "ObjectIdsResponse",
-    "ServiceInfo",
-]
+__all__ = sorted(_REPLACEMENTS)

--- a/restgdf/compat.py
+++ b/restgdf/compat.py
@@ -1,0 +1,63 @@
+"""Compatibility helpers for the 1.x → 2.x migration.
+
+Downstream code that indexed the legacy dict-based public surface (for
+example ``metadata["name"]``, ``crawl_result["services"]``) needs a
+short-term way to keep working during its own upgrade window. These
+helpers convert the 2.x pydantic models back into plain Python
+structures on demand.
+
+They are **migration aids**, not the primary API — prefer direct
+attribute access (``metadata.name``) and ``model_dump()`` in new code.
+These helpers will stay available for the 2.x series but may be removed
+in 3.x.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+__all__ = ["as_dict", "as_json_dict"]
+
+
+def as_dict(obj: Any) -> Any:
+    """Return a plain Python dict view of a restgdf pydantic model.
+
+    If ``obj`` is a :class:`pydantic.BaseModel` instance, returns
+    ``obj.model_dump(mode="python", by_alias=False)`` — a dict keyed by
+    the model's Python (snake_case) field names, with nested models
+    also recursively dumped.
+
+    If ``obj`` is anything else (already-a-dict, ``None``, primitive,
+    list), it is returned unchanged. This lets migration code wrap
+    heterogeneous values uniformly::
+
+        for entry in report.services:
+            row = as_dict(entry)   # dict whether entry is model or already dict
+            save(row["name"], row.get("url"))
+
+    This helper is intentionally conservative: it does not recurse into
+    containers of models and does not coerce ``by_alias=True``. Callers
+    that need the ArcGIS-native camelCase round-trip should call
+    :meth:`~pydantic.BaseModel.model_dump` explicitly.
+    """
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(mode="python", by_alias=False)
+    return obj
+
+
+def as_json_dict(obj: Any) -> Any:
+    """Return a JSON-safe dict view of a restgdf pydantic model.
+
+    Like :func:`as_dict`, but uses ``model_dump(mode="json")`` so every
+    nested value is a JSON-serializable primitive
+    (``SecretStr`` → ``"**********"`` placeholder, ``datetime`` → ISO
+    string, etc.). Handy for structured logging of a model without
+    carrying unserializable objects into the log record.
+
+    Non-model values are returned unchanged.
+    """
+    if isinstance(obj, BaseModel):
+        return obj.model_dump(mode="json", by_alias=False)
+    return obj

--- a/restgdf/directory/directory.py
+++ b/restgdf/directory/directory.py
@@ -1,13 +1,35 @@
 import aiohttp
 from typing import Optional, Union
 
+from restgdf._models.crawl import CrawlReport, CrawlServiceEntry
+from restgdf._models.responses import LayerMetadata
 from restgdf.utils.getinfo import get_metadata
-from restgdf.utils.crawl import fetch_all_data
+from restgdf.utils.crawl import fetch_all_data, safe_crawl  # noqa: F401
 from restgdf.utils.token import ArcGISTokenSession
 
 
 class Directory:
-    """A class for interacting with ArcGIS Server directories."""
+    """A class for interacting with ArcGIS Server directories.
+
+    Attributes
+    ----------
+    metadata : Optional[restgdf.LayerMetadata]
+        Pydantic-validated root metadata populated by :meth:`prep`.
+        ``None`` until ``prep`` (or :meth:`from_url`) has run.
+    services : Optional[list[restgdf.CrawlServiceEntry]]
+        Services discovered by the most recent :meth:`crawl` call.
+        Each entry carries ``name``, ``url``, ``type``, and a parsed
+        ``metadata`` (``LayerMetadata`` or ``None`` if that service's
+        metadata call failed).
+    services_with_feature_count : Optional[list[restgdf.CrawlServiceEntry]]
+        Same as ``services`` but populated with feature counts when
+        :meth:`crawl` was invoked with ``return_feature_count=True``.
+    report : Optional[restgdf.CrawlReport]
+        The full crawl report (services + per-stage errors + root
+        metadata) from the most recent :meth:`crawl` call. Use this
+        when you need to inspect failures that were silently captured
+        instead of raised.
+    """
 
     def __init__(
         self,
@@ -19,12 +41,16 @@ class Directory:
         self.url = url
         self.session = session
         self.token = token
-        self.services: Optional[list[dict]] = None
-        self.services_with_feature_count: Optional[list[dict]] = None
-        self.metadata: Optional[dict] = None
+        self.services: Optional[list[CrawlServiceEntry]] = None
+        self.services_with_feature_count: Optional[list[CrawlServiceEntry]] = None
+        self.metadata: Optional[LayerMetadata] = None
+        self.report: Optional[CrawlReport] = None
 
     async def prep(self):
-        self.metadata = await get_metadata(self.url, self.session, self.token)
+        raw = await get_metadata(self.url, self.session, self.token)
+        self.metadata = (
+            raw if isinstance(raw, LayerMetadata) else LayerMetadata.model_validate(raw)
+        )
 
     @classmethod
     async def from_url(cls, url: str, **kwargs) -> "Directory":
@@ -33,41 +59,49 @@ class Directory:
         await self.prep()
         return self
 
-    async def crawl(self, return_feature_count: bool = False) -> list[dict]:
+    async def crawl(
+        self,
+        return_feature_count: bool = False,
+    ) -> list[CrawlServiceEntry]:
         if return_feature_count:
             if self.services_with_feature_count is None:
-                all_data = await fetch_all_data(
+                report = await safe_crawl(
                     self.session,
                     self.url,
                     self.token,
                     return_feature_count=True,
                 )
-                self.services_with_feature_count = all_data["services"]
+                self.report = report
+                self.services_with_feature_count = report.services
             self.services = self.services_with_feature_count
             return self.services_with_feature_count
 
         if self.services is None:
-            all_data = await fetch_all_data(
+            report = await safe_crawl(
                 self.session,
                 self.url,
                 self.token,
                 return_feature_count=False,
             )
-            self.services = all_data["services"]
+            self.report = report
+            self.services = report.services
         return self.services
 
-    def filter_directory_layers(self, layer_type: str) -> list[dict]:
+    def filter_directory_layers(self, layer_type: str) -> list[LayerMetadata]:
         if self.services is None:
             raise ValueError("You must call .crawl() before filtering layers.")
-        return [
-            layer
-            for service in self.services
-            for layer in service.get("metadata", {}).get("layers", [])
-            if layer["type"] == layer_type
-        ]
+        matched: list[LayerMetadata] = []
+        for service in self.services:
+            service_metadata = service.metadata
+            if service_metadata is None:
+                continue
+            for layer in service_metadata.layers or []:
+                if layer.type == layer_type:
+                    matched.append(layer)
+        return matched
 
-    def feature_layers(self) -> list[dict]:
+    def feature_layers(self) -> list[LayerMetadata]:
         return self.filter_directory_layers("Feature Layer")
 
-    def rasters(self) -> list[dict]:
+    def rasters(self) -> list[LayerMetadata]:
         return self.filter_directory_layers("Raster Layer")

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -10,6 +10,7 @@ from aiohttp import ClientSession
 from geopandas import GeoDataFrame
 from pandas import DataFrame
 
+from restgdf._models.responses import LayerMetadata
 from restgdf.utils.getgdf import get_gdf, row_dict_generator
 from restgdf.utils.getinfo import (
     default_data,
@@ -52,7 +53,25 @@ from restgdf.utils.utils import where_var_in_list, ends_with_num
 
 
 class FeatureLayer:
-    """A class for interacting with ArcGIS FeatureLayers."""
+    """A class for interacting with an ArcGIS REST FeatureLayer.
+
+    Attributes
+    ----------
+    metadata : restgdf.LayerMetadata
+        Pydantic-validated layer metadata (name, fields, max record
+        count, advanced query capabilities, ...). Replaces the pre-2.0
+        raw ``dict``. Extra keys sent by the server are preserved via
+        ``extra="allow"`` and reachable through ``metadata.model_extra``.
+    name : str
+        Convenience alias for ``metadata.name``.
+    fields : tuple[str, ...]
+        Field names consumed by restgdf.
+    object_id_field : str
+        Resolved object-id field name (``"OBJECTID"`` when the server
+        omits it).
+    count : int
+        Feature count, validated via ``CountResponse`` at prep time.
+    """
 
     def __init__(
         self,
@@ -92,7 +111,7 @@ class FeatureLayer:
 
         self.gdf: GeoDataFrame | None = None
 
-        self.metadata: dict
+        self.metadata: LayerMetadata
         self.name: str
         self.fields: tuple[str, ...]
         self.fieldtypes: DataFrame
@@ -101,15 +120,15 @@ class FeatureLayer:
 
     async def prep(self):
         """Prepare the Rest object."""
-        self.metadata = await get_metadata(
+        raw = await get_metadata(
             self.url,
             self.session,
             token=self.kwargs["data"].get("token"),
         )
-        try:
-            if not self.metadata["type"] == "Feature Layer":
-                raise ValueError("The url must point to a FeatureLayer.")
-        except KeyError:
+        self.metadata = (
+            raw if isinstance(raw, LayerMetadata) else LayerMetadata.model_validate(raw)
+        )
+        if self.metadata.type != "Feature Layer":
             raise ValueError("The url must point to a FeatureLayer.")
         self.name = get_name(self.metadata)
         self.fields = get_fields(self.metadata)

--- a/restgdf/utils/_metadata.py
+++ b/restgdf/utils/_metadata.py
@@ -7,17 +7,35 @@ Private submodule; all public names are re-exported by
 from __future__ import annotations
 
 from re import IGNORECASE, compile
+from typing import Any, Union
+from collections.abc import Mapping
 
 from pandas import DataFrame
+from pydantic import BaseModel
 
-from restgdf._types import FieldSpec, LayerMetadata
+from restgdf._models.responses import FieldSpec, LayerMetadata
 from restgdf.utils._deprecations import deprecated_alias
 
 FIELDDOESNOTEXIST: IndexError = IndexError("Field does not exist")
 
+LayerMetadataLike = Union[LayerMetadata, Mapping[str, Any]]
 
-def supports_pagination(metadata: LayerMetadata) -> bool:
+
+def _as_dict(metadata: LayerMetadataLike) -> dict:
+    """Normalize a ``LayerMetadata`` model or raw mapping to a plain dict.
+
+    Extras from permissive-tier parsing are preserved so that case-insensitive
+    regex lookups on keys like ``Name`` or ``MaxRecordCount`` keep working
+    even when the input has already been validated into a pydantic model.
+    """
+    if isinstance(metadata, BaseModel):
+        return metadata.model_dump(by_alias=True, exclude_none=True)
+    return dict(metadata)
+
+
+def supports_pagination(metadata: LayerMetadataLike) -> bool:
     """Return whether the layer supports resultOffset/resultRecordCount pagination."""
+    metadata = _as_dict(metadata)
     advanced_query_capabilities = metadata.get("advancedQueryCapabilities") or {}
     if "supportsPagination" in advanced_query_capabilities:
         return advanced_query_capabilities["supportsPagination"]
@@ -26,8 +44,9 @@ def supports_pagination(metadata: LayerMetadata) -> bool:
     return True
 
 
-def get_object_id_field(metadata: LayerMetadata) -> str:
+def get_object_id_field(metadata: LayerMetadataLike) -> str:
     """Get the object id field name for a layer."""
+    metadata = _as_dict(metadata)
     oid_fields = [
         field["name"]
         for field in metadata.get("fields", [])
@@ -38,8 +57,9 @@ def get_object_id_field(metadata: LayerMetadata) -> str:
     return oid_fields[0]
 
 
-def get_max_record_count(metadata: LayerMetadata) -> int:
+def get_max_record_count(metadata: LayerMetadataLike) -> int:
     """Get the maximum record count for a layer."""
+    metadata = _as_dict(metadata)
     key_pattern = compile(
         r"max(imum)?(\s|_)?record(\s|_)?count$",
         flags=IGNORECASE,
@@ -47,32 +67,32 @@ def get_max_record_count(metadata: LayerMetadata) -> int:
     key_list = [key for key in metadata.keys() if key_pattern.match(key)]
     if len(key_list) != 1:
         raise FIELDDOESNOTEXIST
-    return metadata[key_list[0]]  # type: ignore[literal-required]
+    return metadata[key_list[0]]
 
 
-def get_name(metadata: LayerMetadata) -> str:
+def get_name(metadata: LayerMetadataLike) -> str:
     """Get the name of a layer."""
+    metadata = _as_dict(metadata)
     key_pattern = compile("name", flags=IGNORECASE)
     key_list = [key for key in metadata.keys() if key_pattern.match(key)]
     if len(key_list) != 1:
         raise FIELDDOESNOTEXIST
-    return metadata[key_list[0]]  # type: ignore[literal-required]
+    return metadata[key_list[0]]
 
 
-def get_fields(layer_metadata: LayerMetadata, types: bool = False):
+def get_fields(layer_metadata: LayerMetadataLike, types: bool = False):
     """Get the fields of a layer."""
+    layer_metadata = _as_dict(layer_metadata)
+    fields = layer_metadata.get("fields") or []
     if types:
-        return {
-            f["name"]: f["type"].replace("esriFieldType", "")
-            for f in layer_metadata["fields"]
-        }
-    else:
-        return [f["name"] for f in layer_metadata["fields"]]
+        return {f["name"]: f["type"].replace("esriFieldType", "") for f in fields}
+    return [f["name"] for f in fields]
 
 
-def get_fields_frame(layer_metadata: LayerMetadata) -> DataFrame:
+def get_fields_frame(layer_metadata: LayerMetadataLike) -> DataFrame:
     """Get the fields of a layer as a DataFrame."""
-    fields: list[FieldSpec] = layer_metadata["fields"]
+    layer_metadata = _as_dict(layer_metadata)
+    fields: list[FieldSpec] = layer_metadata.get("fields") or []
     return DataFrame(
         [(f["name"], f["type"].replace("esriFieldType", "")) for f in fields],
         columns=["name", "type"],

--- a/restgdf/utils/_query.py
+++ b/restgdf/utils/_query.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 from aiohttp import ClientSession
 
 from restgdf._client.request import build_conservative_query_data
-from restgdf._types import CountResponse, LayerMetadata, ObjectIdsResponse
+from restgdf._models._drift import _parse_response
+from restgdf._models.responses import (
+    CountResponse,
+    LayerMetadata,
+    ObjectIdsResponse,
+)
 from restgdf.utils._http import default_headers
 from restgdf.utils.token import ArcGISTokenSession
 
@@ -23,23 +28,28 @@ async def get_feature_count(
     session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> int:
-    """Get the feature count for a layer."""
+    """Get the feature count for a layer.
+
+    The JSON body is validated against :class:`CountResponse` (strict
+    tier). A missing/ill-typed ``count`` key raises
+    :class:`~restgdf._models.RestgdfResponseError` with the original
+    payload and request URL attached for operator triage.
+    """
     datadict = build_conservative_query_data(
         {"where": "1=1", "returnCountOnly": True, "f": "json"},
         kwargs.get("data"),
     )
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
+    query_url = f"{url}/query"
     response = await session.post(
-        f"{url}/query",
+        query_url,
         data=datadict,
         headers=default_headers(xkwargs.pop("headers", None)),
         **xkwargs,
     )
-    response_json: CountResponse = await response.json(content_type=None)
-    try:
-        return response_json["count"]
-    except KeyError as e:
-        raise e
+    response_json = await response.json(content_type=None)
+    envelope = _parse_response(CountResponse, response_json, context=query_url)
+    return envelope.count
 
 
 async def get_metadata(
@@ -47,12 +57,20 @@ async def get_metadata(
     session: ClientSession | ArcGISTokenSession,
     token: str | None = None,
 ) -> LayerMetadata:
-    """Get the JSON dict for a layer."""
+    """Get the parsed metadata model for a layer.
+
+    The JSON body is validated against :class:`LayerMetadata` (permissive
+    tier). Vendor-variance extras are preserved via ``extra="allow"``;
+    missing fields default to ``None`` rather than raise. Drift is logged
+    through :mod:`restgdf._models._drift` rather than returned to the
+    caller.
+    """
     data = {"f": "json"}
     if token is not None:
         data["token"] = token
     response = await session.get(url, params=data, headers=default_headers())
-    return await response.json(content_type=None)
+    raw = await response.json(content_type=None)
+    return _parse_response(LayerMetadata, raw, context=url)
 
 
 async def get_object_ids(
@@ -60,17 +78,26 @@ async def get_object_ids(
     session: ClientSession | ArcGISTokenSession,
     **kwargs,
 ) -> tuple[str, list[int]]:
-    """Get the object id field name and matching object ids for a layer query."""
+    """Get the object id field name and matching object ids for a layer query.
+
+    The JSON body is validated against :class:`ObjectIdsResponse` (strict
+    tier) so missing field names or non-list id payloads raise
+    :class:`~restgdf._models.RestgdfResponseError` before the caller can
+    misuse them. ArcGIS returns ``objectIds: null`` for zero-row
+    matches; the model coerces that to ``[]``.
+    """
     datadict = build_conservative_query_data(
         {"where": "1=1", "returnIdsOnly": True, "f": "json"},
         kwargs.get("data"),
     )
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
+    query_url = f"{url}/query"
     response = await session.post(
-        f"{url}/query",
+        query_url,
         data=datadict,
         headers=default_headers(xkwargs.pop("headers", None)),
         **xkwargs,
     )
-    response_json: ObjectIdsResponse = await response.json(content_type=None)
-    return response_json["objectIdFieldName"], response_json["objectIds"]
+    response_json = await response.json(content_type=None)
+    envelope = _parse_response(ObjectIdsResponse, response_json, context=query_url)
+    return envelope.object_id_field_name, envelope.object_ids

--- a/restgdf/utils/_stats.py
+++ b/restgdf/utils/_stats.py
@@ -10,6 +10,8 @@ from aiohttp import ClientSession
 from pandas import DataFrame, concat
 
 from restgdf._client.request import build_conservative_query_data
+from restgdf._models._drift import _parse_response
+from restgdf._models.responses import FeaturesResponse
 from restgdf.utils._deprecations import deprecated_alias
 from restgdf.utils._http import default_headers
 from restgdf.utils.token import ArcGISTokenSession
@@ -42,22 +44,24 @@ async def get_unique_values(
         headers=default_headers(xkwargs.pop("headers", None)),
         **xkwargs,
     )
-    metadata = await response.json(content_type=None)
+    raw = await response.json(content_type=None)
+    envelope = _parse_response(FeaturesResponse, raw, context=f"{url}/query")
+    features = envelope.features or []
 
     res_l: list | None = None
     res_df: DataFrame | None = None
 
     if isinstance(fields, str):
-        res_l = [x["attributes"][fields] for x in metadata["features"]]
+        res_l = [x["attributes"][fields] for x in features]
         if sortby and sortby == fields:
             res_l = sorted(res_l)
     elif len(fields) == 1:
-        res_l = [x["attributes"][fields[0]] for x in metadata["features"]]
+        res_l = [x["attributes"][fields[0]] for x in features]
         if sortby and sortby == fields[0]:
             res_l = sorted(res_l)
     else:
         res_df = concat(
-            [DataFrame(x).T.reset_index(drop=True) for x in metadata["features"]],
+            [DataFrame(x).T.reset_index(drop=True) for x in features],
             ignore_index=True,
         )
         if sortby:
@@ -89,8 +93,9 @@ async def get_value_counts(
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )
-    metadata = await response.json(content_type=None)
-    features = metadata["features"]
+    raw = await response.json(content_type=None)
+    envelope = _parse_response(FeaturesResponse, raw, context=f"{url}/query")
+    features = envelope.features or []
     cc = concat(
         [DataFrame(x["attributes"], index=[0]) for x in features],
         ignore_index=True,
@@ -131,8 +136,9 @@ async def nested_count(
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )
-    metadata = await response.json(content_type=None)
-    features = metadata["features"]
+    raw = await response.json(content_type=None)
+    envelope = _parse_response(FeaturesResponse, raw, context=f"{url}/query")
+    features = envelope.features or []
     cc = concat(
         [DataFrame(x).T.reset_index(drop=True) for x in features],
         ignore_index=True,

--- a/restgdf/utils/crawl.py
+++ b/restgdf/utils/crawl.py
@@ -4,10 +4,19 @@ import asyncio
 from typing import Any
 
 import aiohttp
+from pydantic import BaseModel
 
-from restgdf._types import CrawlError, CrawlReport, CrawlServiceEntry, LayerMetadata
+from restgdf._models.crawl import CrawlError, CrawlReport, CrawlServiceEntry
+from restgdf._models.responses import LayerMetadata
 from restgdf.utils.getinfo import service_metadata, get_metadata
 from restgdf.utils.token import ArcGISTokenSession
+
+
+def _to_plain_dict(value: Any) -> dict:
+    """Normalize a pydantic model or mapping to a mutable ``dict``."""
+    if isinstance(value, BaseModel):
+        return value.model_dump(by_alias=True)
+    return dict(value)
 
 
 async def fetch_all_data(
@@ -19,7 +28,7 @@ async def fetch_all_data(
     """Fetch all services and their layers in a highly concurrent manner."""
     # Retrieve the initial list of folders and services
     try:
-        base_metadata = await get_metadata(base_url, session, token)
+        base_metadata = _to_plain_dict(await get_metadata(base_url, session, token))
     except Exception as e:
         return {"error": e}
 
@@ -38,7 +47,9 @@ async def fetch_all_data(
     for folder in base_metadata.get("folders") or []:
         folder_url = f"{base_url}/{folder}"
         try:
-            folder_metadata = await get_metadata(folder_url, session, token)
+            folder_metadata = _to_plain_dict(
+                await get_metadata(folder_url, session, token),
+            )
         except Exception as e:
             return {"error": e}
         folder_metadata["url"] = folder_url
@@ -82,12 +93,13 @@ async def fetch_all_data(
 
 
 def _make_error(stage: str, url: str, exc: BaseException) -> CrawlError:
-    return {
-        "stage": stage,
-        "url": url,
-        "message": str(exc),
-        "exception": exc,
-    }
+    return CrawlError(stage=stage, url=url, message=str(exc), exception=exc)
+
+
+def _as_layer_metadata(raw: Any) -> LayerMetadata:
+    if isinstance(raw, LayerMetadata):
+        return raw
+    return LayerMetadata.model_validate(raw)
 
 
 async def safe_crawl(
@@ -100,30 +112,34 @@ async def safe_crawl(
 
     Unlike :func:`fetch_all_data`, this function never short-circuits on
     the first failure. Every recoverable error is captured as a typed
-    :class:`~restgdf._types.CrawlError` entry in ``report["errors"]`` and
-    successful services are always present in ``report["services"]``.
+    :class:`~restgdf._models.crawl.CrawlError` entry in
+    :attr:`CrawlReport.errors` and successful services are always
+    present in :attr:`CrawlReport.services`.
 
-    The three failure stages are ``"base_metadata"`` (root ``get_metadata``
-    call), ``"folder_metadata"`` (per-folder ``get_metadata`` call), and
-    ``"service_metadata"`` (per-service ``service_metadata`` call). When a
-    folder's metadata fails, services discovered in earlier folders (and
-    the base) are still returned.
+    The three failure stages are ``"base_metadata"`` (root
+    ``get_metadata`` call), ``"folder_metadata"`` (per-folder
+    ``get_metadata`` call), and ``"service_metadata"`` (per-service
+    ``service_metadata`` call). When a folder's metadata fails, services
+    discovered in earlier folders (and the base) are still returned.
     """
     errors: list[CrawlError] = []
-    services_list: list[CrawlServiceEntry] = []
+    services_raw: list[dict[str, Any]] = []
 
     try:
-        base_metadata: LayerMetadata = await get_metadata(base_url, session, token)
+        base_metadata: dict[str, Any] = _to_plain_dict(
+            await get_metadata(base_url, session, token),
+        )
     except Exception as exc:
         errors.append(_make_error("base_metadata", base_url, exc))
-        return {"services": services_list, "errors": errors}
+        return CrawlReport(services=[], errors=errors, metadata=None)
 
     base_metadata["url"] = base_url
 
     for service in base_metadata.get("services") or []:
-        services_list.append(
+        services_raw.append(
             {
                 "name": service["name"],
+                "type": service.get("type"),
                 "url": f"{base_url}/{service['name']}/{service['type']}",
             },
         )
@@ -131,16 +147,19 @@ async def safe_crawl(
     for folder in base_metadata.get("folders") or []:
         folder_url = f"{base_url}/{folder}"
         try:
-            folder_metadata = await get_metadata(folder_url, session, token)
+            folder_metadata = _to_plain_dict(
+                await get_metadata(folder_url, session, token),
+            )
         except Exception as exc:
             errors.append(_make_error("folder_metadata", folder_url, exc))
             continue
 
         folder_metadata["url"] = folder_url
         for service in folder_metadata.get("services") or []:
-            services_list.append(
+            services_raw.append(
                 {
                     "name": service["name"],
+                    "type": service.get("type"),
                     "url": f"{base_url}/{service['name']}/{service['type']}",
                 },
             )
@@ -157,13 +176,20 @@ async def safe_crawl(
             errors.append(_make_error("service_metadata", url, exc))
             return None
 
-    results = await asyncio.gather(*(_svc(svc["url"]) for svc in services_list))
-    for entry, result in zip(services_list, results):
-        if result is not None:
-            entry["metadata"] = result
+    results = await asyncio.gather(*(_svc(svc["url"]) for svc in services_raw))
+    service_entries: list[CrawlServiceEntry] = []
+    for entry, result in zip(services_raw, results):
+        service_entries.append(
+            CrawlServiceEntry(
+                name=entry["name"],
+                url=entry["url"],
+                type=entry.get("type"),
+                metadata=_as_layer_metadata(result) if result is not None else None,
+            ),
+        )
 
-    return {
-        "metadata": base_metadata,
-        "services": services_list,
-        "errors": errors,
-    }
+    return CrawlReport(
+        services=service_entries,
+        errors=errors,
+        metadata=_as_layer_metadata(base_metadata),
+    )

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -14,8 +14,10 @@ The ``from aiohttp import ClientSession`` line is PUBLIC API: tests patch
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 from aiohttp import ClientSession
+from pydantic import BaseModel
 
 from restgdf.utils._http import (
     DEFAULT_METADATA_HEADERS,
@@ -34,7 +36,8 @@ from restgdf.utils._metadata import (
     getfields_df,
     supports_pagination,
 )
-from restgdf._types import LayerMetadata
+from restgdf._models._drift import _parse_response
+from restgdf._models.responses import LayerMetadata
 from restgdf.utils._query import get_feature_count, get_metadata, get_object_ids
 from restgdf.utils._stats import (
     get_unique_values,
@@ -104,13 +107,24 @@ async def service_metadata(
     Orchestrator: resolves ``get_metadata`` and ``get_feature_count`` through
     this module's namespace so that
     ``unittest.mock.patch("restgdf.utils.getinfo.<helper>")`` intercepts.
+    The aggregated payload is validated against :class:`LayerMetadata` via
+    the drift adapter before being returned, so vendor-variance extras are
+    logged (not raised) and callers get a typed envelope.
     """
-    _service_metadata = await get_metadata(service_url, session, token=token)
+    _raw = await get_metadata(service_url, session, token=token)
+    _service_metadata: dict[str, Any] = (
+        _raw.model_dump(by_alias=True) if isinstance(_raw, BaseModel) else dict(_raw)
+    )
 
-    async def _comprehensive_metadata(layer_url: str) -> LayerMetadata:
-        metadata = await get_metadata(layer_url, session, token=token)
+    async def _comprehensive_metadata(layer_url: str) -> dict[str, Any]:
+        layer_raw = await get_metadata(layer_url, session, token=token)
+        metadata: dict[str, Any] = (
+            layer_raw.model_dump(by_alias=True)
+            if isinstance(layer_raw, BaseModel)
+            else dict(layer_raw)
+        )
         metadata["url"] = layer_url
-        if return_feature_count and metadata["type"] == "Feature Layer":
+        if return_feature_count and metadata.get("type") == "Feature Layer":
             try:
                 feature_count = await get_feature_count(
                     layer_url,
@@ -119,7 +133,7 @@ async def service_metadata(
                 )
             except KeyError:
                 feature_count = None
-            metadata["feature_count"] = feature_count  # type: ignore
+            metadata["feature_count"] = feature_count
         return metadata
 
     tasks = [
@@ -128,4 +142,4 @@ async def service_metadata(
     ]
     results = await asyncio.gather(*tasks)
     _service_metadata["layers"] = results
-    return _service_metadata
+    return _parse_response(LayerMetadata, _service_metadata, context=service_url)

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -1,17 +1,32 @@
+"""Token-session helpers for ArcGIS Online / Enterprise.
+
+The :class:`AGOLUserPass` and :class:`TokenSessionConfig` models live in
+:mod:`restgdf._models.credentials`. They are re-exported here for
+backward compatibility with ``from restgdf.utils.token import
+AGOLUserPass`` and with the public ``from restgdf import AGOLUserPass``
+surface documented in the README. The legacy frozen dataclass
+``AGOLUserPass`` was migrated to a pydantic ``StrictModel`` in v2.0.0;
+the import path is unchanged but the constructor is keyword-only.
+"""
+
+from __future__ import annotations
+
 import datetime
-from dataclasses import dataclass
-from typing import Optional, Union
+from dataclasses import dataclass, field
 
 import aiohttp
 import requests
 
+from restgdf._models._drift import _parse_response
+from restgdf._models.credentials import AGOLUserPass, TokenSessionConfig
+from restgdf._models.responses import TokenResponse
 
-@dataclass(frozen=True)
-class AGOLUserPass:
-    """ArcGIS Online credentials used to mint short-lived tokens."""
-
-    username: str
-    password: str
+__all__ = [
+    "AGOLUserPass",
+    "ArcGISTokenSession",
+    "TokenSessionConfig",
+    "get_token",
+]
 
 
 def get_token(username: str, password: str) -> dict:
@@ -29,19 +44,43 @@ def get_token(username: str, password: str) -> dict:
 
 @dataclass
 class ArcGISTokenSession:
-    """
-    Wrap an aiohttp session with ArcGIS token refresh behavior.
+    """Wrap an aiohttp session with ArcGIS token refresh behavior.
 
-    The wrapped session still performs the actual requests; this helper only
-    injects auth headers/body params and refreshes tokens when needed.
+    Construction knobs (``token_url``, ``token_refresh_threshold``,
+    ``credentials``) are validated via
+    :class:`~restgdf._models.credentials.TokenSessionConfig` in
+    :meth:`__post_init__` so a bogus scheme or zero-length username
+    fails fast with :class:`~restgdf._models.RestgdfResponseError`
+    rather than surfacing as a 401 or an ``aiohttp`` error deep in
+    the request path.
     """
 
     session: aiohttp.ClientSession
-    credentials: Optional[AGOLUserPass] = None
+    credentials: AGOLUserPass | None = None
     token_url: str = "https://www.arcgis.com/sharing/rest/generateToken"
     token_refresh_threshold: int = 60
-    token: Optional[str] = None
-    expires: Optional[Union[int, float]] = None
+    token: str | None = None
+    expires: int | float | None = None
+    verify_ssl: bool = True
+    config: TokenSessionConfig | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.credentials is not None:
+            # Validate config via TokenSessionConfig. Pass the already-
+            # validated credentials instance directly; pydantic accepts
+            # a model instance for a model-typed field without re-
+            # validating the SecretStr password.
+            self.config = _parse_response(
+                TokenSessionConfig,
+                {
+                    "token_url": self.token_url,
+                    "credentials": self.credentials,
+                    "refresh_threshold_seconds": self.token_refresh_threshold,
+                    "verify_ssl": self.verify_ssl,
+                },
+                context="ArcGISTokenSession",
+            )
+            self.credentials = self.config.credentials
 
     @property
     def token_request_payload(self) -> dict:
@@ -52,7 +91,8 @@ class ArcGISTokenSession:
             "f": "json",
             "client": "requestip",
             "username": self.credentials.username,
-            "password": self.credentials.password,
+            # Unwrap SecretStr only at the HTTP-POST boundary.
+            "password": self.credentials.password.get_secret_value(),
         }
 
     @property
@@ -63,13 +103,13 @@ class ArcGISTokenSession:
             headers["Authorization"] = f"Bearer {self.token}"
         return headers
 
-    def update_headers(self, headers: Optional[dict] = None) -> dict:
+    def update_headers(self, headers: dict | None = None) -> dict:
         """Return headers merged with the active token."""
         request_headers = dict(headers or {})
         request_headers.update(self.auth_headers)
         return request_headers
 
-    def update_dict(self, input_dict: Optional[dict] = None) -> dict:
+    def update_dict(self, input_dict: dict | None = None) -> dict:
         """Return a request payload/query dict merged with the active token."""
         output_dict = dict(input_dict or {})
         if self.token and "token" not in output_dict:
@@ -77,7 +117,14 @@ class ArcGISTokenSession:
         return output_dict
 
     async def update_token(self) -> None:
-        """Update the token by making a request to the token URL."""
+        """Update the token by making a request to the token URL.
+
+        The ``/generateToken`` payload is validated against
+        :class:`~restgdf._models.responses.TokenResponse` (strict tier)
+        so malformed/error envelopes raise
+        :class:`~restgdf._models.RestgdfResponseError` instead of
+        ``KeyError`` deep in caller code paths.
+        """
         async with self.session.post(
             self.token_url,
             data=self.token_request_payload,
@@ -85,8 +132,9 @@ class ArcGISTokenSession:
         ) as resp:
             resp.raise_for_status()
             data = await resp.json()
-        self.token = data["token"]
-        self.expires = data["expires"]
+        envelope = _parse_response(TokenResponse, data, context=self.token_url)
+        self.token = envelope.token
+        self.expires = envelope.expires
 
     def token_needs_update(self) -> bool:
         """Check if the token needs to be updated."""
@@ -110,8 +158,8 @@ class ArcGISTokenSession:
     async def get(
         self,
         url: str,
-        params: Optional[dict] = None,
-        headers: Optional[dict] = None,
+        params: dict | None = None,
+        headers: dict | None = None,
         **kwargs,
     ) -> aiohttp.ClientResponse:
         """Make a GET request to the specified URL with the token."""
@@ -134,8 +182,8 @@ class ArcGISTokenSession:
     async def post(
         self,
         url: str,
-        data: Optional[dict] = None,
-        headers: Optional[dict] = None,
+        data: dict | None = None,
+        headers: dict | None = None,
         **kwargs,
     ) -> aiohttp.ClientResponse:
         """Make a POST request to the specified URL with the token."""
@@ -155,7 +203,7 @@ class ArcGISTokenSession:
             **kwargs,
         )
 
-    async def __aenter__(self) -> "ArcGISTokenSession":
+    async def __aenter__(self) -> ArcGISTokenSession:
         """Enter the runtime context related to this object."""
         await self.update_token_if_needed()
         return self

--- a/tests/test_Directory.py
+++ b/tests/test_Directory.py
@@ -2,6 +2,8 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from restgdf._models.crawl import CrawlReport, CrawlServiceEntry
+from restgdf._models.responses import LayerMetadata
 from restgdf.directory.directory import Directory
 
 
@@ -16,17 +18,20 @@ async def test_directory(client_session):
     assert directory.services == services
     first_service_with_layers = None
     for service in services:
-        service_layers = service.get("metadata", {}).get("layers", [])
+        service_layers = (
+            service.metadata.layers if service.metadata is not None else None
+        ) or []
         if service_layers:
             first_service_with_layers = service
             break
-    first_service_layers = first_service_with_layers.get("metadata", {}).get(
-        "layers",
-        [],
-    )
+    first_service_layers = (
+        first_service_with_layers.metadata.layers
+        if first_service_with_layers is not None
+        else []
+    ) or []
     assert len(first_service_layers) > 0
-    assert isinstance(first_service_layers[0], dict)
-    assert len(directory.metadata) > 0
+    assert isinstance(first_service_layers[0], LayerMetadata)
+    assert directory.metadata is not None
     assert len(directory.rasters()) > 0
     assert len(directory.feature_layers()) > 0
 
@@ -34,21 +39,30 @@ async def test_directory(client_session):
 @pytest.mark.asyncio
 async def test_directory_crawl_caches_feature_count_variant_separately():
     directory = Directory("https://example.com/arcgis/rest/services", session=object())
-    without_count = {"services": [{"name": "base"}]}
-    with_count = {
-        "services": [{"name": "with-count", "metadata": {"feature_count": 1}}],
-    }
+    without_count = CrawlReport(
+        services=[CrawlServiceEntry(name="base", url="https://example.com/base")],
+    )
+    with_count = CrawlReport(
+        services=[
+            CrawlServiceEntry(
+                name="with-count",
+                url="https://example.com/with-count",
+                metadata=LayerMetadata(feature_count=1),
+            ),
+        ],
+    )
 
     with patch(
-        "restgdf.directory.directory.fetch_all_data",
+        "restgdf.directory.directory.safe_crawl",
         new=AsyncMock(side_effect=[without_count, with_count]),
-    ) as mock_fetch:
+    ) as mock_crawl:
         first = await directory.crawl(return_feature_count=False)
         second = await directory.crawl(return_feature_count=True)
 
-    assert first == without_count["services"]
-    assert second == with_count["services"]
-    assert mock_fetch.await_count == 2
+    assert first == without_count.services
+    assert second == with_count.services
+    assert mock_crawl.await_count == 2
+    assert directory.report is with_count
 
 
 @pytest.mark.asyncio
@@ -67,7 +81,8 @@ async def test_directory_prep_stores_metadata():
     ) as mock_get_metadata:
         await directory.prep()
 
-    assert directory.metadata == metadata
+    assert isinstance(directory.metadata, LayerMetadata)
+    assert directory.metadata.model_dump(by_alias=True, exclude_none=True) == metadata
     mock_get_metadata.assert_awaited_once_with(
         "https://example.com/arcgis/rest/services",
         session,
@@ -90,17 +105,17 @@ async def test_directory_from_url_calls_prep():
 @pytest.mark.asyncio
 async def test_directory_crawl_reuses_cached_services():
     directory = Directory("https://example.com/arcgis/rest/services", session=object())
-    cached_services = [{"name": "cached"}]
+    cached_services = [CrawlServiceEntry(name="cached", url="https://example.com/c")]
     directory.services = cached_services
 
     with patch(
-        "restgdf.directory.directory.fetch_all_data",
+        "restgdf.directory.directory.safe_crawl",
         new=AsyncMock(),
-    ) as mock_fetch:
+    ) as mock_crawl:
         result = await directory.crawl()
 
     assert result is cached_services
-    mock_fetch.assert_not_awaited()
+    mock_crawl.assert_not_awaited()
 
 
 def test_filter_directory_layers_requires_crawl():
@@ -113,17 +128,35 @@ def test_filter_directory_layers_requires_crawl():
 def test_filter_directory_layers_selects_matching_types():
     directory = Directory("https://example.com/arcgis/rest/services", session=object())
     directory.services = [
-        {
-            "metadata": {
-                "layers": [
-                    {"id": 0, "type": "Feature Layer"},
-                    {"id": 1, "type": "Raster Layer"},
+        CrawlServiceEntry(
+            name="svc-with-layers",
+            url="https://example.com/svc-with-layers",
+            metadata=LayerMetadata(
+                layers=[
+                    LayerMetadata(id=0, type="Feature Layer"),
+                    LayerMetadata(id=1, type="Raster Layer"),
                 ],
-            },
-        },
-        {"metadata": {}},
-        {},
+            ),
+        ),
+        CrawlServiceEntry(
+            name="svc-empty-metadata",
+            url="https://example.com/svc-empty-metadata",
+            metadata=LayerMetadata(),
+        ),
+        CrawlServiceEntry(
+            name="svc-no-metadata",
+            url="https://example.com/svc-no-metadata",
+            metadata=None,
+        ),
     ]
 
-    assert directory.feature_layers() == [{"id": 0, "type": "Feature Layer"}]
-    assert directory.rasters() == [{"id": 1, "type": "Raster Layer"}]
+    feature_layers = directory.feature_layers()
+    rasters = directory.rasters()
+
+    assert len(feature_layers) == 1
+    assert feature_layers[0].id == 0
+    assert feature_layers[0].type == "Feature Layer"
+
+    assert len(rasters) == 1
+    assert rasters[0].id == 1
+    assert rasters[0].type == "Raster Layer"

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -192,7 +192,10 @@ async def test_featurelayer_prep_populates_metadata_fields(feature_layer_metadat
 
     await layer.prep()
 
-    assert layer.metadata == feature_layer_metadata
+    assert (
+        layer.metadata.model_dump(by_alias=True, exclude_none=True)
+        == feature_layer_metadata
+    )
     assert layer.name == "Test Layer"
     assert layer.fields == ["OBJECTID", "CITY", "STATUS"]
     assert layer.object_id_field == "OBJECTID"
@@ -612,6 +615,6 @@ async def test_featurelayer(client_session):
     with raises(IndexError):
         assert len(await ziprest.getnestedcount(("PO_NAME", "ZIP"))) > 900
     assert len(await ziprest.getnestedcount(("PO_NAME", "ZIP_CODE"))) > 900
-    assert ziprest.count > ziprest.metadata["maxRecordCount"]
-    assert len(await ziprest.getgdf()) > ziprest.metadata["maxRecordCount"]
+    assert ziprest.count > ziprest.metadata.max_record_count
+    assert len(await ziprest.getgdf()) > ziprest.metadata.max_record_count
     assert ziprest.kwargs == testkwargs  # make sure nothing is altering kwargs

--- a/tests/test_compat_helpers.py
+++ b/tests/test_compat_helpers.py
@@ -1,0 +1,100 @@
+"""Tests for :mod:`restgdf.compat` migration helpers."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, SecretStr
+
+from restgdf import AGOLUserPass, CrawlError, LayerMetadata
+from restgdf.compat import as_dict, as_json_dict
+
+
+def test_as_dict_basemodel_returns_plain_dict() -> None:
+    md = LayerMetadata(name="layer0", maxRecordCount=1000)
+    result = as_dict(md)
+    assert isinstance(result, dict)
+    assert result["name"] == "layer0"
+    assert result["max_record_count"] == 1000
+
+
+def test_as_dict_uses_snake_case_keys() -> None:
+    md = LayerMetadata.model_validate(
+        {"name": "n", "supportsPagination": True},
+    )
+    result = as_dict(md)
+    assert "supports_pagination" in result
+    assert "supportsPagination" not in result
+
+
+def test_as_dict_passes_through_dict_unchanged() -> None:
+    payload = {"name": "layer", "id": 1}
+    assert as_dict(payload) is payload
+
+
+def test_as_dict_passes_through_none() -> None:
+    assert as_dict(None) is None
+
+
+def test_as_dict_passes_through_primitives() -> None:
+    for value in (1, 1.5, "hello", True, False):
+        assert as_dict(value) == value
+
+
+def test_as_dict_passes_through_list() -> None:
+    items = [1, 2, 3]
+    assert as_dict(items) is items
+
+
+def test_as_dict_handles_crawl_error_with_exception() -> None:
+    err = CrawlError(stage="service_metadata", url="http://x/0", message="boom")
+    result = as_dict(err)
+    assert result["stage"] == "service_metadata"
+    assert result["message"] == "boom"
+
+
+def test_as_json_dict_basemodel_returns_json_safe() -> None:
+    md = LayerMetadata(name="layer0")
+    result = as_json_dict(md)
+    assert isinstance(result, dict)
+    assert result["name"] == "layer0"
+
+
+def test_as_json_dict_redacts_secret_str() -> None:
+    creds = AGOLUserPass(username="u", password=SecretStr("supersecret"))
+    result = as_json_dict(creds)
+    assert isinstance(result, dict)
+    # SecretStr serialises to a placeholder in json mode, not the raw value
+    assert result["password"] != "supersecret"
+
+
+def test_as_json_dict_passes_through_dict() -> None:
+    payload = {"a": 1}
+    assert as_json_dict(payload) is payload
+
+
+def test_as_json_dict_passes_through_none_and_primitives() -> None:
+    assert as_json_dict(None) is None
+    assert as_json_dict(42) == 42
+    assert as_json_dict("s") == "s"
+
+
+def test_compat_submodule_import_path() -> None:
+    from restgdf.compat import as_dict as imported_as_dict
+    from restgdf.compat import as_json_dict as imported_as_json
+
+    assert callable(imported_as_dict)
+    assert callable(imported_as_json)
+
+
+def test_compat_attached_to_package() -> None:
+    import restgdf
+
+    assert restgdf.compat.as_dict is as_dict
+    assert restgdf.compat.as_json_dict is as_json_dict
+
+
+def test_as_dict_generic_basemodel_subclass() -> None:
+    class Tiny(BaseModel):
+        x: int
+
+    result = as_dict(Tiny(x=7))
+    assert result == {"x": 7}

--- a/tests/test_crawl_report.py
+++ b/tests/test_crawl_report.py
@@ -1,4 +1,4 @@
-"""Phase 4 TDD tests for :func:`restgdf.utils.crawl.safe_crawl`.
+"""S-4 TDD tests for :func:`restgdf.utils.crawl.safe_crawl`.
 
 Unlike the legacy ``fetch_all_data`` which short-circuits the whole
 crawl to ``{"error": exc}`` on the first failure, ``safe_crawl`` must
@@ -14,11 +14,17 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from restgdf._types import CrawlError, CrawlReport
+from restgdf._models import CrawlError, CrawlReport, CrawlServiceEntry
+from restgdf._models._drift import reset_drift_cache
 from restgdf.utils.crawl import safe_crawl
 
 
 BASE_URL = "https://example.com/arcgis/rest/services"
+
+
+@pytest.fixture(autouse=True)
+def _reset_drift_cache() -> None:
+    reset_drift_cache()
 
 
 def _metadata_by_url(mapping):
@@ -32,7 +38,7 @@ def _metadata_by_url(mapping):
 
 
 @pytest.mark.asyncio
-async def test_safe_crawl_returns_crawl_report_shape():
+async def test_safe_crawl_returns_crawl_report_model():
     async def fake_get_metadata(url, session, token=None):
         return {"services": [], "folders": []}
 
@@ -42,9 +48,9 @@ async def test_safe_crawl_returns_crawl_report_shape():
     ):
         report = await safe_crawl(object(), BASE_URL)
 
-    assert set(report.keys()) >= {"services", "errors"}
-    assert isinstance(report["services"], list)
-    assert isinstance(report["errors"], list)
+    assert isinstance(report, CrawlReport)
+    assert report.services == []
+    assert report.errors == []
 
 
 @pytest.mark.asyncio
@@ -60,7 +66,7 @@ async def test_safe_crawl_happy_path_collects_services_and_metadata():
     }
 
     async def fake_service_metadata(session, service_url, token, **kwargs):
-        return {"service_url": service_url}
+        return {"name": service_url}
 
     with patch(
         "restgdf.utils.crawl.get_metadata",
@@ -71,13 +77,15 @@ async def test_safe_crawl_happy_path_collects_services_and_metadata():
     ):
         report = await safe_crawl(object(), BASE_URL, token="abc")
 
-    assert report["errors"] == []
-    assert report["metadata"]["url"] == BASE_URL
-    assert [svc["name"] for svc in report["services"]] == [
+    assert report.errors == []
+    assert report.metadata is not None
+    assert report.metadata.url == BASE_URL
+    assert [svc.name for svc in report.services] == [
         "Root/Parcels",
         "Utilities/Storm",
     ]
-    assert all("metadata" in svc for svc in report["services"])
+    assert all(svc.metadata is not None for svc in report.services)
+    assert all(isinstance(svc, CrawlServiceEntry) for svc in report.services)
 
 
 @pytest.mark.asyncio
@@ -90,13 +98,14 @@ async def test_safe_crawl_records_base_metadata_error_without_raising():
     ):
         report = await safe_crawl(object(), BASE_URL)
 
-    assert report["services"] == []
-    assert len(report["errors"]) == 1
-    error = report["errors"][0]
-    assert error["stage"] == "base_metadata"
-    assert error["url"] == BASE_URL
-    assert error["message"] == "base boom"
-    assert error["exception"] is boom
+    assert report.services == []
+    assert len(report.errors) == 1
+    error = report.errors[0]
+    assert isinstance(error, CrawlError)
+    assert error.stage == "base_metadata"
+    assert error.url == BASE_URL
+    assert error.message == "base boom"
+    assert error.exception is boom
 
 
 @pytest.mark.asyncio
@@ -111,7 +120,7 @@ async def test_safe_crawl_records_folder_error_and_keeps_base_services():
     }
 
     async def fake_service_metadata(session, service_url, token, **kwargs):
-        return {"service_url": service_url}
+        return {"name": service_url}
 
     with patch(
         "restgdf.utils.crawl.get_metadata",
@@ -122,13 +131,13 @@ async def test_safe_crawl_records_folder_error_and_keeps_base_services():
     ):
         report = await safe_crawl(object(), BASE_URL)
 
-    assert [svc["name"] for svc in report["services"]] == ["Root/Parcels"]
-    assert all("metadata" in svc for svc in report["services"])
-    assert len(report["errors"]) == 1
-    error = report["errors"][0]
-    assert error["stage"] == "folder_metadata"
-    assert error["url"] == f"{BASE_URL}/Utilities"
-    assert error["exception"] is folder_boom
+    assert [svc.name for svc in report.services] == ["Root/Parcels"]
+    assert all(svc.metadata is not None for svc in report.services)
+    assert len(report.errors) == 1
+    error = report.errors[0]
+    assert error.stage == "folder_metadata"
+    assert error.url == f"{BASE_URL}/Utilities"
+    assert error.exception is folder_boom
 
 
 @pytest.mark.asyncio
@@ -149,7 +158,7 @@ async def test_safe_crawl_records_service_metadata_errors_per_service():
     async def fake_service_metadata(session, service_url, token, **kwargs):
         if service_url == bad_url:
             raise svc_boom
-        return {"service_url": service_url}
+        return {"name": service_url}
 
     with patch(
         "restgdf.utils.crawl.get_metadata",
@@ -160,16 +169,16 @@ async def test_safe_crawl_records_service_metadata_errors_per_service():
     ):
         report = await safe_crawl(object(), BASE_URL)
 
-    by_name = {svc["name"]: svc for svc in report["services"]}
-    assert "metadata" in by_name["Root/OK"]
-    assert "metadata" not in by_name["Root/Bad"]
-    assert len(report["errors"]) == 1
-    error = report["errors"][0]
-    assert error["stage"] == "service_metadata"
-    assert error["url"] == bad_url
-    assert error["exception"] is svc_boom
+    by_name = {svc.name: svc for svc in report.services}
+    assert by_name["Root/OK"].metadata is not None
+    assert by_name["Root/Bad"].metadata is None
+    assert len(report.errors) == 1
+    error = report.errors[0]
+    assert error.stage == "service_metadata"
+    assert error.url == bad_url
+    assert error.exception is svc_boom
     # ok service still fetched
-    assert by_name["Root/OK"]["metadata"]["service_url"] == ok_url
+    assert by_name["Root/OK"].metadata.name == ok_url
 
 
 @pytest.mark.asyncio
@@ -198,13 +207,8 @@ async def test_safe_crawl_return_feature_count_propagated_to_service_metadata():
     assert seen["return_feature_count"] is True
 
 
-def test_crawl_error_and_report_types_are_plain_dicts():
-    err: CrawlError = {
-        "stage": "base_metadata",
-        "url": "https://example.com",
-        "message": "boom",
-    }
-    report: CrawlReport = {"services": [], "errors": [err]}
-    assert isinstance(err, dict)
-    assert isinstance(report, dict)
-    assert report["errors"][0]["stage"] == "base_metadata"
+def test_crawl_error_and_report_models_expose_expected_fields():
+    err = CrawlError(stage="base_metadata", url="https://example.com", message="boom")
+    report = CrawlReport(errors=[err])
+    assert report.errors[0].stage == "base_metadata"
+    assert report.services == []

--- a/tests/test_directory_typed.py
+++ b/tests/test_directory_typed.py
@@ -1,0 +1,48 @@
+"""S-6: verify Directory exposes typed CrawlReport / CrawlServiceEntry models."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from restgdf._models.crawl import CrawlReport, CrawlServiceEntry
+from restgdf._models.responses import LayerMetadata
+from restgdf.directory.directory import Directory
+
+
+@pytest.mark.asyncio
+async def test_directory_crawl_returns_typed_entries_and_stores_report():
+    directory = Directory(
+        "https://example.com/arcgis/rest/services",
+        session=object(),
+    )
+    report = CrawlReport(
+        services=[
+            CrawlServiceEntry(
+                name="svc-a",
+                url="https://example.com/svc-a",
+                type="FeatureServer",
+                metadata=LayerMetadata(
+                    layers=[LayerMetadata(id=0, type="Feature Layer")],
+                ),
+            ),
+        ],
+        errors=[],
+        metadata=LayerMetadata(current_version=11.3),
+    )
+
+    with patch(
+        "restgdf.directory.directory.safe_crawl",
+        new=AsyncMock(return_value=report),
+    ):
+        services = await directory.crawl()
+
+    assert isinstance(directory.report, CrawlReport)
+    assert directory.report is report
+    assert len(services) == 1
+    assert isinstance(services[0], CrawlServiceEntry)
+    assert services[0].metadata is not None
+    assert isinstance(services[0].metadata, LayerMetadata)
+    assert services[0].metadata.layers is not None
+    assert isinstance(services[0].metadata.layers[0], LayerMetadata)

--- a/tests/test_featurelayer_typed.py
+++ b/tests/test_featurelayer_typed.py
@@ -1,0 +1,70 @@
+"""S-6: verify FeatureLayer exposes typed LayerMetadata / FieldSpec models."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from restgdf._models.responses import FieldSpec, LayerMetadata
+from restgdf.featurelayer.featurelayer import FeatureLayer
+
+
+class _Resp:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def __await__(self):
+        async def _r():
+            return self
+
+        return _r().__await__()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return None
+
+    async def json(self, content_type=None):
+        return self.payload
+
+    async def text(self):
+        return json.dumps(self.payload)
+
+    def raise_for_status(self):
+        return None
+
+
+class _Session:
+    def __init__(self, metadata, count):
+        self.metadata = metadata
+        self.count = count
+
+    def get(self, url, **kwargs):
+        return _Resp(self.metadata)
+
+    def post(self, url, **kwargs):
+        data = kwargs.get("data") or {}
+        if url.endswith("/query") and data.get("returnCountOnly"):
+            return _Resp({"count": self.count})
+        return _Resp(self.metadata)
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_prep_exposes_layer_metadata_model(feature_layer_metadata):
+    session = _Session(metadata=feature_layer_metadata, count=3)
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=session,
+    )
+
+    await layer.prep()
+
+    assert isinstance(layer.metadata, LayerMetadata)
+    assert layer.metadata.type == "Feature Layer"
+    assert layer.metadata.max_record_count == feature_layer_metadata["maxRecordCount"]
+    assert layer.metadata.fields is not None
+    assert len(layer.metadata.fields) == len(feature_layer_metadata["fields"])
+    assert all(isinstance(f, FieldSpec) for f in layer.metadata.fields)
+    assert layer.metadata.fields[0].name == "OBJECTID"

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -108,7 +108,8 @@ def mock_uniquevalues_post(*args, **kwargs):
     side_effect=mock_session_get,
 )
 async def test_get_json_dict(mock_response, client_session):
-    assert await get_metadata("test", session=client_session) == TESTJSON
+    result = await get_metadata("test", session=client_session)
+    assert result.model_dump(by_alias=True, exclude_none=True) == TESTJSON
 
 
 @pytest.mark.asyncio
@@ -501,9 +502,9 @@ async def test_service_metadata_fetches_layers_and_feature_counts():
             return_feature_count=True,
         )
 
-    assert result["layers"][0]["url"] == "https://example.com/service/0"
-    assert result["layers"][0]["feature_count"] == 12
-    assert "feature_count" not in result["layers"][1]
+    assert result.layers[0].url == "https://example.com/service/0"
+    assert result.layers[0].feature_count == 12
+    assert result.layers[1].feature_count is None
     mock_get_feature_count.assert_awaited_once()
 
 
@@ -527,4 +528,4 @@ async def test_service_metadata_sets_feature_count_none_when_count_lookup_fails(
             return_feature_count=True,
         )
 
-    assert result["layers"][0]["feature_count"] is None
+    assert result.layers[0].feature_count is None

--- a/tests/test_getinfo_seams.py
+++ b/tests/test_getinfo_seams.py
@@ -38,7 +38,7 @@ async def test_service_metadata_uses_getinfo_get_metadata_seam():
         result = await service_metadata(object(), "https://example.com/svc")
 
     assert mock_gm.await_count >= 1
-    assert result["layers"][0]["url"] == "https://example.com/svc/0"
+    assert result.layers[0].url == "https://example.com/svc/0"
 
 
 @pytest.mark.compat
@@ -66,7 +66,7 @@ async def test_service_metadata_uses_getinfo_get_feature_count_seam():
         )
 
     mock_gfc.assert_awaited()
-    assert result["layers"][0]["feature_count"] == 7
+    assert result.layers[0].feature_count == 7
 
 
 @pytest.mark.compat

--- a/tests/test_models_crawl.py
+++ b/tests/test_models_crawl.py
@@ -1,0 +1,232 @@
+"""S-4: Pydantic models for the ``safe_crawl`` report.
+
+These tests pin the public contract of :class:`CrawlError`,
+:class:`CrawlServiceEntry`, and :class:`CrawlReport` — permissive
+models returned by :func:`restgdf.utils.crawl.safe_crawl`.
+
+Contract points:
+
+* All three are :class:`PermissiveModel` subclasses: extras are kept,
+  missing optional fields default to ``None`` / empty lists rather
+  than raise.
+* :class:`CrawlError.exception` accepts arbitrary
+  :class:`BaseException` instances (``arbitrary_types_allowed``) and is
+  excluded from the default :meth:`~pydantic.BaseModel.model_dump`
+  output so the report stays JSON-serializable.
+* :class:`CrawlReport` round-trips nested lists of the other two models.
+* Unknown extras on :class:`CrawlServiceEntry` trigger a
+  drift-adapter DEBUG log, never a validation error.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from restgdf._models import CrawlError, CrawlReport, CrawlServiceEntry
+from restgdf._models._drift import (
+    PermissiveModel,
+    _parse_response,
+    reset_drift_cache,
+)
+from restgdf._models.responses import LayerMetadata
+
+
+@pytest.fixture(autouse=True)
+def _reset_drift_cache() -> None:
+    reset_drift_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Tier                                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_crawl_error_is_permissive_subclass() -> None:
+    assert issubclass(CrawlError, PermissiveModel)
+
+
+def test_crawl_service_entry_is_permissive_subclass() -> None:
+    assert issubclass(CrawlServiceEntry, PermissiveModel)
+
+
+def test_crawl_report_is_permissive_subclass() -> None:
+    assert issubclass(CrawlReport, PermissiveModel)
+
+
+# --------------------------------------------------------------------------- #
+# Forgiving validation                                                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_crawl_error_accepts_empty_payload_without_raising() -> None:
+    err = CrawlError.model_validate({})
+    assert err.stage is None
+    assert err.url is None
+    assert err.message is None
+    assert err.exception is None
+
+
+def test_crawl_service_entry_accepts_empty_payload_without_raising() -> None:
+    entry = CrawlServiceEntry.model_validate({})
+    assert entry.name is None
+    assert entry.url is None
+    assert entry.metadata is None
+
+
+def test_crawl_report_accepts_empty_payload_and_defaults_lists() -> None:
+    report = CrawlReport.model_validate({})
+    assert report.services == []
+    assert report.errors == []
+    assert report.metadata is None
+
+
+# --------------------------------------------------------------------------- #
+# Construction / round-trip                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_crawl_error_round_trip_preserves_stage_url_message() -> None:
+    err = CrawlError(
+        stage="service_metadata",
+        url="https://example.com/arcgis/rest/services/S/FeatureServer",
+        message="boom",
+    )
+    dumped = err.model_dump(exclude_none=True)
+    assert dumped == {
+        "stage": "service_metadata",
+        "url": "https://example.com/arcgis/rest/services/S/FeatureServer",
+        "message": "boom",
+    }
+
+
+def test_crawl_error_preserves_exception_attribute_but_excludes_from_dump() -> None:
+    boom = RuntimeError("boom")
+    err = CrawlError(stage="base_metadata", url="u", message="boom", exception=boom)
+    assert err.exception is boom
+    dumped = err.model_dump()
+    assert "exception" not in dumped
+
+
+def test_crawl_error_exception_preserves_arbitrary_base_exception_subclass() -> None:
+    class _Custom(BaseException):
+        pass
+
+    boom = _Custom("weird")
+    err = CrawlError(exception=boom)
+    assert err.exception is boom
+
+
+def test_crawl_service_entry_round_trip() -> None:
+    entry = CrawlServiceEntry(
+        name="Root/Parcels",
+        url="https://example.com/arcgis/rest/services/Root/Parcels/FeatureServer",
+        type="FeatureServer",
+    )
+    dumped = entry.model_dump(exclude_none=True)
+    assert dumped["name"] == "Root/Parcels"
+    assert dumped["url"].endswith("/FeatureServer")
+    assert dumped["type"] == "FeatureServer"
+
+
+def test_crawl_service_entry_accepts_nested_metadata_as_layer_metadata() -> None:
+    entry = CrawlServiceEntry.model_validate(
+        {
+            "name": "S",
+            "url": "https://example.com/S/FeatureServer",
+            "metadata": {"name": "Root", "maxRecordCount": 1000},
+        },
+    )
+    assert isinstance(entry.metadata, LayerMetadata)
+    assert entry.metadata.name == "Root"
+    assert entry.metadata.max_record_count == 1000
+
+
+def test_crawl_report_round_trip_with_nested_lists() -> None:
+    report = CrawlReport(
+        services=[
+            CrawlServiceEntry(name="A", url="https://ex/A"),
+            CrawlServiceEntry(name="B", url="https://ex/B"),
+        ],
+        errors=[
+            CrawlError(stage="service_metadata", url="https://ex/B", message="nope"),
+        ],
+        metadata=LayerMetadata(name="Root"),
+    )
+    assert [svc.name for svc in report.services] == ["A", "B"]
+    assert report.errors[0].stage == "service_metadata"
+    assert isinstance(report.metadata, LayerMetadata)
+    assert report.metadata.name == "Root"
+
+
+def test_crawl_report_round_trips_through_model_validate_dict() -> None:
+    raw = {
+        "services": [
+            {"name": "A", "url": "https://ex/A"},
+            {
+                "name": "B",
+                "url": "https://ex/B",
+                "metadata": {"name": "LayerB"},
+            },
+        ],
+        "errors": [
+            {"stage": "service_metadata", "url": "https://ex/C", "message": "boom"},
+        ],
+        "metadata": {"name": "Root", "folders": ["Utils"]},
+    }
+    report = CrawlReport.model_validate(raw)
+    assert isinstance(report.services[0], CrawlServiceEntry)
+    assert isinstance(report.services[1].metadata, LayerMetadata)
+    assert report.services[1].metadata.name == "LayerB"
+    assert isinstance(report.errors[0], CrawlError)
+    assert isinstance(report.metadata, LayerMetadata)
+    assert report.metadata.folders == ["Utils"]
+
+
+# --------------------------------------------------------------------------- #
+# Extras preserved                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_crawl_service_entry_preserves_unknown_extras() -> None:
+    entry = CrawlServiceEntry.model_validate(
+        {"name": "S", "url": "https://ex/S", "serverGen": 17},
+    )
+    dumped = entry.model_dump(exclude_none=True)
+    assert dumped.get("serverGen") == 17
+
+
+# --------------------------------------------------------------------------- #
+# Drift logging for unknown extras via _parse_response                        #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_response_crawl_service_entry_logs_unknown_extras_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    _parse_response(
+        CrawlServiceEntry,
+        {"name": "S", "url": "https://ex/S", "mysteryKey": "?"},
+        context="safe_crawl",
+    )
+    drift_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.DEBUG and "mysteryKey" in r.getMessage()
+    ]
+    assert drift_records, "expected DEBUG drift log for unknown extra"
+
+
+# --------------------------------------------------------------------------- #
+# Re-export                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_models_package_reexports_crawl_models() -> None:
+    import restgdf._models as m
+
+    assert m.CrawlError is CrawlError
+    assert m.CrawlServiceEntry is CrawlServiceEntry
+    assert m.CrawlReport is CrawlReport

--- a/tests/test_models_credentials.py
+++ b/tests/test_models_credentials.py
@@ -1,0 +1,151 @@
+"""Tests for :mod:`restgdf._models.credentials`.
+
+TDD-first: this file is authored before the module it exercises.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from restgdf._models import RestgdfResponseError
+from restgdf._models._drift import StrictModel, _parse_response
+from restgdf._models.credentials import AGOLUserPass, TokenSessionConfig
+
+
+# ---------------------------------------------------------------------------
+# Tier + SecretStr behavior
+# ---------------------------------------------------------------------------
+
+
+def test_agoluserpass_is_strict_tier():
+    assert issubclass(AGOLUserPass, StrictModel)
+
+
+def test_tokensessionconfig_is_strict_tier():
+    assert issubclass(TokenSessionConfig, StrictModel)
+
+
+def test_agoluserpass_password_is_secretstr_and_redacted_in_str():
+    creds = AGOLUserPass(username="u", password="p")
+    assert isinstance(creds.password, SecretStr)
+    rendered = str(creds)
+    assert "p" not in rendered or "password" in rendered
+    # Stronger: the literal secret value must not appear in str/repr.
+    rendered_repr = repr(creds)
+    assert "p" not in _strip_known_noise(rendered_repr)
+
+
+def test_agoluserpass_get_secret_value_returns_real_password():
+    creds = AGOLUserPass(username="u", password="supersecret")
+    assert creds.password.get_secret_value() == "supersecret"
+
+
+def _strip_known_noise(text: str) -> str:
+    """Remove tokens that legitimately contain ``p`` from a repr for the
+    'password value is redacted' assertion (field names like ``password``
+    and the ``AGOLUserPass`` class name are expected to contain ``p``)."""
+    for noise in ("AGOLUserPass", "password", "SecretStr", "expiration"):
+        text = text.replace(noise, "")
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Validation via _parse_response (strict tier contract)
+# ---------------------------------------------------------------------------
+
+
+def test_agoluserpass_empty_username_raises_via_parse_response():
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(
+            AGOLUserPass,
+            {"username": "", "password": "p"},
+            context="test",
+        )
+
+
+def test_agoluserpass_missing_password_raises_via_parse_response():
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(AGOLUserPass, {"username": "u"}, context="test")
+
+
+def test_agoluserpass_defaults():
+    creds = AGOLUserPass(username="u", password="p")
+    assert creds.expiration == 60
+    assert creds.referer is None
+
+
+# ---------------------------------------------------------------------------
+# TokenSessionConfig: ArcGIS Enterprise HTTP compat
+# ---------------------------------------------------------------------------
+
+
+def _creds() -> AGOLUserPass:
+    return AGOLUserPass(username="u", password="p")
+
+
+def test_tokensessionconfig_accepts_https_url():
+    cfg = TokenSessionConfig(
+        token_url="https://www.arcgis.com/sharing/rest/generateToken",
+        credentials=_creds(),
+    )
+    assert cfg.token_url.startswith("https://")
+
+
+def test_tokensessionconfig_accepts_http_enterprise_url():
+    # CRITICAL compat test: ArcGIS Enterprise frequently runs plain http
+    # on internal networks. Rejecting http:// would break real users.
+    cfg = TokenSessionConfig(
+        token_url="http://enterprise.example.com/sharing/rest/generateToken",
+        credentials=_creds(),
+    )
+    assert cfg.token_url.startswith("http://")
+
+
+@pytest.mark.parametrize(
+    "bad_url",
+    ["ftp://example.com/token", "file:///etc/passwd", "javascript:alert(1)", ""],
+)
+def test_tokensessionconfig_rejects_non_http_schemes(bad_url: str):
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(
+            TokenSessionConfig,
+            {
+                "token_url": bad_url,
+                "credentials": {"username": "u", "password": "p"},
+            },
+            context="test",
+        )
+
+
+def test_tokensessionconfig_defaults():
+    cfg = TokenSessionConfig(
+        token_url="https://example.com/sharing/rest/generateToken",
+        credentials=_creds(),
+    )
+    assert cfg.refresh_threshold_seconds == 60
+    assert cfg.verify_ssl is True
+
+
+def test_tokensessionconfig_nested_credentials_preserve_secretstr():
+    cfg = TokenSessionConfig(
+        token_url="https://example.com/sharing/rest/generateToken",
+        credentials={"username": "u", "password": "p"},
+    )
+    assert isinstance(cfg.credentials, AGOLUserPass)
+    assert cfg.credentials.password.get_secret_value() == "p"
+
+
+def test_tokensessionconfig_parse_response_roundtrip():
+    cfg = _parse_response(
+        TokenSessionConfig,
+        {
+            "token_url": "https://example.com/sharing/rest/generateToken",
+            "credentials": {"username": "u", "password": "p"},
+            "refresh_threshold_seconds": 120,
+            "verify_ssl": False,
+        },
+        context="test",
+    )
+    assert cfg.refresh_threshold_seconds == 120
+    assert cfg.verify_ssl is False

--- a/tests/test_models_metadata.py
+++ b/tests/test_models_metadata.py
@@ -1,0 +1,237 @@
+"""S-2: Pydantic metadata models for ArcGIS service/layer shapes.
+
+These tests pin the public contract of :class:`LayerMetadata` and
+:class:`ServiceInfo` — permissive models that describe the polymorphic
+``GET <layer_url>?f=json`` and ``GET <services_root>?f=json`` payloads
+restgdf consumes. See :mod:`restgdf._models.responses` for the tier.
+
+Key contract points:
+
+* Both are :class:`PermissiveModel` subclasses: extras are kept and
+  missing keys default to ``None`` (never raise).
+* Fields use :class:`~pydantic.AliasChoices` so either camelCase ArcGIS
+  keys or snake_case Python names validate. ``model_dump(by_alias=True)``
+  round-trips the original camelCase for downstream serialization.
+* ``LayerMetadata.layers`` is self-referential (a layer's sublayers are
+  themselves :class:`LayerMetadata`). ``model_rebuild`` resolves the
+  forward reference at import time.
+* The drift adapter :func:`_parse_response` logs unknown extras at
+  ``DEBUG`` and non-mapping roots at ``WARNING`` without raising.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from restgdf._models._drift import (
+    PermissiveModel,
+    _parse_response,
+    reset_drift_cache,
+)
+from restgdf._models.responses import LayerMetadata, ServiceInfo
+
+
+@pytest.fixture(autouse=True)
+def _reset_drift_cache() -> None:
+    reset_drift_cache()
+
+
+# --------------------------------------------------------------------------- #
+# LayerMetadata — tier + basic contract                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_layer_metadata_is_permissive_subclass() -> None:
+    assert issubclass(LayerMetadata, PermissiveModel)
+
+
+def test_service_info_is_permissive_subclass() -> None:
+    assert issubclass(ServiceInfo, PermissiveModel)
+
+
+def test_layer_metadata_accepts_empty_payload_without_raising() -> None:
+    layer = LayerMetadata.model_validate({})
+    assert layer.name is None
+    assert layer.type is None
+    assert layer.id is None
+    assert layer.fields is None
+    assert layer.max_record_count is None
+    assert layer.supports_pagination is None
+    assert layer.advanced_query_capabilities is None
+    assert layer.layers is None
+    assert layer.services is None
+    assert layer.folders is None
+    assert layer.url is None
+    assert layer.feature_count is None
+
+
+# --------------------------------------------------------------------------- #
+# LayerMetadata — camelCase ↔ snake_case aliases                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_layer_metadata_accepts_camelcase_arcgis_payload() -> None:
+    raw = {
+        "id": 0,
+        "name": "Parcels",
+        "type": "Feature Layer",
+        "maxRecordCount": 2000,
+        "supportsPagination": True,
+        "advancedQueryCapabilities": {"supportsPagination": True},
+        "fields": [
+            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+            {"name": "CITY", "type": "esriFieldTypeString"},
+        ],
+    }
+    layer = LayerMetadata.model_validate(raw)
+    assert layer.id == 0
+    assert layer.name == "Parcels"
+    assert layer.type == "Feature Layer"
+    assert layer.max_record_count == 2000
+    assert layer.supports_pagination is True
+    assert layer.advanced_query_capabilities == {"supportsPagination": True}
+    assert layer.fields is not None
+    assert layer.fields[0].name == "OBJECTID"
+
+
+def test_layer_metadata_accepts_snake_case_input() -> None:
+    raw = {
+        "name": "L",
+        "max_record_count": 50,
+        "supports_pagination": False,
+        "advanced_query_capabilities": {"supportsPagination": False},
+        "feature_count": 7,
+    }
+    layer = LayerMetadata.model_validate(raw)
+    assert layer.max_record_count == 50
+    assert layer.supports_pagination is False
+    assert layer.feature_count == 7
+
+
+def test_layer_metadata_dumps_camelcase_by_alias() -> None:
+    layer = LayerMetadata.model_validate(
+        {
+            "name": "L",
+            "maxRecordCount": 10,
+            "supportsPagination": True,
+            "advancedQueryCapabilities": {"supportsPagination": True},
+            "url": "https://example.com/0",
+            "feature_count": 3,
+        },
+    )
+    dumped = layer.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["maxRecordCount"] == 10
+    assert dumped["supportsPagination"] is True
+    assert dumped["advancedQueryCapabilities"] == {"supportsPagination": True}
+    # url and feature_count are already snake_case in ArcGIS (added by restgdf),
+    # so by_alias does not mangle them.
+    assert dumped["url"] == "https://example.com/0"
+    assert dumped["feature_count"] == 3
+
+
+def test_layer_metadata_preserves_unknown_extras() -> None:
+    raw = {"name": "L", "serverGens": {"minServerGen": 1}}
+    layer = LayerMetadata.model_validate(raw)
+    dumped = layer.model_dump(exclude_none=True)
+    assert dumped.get("serverGens") == {"minServerGen": 1}
+
+
+# --------------------------------------------------------------------------- #
+# LayerMetadata — self-referential sublayers                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_layer_metadata_layers_field_is_self_referential() -> None:
+    raw = {
+        "layers": [
+            {"id": 0, "name": "Root"},
+            {"id": 1, "name": "Sub"},
+        ],
+    }
+    layer = LayerMetadata.model_validate(raw)
+    assert layer.layers is not None
+    assert len(layer.layers) == 2
+    assert isinstance(layer.layers[0], LayerMetadata)
+    assert layer.layers[0].id == 0
+    assert layer.layers[1].name == "Sub"
+
+
+def test_layer_metadata_nested_layers_preserve_camelcase() -> None:
+    raw = {
+        "layers": [
+            {"id": 0, "maxRecordCount": 100},
+        ],
+    }
+    layer = LayerMetadata.model_validate(raw)
+    assert layer.layers[0].max_record_count == 100
+
+
+# --------------------------------------------------------------------------- #
+# ServiceInfo — service-root payload                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_service_info_accepts_service_root_payload() -> None:
+    raw = {
+        "services": [{"name": "Root/Parcels", "type": "FeatureServer"}],
+        "folders": ["Utilities"],
+    }
+    info = ServiceInfo.model_validate(raw)
+    assert info.services == [{"name": "Root/Parcels", "type": "FeatureServer"}]
+    assert info.folders == ["Utilities"]
+
+
+def test_service_info_accepts_empty_payload() -> None:
+    info = ServiceInfo.model_validate({})
+    assert info.services is None
+    assert info.folders is None
+
+
+# --------------------------------------------------------------------------- #
+# Drift adapter integration                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_response_layer_metadata_logs_unknown_extras_at_debug(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    _parse_response(
+        LayerMetadata,
+        {"name": "L", "maxRecordCount": 1, "mysteryKey": "?"},
+        context="https://example.com/0",
+    )
+    drift_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.DEBUG and "mysteryKey" in r.getMessage()
+    ]
+    assert drift_records, "expected DEBUG drift log for unknown extra"
+
+
+def test_parse_response_layer_metadata_non_mapping_warns_and_returns_empty(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    layer = _parse_response(LayerMetadata, "not a dict", context="ctx")  # type: ignore[arg-type]
+    assert isinstance(layer, LayerMetadata)
+    assert layer.name is None
+    assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+def test_parse_response_layer_metadata_falls_back_for_bad_typed_field(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    layer = _parse_response(
+        LayerMetadata,
+        {"name": "L", "maxRecordCount": "not-an-int"},
+        context="ctx",
+    )
+    assert layer.name == "L"
+    # max_record_count was stripped; defaults to None
+    assert layer.max_record_count is None
+    bad_type_records = [r for r in caplog.records if "bad_type" in r.getMessage()]
+    assert bad_type_records

--- a/tests/test_models_primitives.py
+++ b/tests/test_models_primitives.py
@@ -1,0 +1,323 @@
+"""S-1: Pydantic primitives for ArcGIS response parsing.
+
+These tests pin the public contract of the new primitive models
+(:class:`FieldSpec`, :class:`ErrorInfo`, :class:`ErrorResponse`,
+:class:`Feature`) and of the shared drift adapter
+(``restgdf._models._drift._parse_response``).
+
+The two-tier validation contract is:
+
+* Permissive models accept extras and treat all consumed fields as
+  optional. Extras are logged at ``DEBUG`` via the
+  ``restgdf.schema_drift`` logger. Missing optional fields do not raise.
+* Strict models tolerate extras silently (so vendor additions never
+  break us) but raise :class:`RestgdfResponseError` when a required
+  field is missing or ill-typed.
+
+Dedupe is keyed on ``(model_name, path, kind, value_type)`` so the same
+drift only logs once per process.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from restgdf._models import RestgdfResponseError
+from restgdf._models._drift import (
+    PermissiveModel,
+    StrictModel,
+    _parse_response,
+    reset_drift_cache,
+)
+from restgdf._models.responses import (
+    ErrorInfo,
+    ErrorResponse,
+    Feature,
+    FieldSpec,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_drift_cache() -> None:
+    reset_drift_cache()
+
+
+# --------------------------------------------------------------------------- #
+# FieldSpec                                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_fieldspec_accepts_typical_arcgis_shape() -> None:
+    raw = {
+        "name": "OBJECTID",
+        "type": "esriFieldTypeOID",
+        "alias": "OBJECTID",
+        "length": 4,
+        "domain": None,
+        "nullable": False,
+        "editable": False,
+    }
+    field = FieldSpec.model_validate(raw)
+    assert field.name == "OBJECTID"
+    assert field.type == "esriFieldTypeOID"
+    assert field.alias == "OBJECTID"
+    assert field.length == 4
+    assert field.domain is None
+    assert field.nullable is False
+
+
+def test_fieldspec_preserves_unknown_extras() -> None:
+    raw = {"name": "FOO", "type": "esriFieldTypeString", "sqlType": "sqlTypeNVarchar"}
+    field = FieldSpec.model_validate(raw)
+    # extra="allow" → unknown keys available on model via attribute or dump
+    assert field.model_dump(exclude_none=True).get("sqlType") == "sqlTypeNVarchar"
+
+
+def test_fieldspec_missing_name_and_type_are_optional() -> None:
+    # Permissive tier: even "expected" keys are Optional so ArcGIS drift
+    # does not explode. Downstream parsers still raise their own errors.
+    field = FieldSpec.model_validate({})
+    assert field.name is None
+    assert field.type is None
+
+
+# --------------------------------------------------------------------------- #
+# ErrorInfo / ErrorResponse                                                   #
+# --------------------------------------------------------------------------- #
+
+
+def test_error_info_accepts_code_message_details() -> None:
+    info = ErrorInfo.model_validate(
+        {"code": 400, "message": "Invalid", "details": ["field X bad"]},
+    )
+    assert info.code == 400
+    assert info.message == "Invalid"
+    assert info.details == ["field X bad"]
+
+
+def test_error_response_is_strict_requires_error_key() -> None:
+    with pytest.raises(RestgdfResponseError) as exc_info:
+        _parse_response(ErrorResponse, {"not_error": 1}, context="test")
+    err = exc_info.value
+    assert err.model_name == "ErrorResponse"
+    assert err.context == "test"
+    assert err.raw == {"not_error": 1}
+
+
+def test_error_response_validates_well_formed_error_envelope() -> None:
+    raw = {"error": {"code": 498, "message": "Invalid Token"}}
+    resp = _parse_response(ErrorResponse, raw, context="token-refresh")
+    assert resp.error.code == 498
+    assert resp.error.message == "Invalid Token"
+
+
+def test_error_response_tolerates_extra_keys_silently() -> None:
+    raw = {
+        "error": {"code": 400, "message": "bad"},
+        "requestId": "abc-123",
+    }
+    resp = _parse_response(ErrorResponse, raw, context="test")
+    assert resp.error.code == 400
+
+
+# --------------------------------------------------------------------------- #
+# Feature                                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_feature_accepts_attributes_and_optional_geometry() -> None:
+    f = Feature.model_validate(
+        {"attributes": {"OBJECTID": 1, "NAME": "X"}, "geometry": {"x": 1.0, "y": 2.0}},
+    )
+    assert f.attributes == {"OBJECTID": 1, "NAME": "X"}
+    assert f.geometry == {"x": 1.0, "y": 2.0}
+
+
+def test_feature_geometry_optional() -> None:
+    f = Feature.model_validate({"attributes": {"X": 1}})
+    assert f.geometry is None
+
+
+# --------------------------------------------------------------------------- #
+# _parse_response drift logging                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_response_logs_unknown_extras_at_debug_for_permissive(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    _parse_response(FieldSpec, {"name": "X", "type": "Y", "weirdKey": 1}, context="ctx")
+    debug_records = [
+        r
+        for r in caplog.records
+        if r.levelno == logging.DEBUG and r.name == "restgdf.schema_drift"
+    ]
+    assert debug_records, "expected at least one DEBUG record for unknown extras"
+    assert any("weirdKey" in r.getMessage() for r in debug_records)
+
+
+def test_parse_response_strict_validation_error_includes_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    with pytest.raises(RestgdfResponseError) as exc_info:
+        _parse_response(ErrorResponse, {"bogus": 1}, context="some-url")
+    assert exc_info.value.context == "some-url"
+
+
+def test_parse_response_dedupes_drift_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    payload = {"name": "X", "type": "Y", "weirdKey": 1}
+    _parse_response(FieldSpec, payload, context="ctx")
+    _parse_response(FieldSpec, payload, context="ctx")
+    weird_records = [r for r in caplog.records if "weirdKey" in r.getMessage()]
+    assert (
+        len(weird_records) == 1
+    ), f"expected deduped drift log, got {len(weird_records)}"
+
+
+def test_parse_response_passes_through_valid_permissive_model() -> None:
+    raw = {"name": "X", "type": "Y"}
+    result = _parse_response(FieldSpec, raw, context="ctx")
+    assert isinstance(result, FieldSpec)
+    assert result.name == "X"
+
+
+def test_tier_base_classes_have_expected_configs() -> None:
+    assert PermissiveModel.model_config.get("extra") == "allow"
+    assert PermissiveModel.model_config.get("populate_by_name") is True
+    assert StrictModel.model_config.get("extra") == "ignore"
+    assert StrictModel.model_config.get("populate_by_name") is True
+
+
+def test_reset_drift_cache_clears_dedupe(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    payload = {"name": "X", "type": "Y", "weirdKey": 1}
+    _parse_response(FieldSpec, payload, context="ctx")
+    reset_drift_cache()
+    _parse_response(FieldSpec, payload, context="ctx")
+    weird_records = [r for r in caplog.records if "weirdKey" in r.getMessage()]
+    assert len(weird_records) == 2
+
+
+def test_parse_response_rejects_non_mapping_for_strict(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(ErrorResponse, "not a dict", context="ctx")  # type: ignore[arg-type]
+
+
+def test_field_spec_is_permissive_subclass() -> None:
+    assert issubclass(FieldSpec, PermissiveModel)
+
+
+def test_error_response_is_strict_subclass() -> None:
+    assert issubclass(ErrorResponse, StrictModel)
+
+
+def test_feature_is_permissive_subclass() -> None:
+    assert issubclass(Feature, PermissiveModel)
+
+
+def test_error_info_is_permissive_subclass() -> None:
+    # ErrorInfo nested inside strict ErrorResponse stays permissive — ArcGIS
+    # error payloads often carry extra troubleshooting keys we do not model.
+    assert issubclass(ErrorInfo, PermissiveModel)
+
+
+def test_parse_response_accepts_dict_of_arbitrary_types(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Permissive parsing should never raise, even with nonsense types."""
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    bad: dict[str, Any] = {"name": "X", "type": "Y", "length": "not-an-int"}
+    # length has declared type; coerce or drop-to-None but never raise
+    result = _parse_response(FieldSpec, bad, context="ctx")
+    # We do not pin what length resolves to — only that parse did not raise.
+    assert result.name == "X"
+
+
+# --------------------------------------------------------------------------- #
+# Drift adapter edge cases                                                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_response_permissive_non_mapping_logs_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    result = _parse_response(FieldSpec, "not a dict", context="ctx")  # type: ignore[arg-type]
+    assert isinstance(result, FieldSpec)
+    assert result.name is None
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("not_a_mapping" in r.getMessage() for r in warnings)
+
+
+def test_parse_response_permissive_bad_type_falls_back_and_logs(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from pydantic import BaseModel
+
+    from restgdf._models._drift import PermissiveModel as _Perm
+    from restgdf._models._drift import _parse_response as _pr
+
+    class _ModelWithStrictInt(_Perm):
+        n: int = 0
+
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    result = _pr(_ModelWithStrictInt, {"n": "definitely-not-int"}, context="ctx")
+    # Bad-typed field is stripped; default (0) applies
+    assert isinstance(result, BaseModel)
+    bad_records = [r for r in caplog.records if "bad_type" in r.getMessage()]
+    assert bad_records
+
+
+def test_known_keys_includes_field_alias_and_alias_choices() -> None:
+    from pydantic import AliasChoices, Field
+
+    from restgdf._models._drift import PermissiveModel as _Perm
+    from restgdf._models._drift import _known_keys
+
+    class _Aliased(_Perm):
+        object_id_field: str = Field(
+            default="",
+            alias="objectIdFieldName",
+            validation_alias=AliasChoices("objectIdFieldName", "OBJECTID_FIELD"),
+        )
+
+    keys = _known_keys(_Aliased)
+    assert {"object_id_field", "objectIdFieldName", "OBJECTID_FIELD"} <= keys
+
+
+def test_parse_response_ignores_validation_errors_without_loc(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An error row without a usable ``loc`` should not explode the adapter."""
+    from pydantic import model_validator
+
+    from restgdf._models._drift import PermissiveModel as _Perm
+    from restgdf._models._drift import _parse_response as _pr
+
+    class _Whole(_Perm):
+        x: int = 0
+
+        @model_validator(mode="after")
+        def _reject(self) -> _Whole:
+            raise ValueError("bad whole")
+
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    # model_validator errors have loc=() — adapter should tolerate, but then
+    # revalidation still fails. We assert the failure path is a ValidationError
+    # re-raised (permissive models surface underlying errors when no field can
+    # be stripped).
+    with pytest.raises(Exception):
+        _pr(_Whole, {"x": 1}, context="ctx")

--- a/tests/test_models_queries.py
+++ b/tests/test_models_queries.py
@@ -1,0 +1,264 @@
+"""S-3: Pydantic query envelope models.
+
+These tests pin the public contract of the query/count/objectIds/token
+envelope models added in slice S-3:
+
+* :class:`CountResponse` — strict; ``returnCountOnly=true`` result.
+* :class:`ObjectIdsResponse` — strict; ``returnIdsOnly=true`` result.
+  ArcGIS emits ``{"objectIdFieldName": "OBJECTID", "objectIds": null}``
+  when the query matches zero rows; the model coerces ``None`` to ``[]``
+  so consumers can safely iterate.
+* :class:`FeaturesResponse` — permissive envelope; the per-feature
+  validation lives in :class:`Feature` and is intentionally *not* applied
+  here so large feature batches flow through without per-item overhead.
+* :class:`TokenResponse` — strict; validates the ``/generateToken`` reply.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from restgdf._models import RestgdfResponseError
+from restgdf._models._drift import (
+    PermissiveModel,
+    StrictModel,
+    _parse_response,
+    reset_drift_cache,
+)
+from restgdf._models.responses import (
+    CountResponse,
+    FeaturesResponse,
+    ObjectIdsResponse,
+    TokenResponse,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_drift_cache() -> None:
+    reset_drift_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Tier membership                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def test_count_response_is_strict_subclass() -> None:
+    assert issubclass(CountResponse, StrictModel)
+
+
+def test_object_ids_response_is_strict_subclass() -> None:
+    assert issubclass(ObjectIdsResponse, StrictModel)
+
+
+def test_features_response_is_permissive_subclass() -> None:
+    assert issubclass(FeaturesResponse, PermissiveModel)
+
+
+def test_token_response_is_strict_subclass() -> None:
+    assert issubclass(TokenResponse, StrictModel)
+
+
+# --------------------------------------------------------------------------- #
+# CountResponse                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_count_response_accepts_valid_payload() -> None:
+    resp = _parse_response(CountResponse, {"count": 42}, context="ctx")
+    assert resp.count == 42
+
+
+def test_count_response_raises_on_missing_count() -> None:
+    with pytest.raises(RestgdfResponseError) as exc_info:
+        _parse_response(CountResponse, {"no_count_here": 1}, context="url")
+    assert exc_info.value.model_name == "CountResponse"
+    assert exc_info.value.context == "url"
+
+
+def test_count_response_raises_on_bad_type() -> None:
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(CountResponse, {"count": "not-an-int"}, context="url")
+
+
+def test_count_response_tolerates_extra_keys_silently() -> None:
+    # Strict tier: extras are ignored, not raised.
+    resp = _parse_response(
+        CountResponse,
+        {"count": 7, "requestId": "abc", "serverGens": {}},
+        context="ctx",
+    )
+    assert resp.count == 7
+
+
+# --------------------------------------------------------------------------- #
+# ObjectIdsResponse                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def test_object_ids_response_accepts_camelcase() -> None:
+    resp = _parse_response(
+        ObjectIdsResponse,
+        {"objectIdFieldName": "OBJECTID", "objectIds": [1, 2, 3]},
+        context="ctx",
+    )
+    assert resp.object_id_field_name == "OBJECTID"
+    assert resp.object_ids == [1, 2, 3]
+
+
+def test_object_ids_response_accepts_snake_case() -> None:
+    resp = _parse_response(
+        ObjectIdsResponse,
+        {"object_id_field_name": "FID", "object_ids": [9]},
+        context="ctx",
+    )
+    assert resp.object_id_field_name == "FID"
+    assert resp.object_ids == [9]
+
+
+def test_object_ids_response_coerces_null_ids_to_empty_list() -> None:
+    # ArcGIS returns `"objectIds": null` when the query matches zero rows.
+    # The model coerces that to `[]` so consumers can iterate safely.
+    resp = _parse_response(
+        ObjectIdsResponse,
+        {"objectIdFieldName": "OBJECTID", "objectIds": None},
+        context="ctx",
+    )
+    assert resp.object_ids == []
+
+
+def test_object_ids_response_raises_on_missing_field_name() -> None:
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(
+            ObjectIdsResponse,
+            {"objectIds": [1, 2]},
+            context="ctx",
+        )
+
+
+def test_object_ids_response_raises_on_bad_id_type() -> None:
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(
+            ObjectIdsResponse,
+            {"objectIdFieldName": "OBJECTID", "objectIds": "not-a-list"},
+            context="ctx",
+        )
+
+
+def test_object_ids_response_dumps_camelcase_by_alias() -> None:
+    resp = _parse_response(
+        ObjectIdsResponse,
+        {"objectIdFieldName": "OBJECTID", "objectIds": [1]},
+        context="ctx",
+    )
+    dumped = resp.model_dump(by_alias=True)
+    assert dumped == {"objectIdFieldName": "OBJECTID", "objectIds": [1]}
+
+
+# --------------------------------------------------------------------------- #
+# FeaturesResponse                                                             #
+# --------------------------------------------------------------------------- #
+
+
+def test_features_response_accepts_features_as_list_of_dicts() -> None:
+    raw = {
+        "objectIdFieldName": "OBJECTID",
+        "features": [
+            {"attributes": {"OBJECTID": 1}, "geometry": {"x": 0, "y": 0}},
+            {"attributes": {"OBJECTID": 2}},
+        ],
+        "exceededTransferLimit": False,
+    }
+    resp = _parse_response(FeaturesResponse, raw, context="ctx")
+    assert resp.object_id_field_name == "OBJECTID"
+    assert resp.features == raw["features"]
+    # Envelope preserves features as raw dicts (not Feature instances).
+    assert isinstance(resp.features[0], dict)
+    assert resp.exceeded_transfer_limit is False
+
+
+def test_features_response_defaults_features_to_empty_list() -> None:
+    resp = _parse_response(FeaturesResponse, {}, context="ctx")
+    assert resp.features == []
+    assert resp.object_id_field_name is None
+    assert resp.exceeded_transfer_limit is None
+
+
+def test_features_response_logs_unknown_extras_as_drift(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    _parse_response(
+        FeaturesResponse,
+        {"features": [], "mysteryKey": "?"},
+        context="ctx",
+    )
+    assert any(
+        r.levelno == logging.DEBUG and "mysteryKey" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+def test_features_response_accepts_snake_case_aliases() -> None:
+    resp = _parse_response(
+        FeaturesResponse,
+        {
+            "object_id_field_name": "OBJECTID",
+            "features": [],
+            "exceeded_transfer_limit": True,
+        },
+        context="ctx",
+    )
+    assert resp.object_id_field_name == "OBJECTID"
+    assert resp.exceeded_transfer_limit is True
+
+
+# --------------------------------------------------------------------------- #
+# TokenResponse                                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_token_response_accepts_minimal_payload() -> None:
+    resp = _parse_response(
+        TokenResponse,
+        {"token": "xyz", "expires": 32503680000000},
+        context="token-refresh",
+    )
+    assert resp.token == "xyz"
+    assert resp.expires == 32503680000000
+    assert resp.ssl is None
+
+
+def test_token_response_ssl_is_optional_when_present() -> None:
+    resp = _parse_response(
+        TokenResponse,
+        {"token": "xyz", "expires": 1234, "ssl": True},
+        context="ctx",
+    )
+    assert resp.ssl is True
+
+
+def test_token_response_raises_on_missing_token() -> None:
+    with pytest.raises(RestgdfResponseError) as exc_info:
+        _parse_response(
+            TokenResponse,
+            {"expires": 1234},
+            context="ctx",
+        )
+    assert exc_info.value.model_name == "TokenResponse"
+
+
+def test_token_response_raises_on_missing_expires() -> None:
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(TokenResponse, {"token": "x"}, context="ctx")
+
+
+def test_token_response_raises_on_bad_expires_type() -> None:
+    with pytest.raises(RestgdfResponseError):
+        _parse_response(
+            TokenResponse,
+            {"token": "x", "expires": "not-ms"},
+            context="ctx",
+        )

--- a/tests/test_models_scaffolding.py
+++ b/tests/test_models_scaffolding.py
@@ -1,0 +1,67 @@
+"""Scaffolding tests for the pydantic 2.x model integration (S-0).
+
+These tests pin the public contract of the new shared plumbing:
+
+* ``restgdf._logging.get_drift_logger`` returns the ``restgdf.schema_drift``
+  logger with a ``NullHandler`` attached so importing the library is silent
+  by default.
+* ``restgdf._models.RestgdfResponseError`` is the single strict-tier
+  validation exception type, preserves operator-triage context, and
+  subclasses ``ValueError`` (so existing ``except ValueError`` handlers
+  keep working).
+
+Later slices build on this scaffolding; these tests guard against
+accidental renames/moves during the migration.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from restgdf._logging import SCHEMA_DRIFT_LOGGER_NAME, get_drift_logger
+from restgdf._models import RestgdfResponseError
+
+
+def test_drift_logger_is_named_schema_drift() -> None:
+    logger = get_drift_logger()
+    assert logger.name == SCHEMA_DRIFT_LOGGER_NAME == "restgdf.schema_drift"
+
+
+def test_drift_logger_has_null_handler_by_default() -> None:
+    logger = get_drift_logger()
+    assert any(isinstance(h, logging.NullHandler) for h in logger.handlers)
+
+
+def test_drift_logger_does_not_stack_null_handlers_on_repeat_access() -> None:
+    first = get_drift_logger()
+    before = sum(1 for h in first.handlers if isinstance(h, logging.NullHandler))
+    second = get_drift_logger()
+    after = sum(1 for h in second.handlers if isinstance(h, logging.NullHandler))
+    assert first is second
+    assert before == after == 1
+
+
+def test_response_error_subclasses_value_error() -> None:
+    with pytest.raises(ValueError):
+        raise RestgdfResponseError(
+            "boom",
+            model_name="CountResponse",
+            context="https://example/arcgis/rest/services/Foo/FeatureServer/0/query",
+            raw={"count": "not-an-int"},
+        )
+
+
+def test_response_error_preserves_triage_context() -> None:
+    raw = {"error": {"code": 498, "message": "Invalid Token"}}
+    err = RestgdfResponseError(
+        "token invalid",
+        model_name="TokenResponse",
+        context="token refresh",
+        raw=raw,
+    )
+    assert err.model_name == "TokenResponse"
+    assert err.context == "token refresh"
+    assert err.raw is raw
+    assert str(err) == "token invalid"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,134 @@
+"""Public API surface tests for restgdf v2.0.0.
+
+Enumerates every name in :data:`restgdf.__all__` and asserts each is
+importable and of the expected kind (class / callable / module).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+import restgdf
+
+
+_EXPECTED_CLASSES = {
+    "AGOLUserPass",
+    "ArcGISTokenSession",
+    "CountResponse",
+    "CrawlError",
+    "CrawlReport",
+    "CrawlServiceEntry",
+    "Directory",
+    "ErrorInfo",
+    "ErrorResponse",
+    "Feature",
+    "FeatureLayer",
+    "FeaturesResponse",
+    "FieldSpec",
+    "LayerMetadata",
+    "ObjectIdsResponse",
+    "RestgdfResponseError",
+    "ServiceInfo",
+    "Settings",
+    "TokenResponse",
+    "TokenSessionConfig",
+}
+
+_EXPECTED_CALLABLES = {
+    "get_settings",
+}
+
+_EXPECTED_MODULES = {
+    "compat",
+    "utils",
+}
+
+
+def test_public_all_is_complete() -> None:
+    assert set(restgdf.__all__) == (
+        _EXPECTED_CLASSES | _EXPECTED_CALLABLES | _EXPECTED_MODULES
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED_CLASSES))
+def test_class_is_importable_and_is_a_class(name: str) -> None:
+    obj = getattr(restgdf, name)
+    assert inspect.isclass(obj), f"{name} should be a class, got {type(obj)!r}"
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED_CALLABLES))
+def test_callable_is_importable_and_callable(name: str) -> None:
+    obj = getattr(restgdf, name)
+    assert callable(obj), f"{name} should be callable"
+    assert not inspect.isclass(obj), f"{name} should not be a class"
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED_MODULES))
+def test_module_is_importable_and_is_a_module(name: str) -> None:
+    obj = getattr(restgdf, name)
+    assert inspect.ismodule(obj), f"{name} should be a module"
+
+
+def test_all_names_in_all_are_attributes() -> None:
+    for name in restgdf.__all__:
+        assert hasattr(restgdf, name), f"restgdf.{name} in __all__ but missing"
+
+
+def test_flat_import_forms_work() -> None:
+    from restgdf import (  # noqa: F401
+        AGOLUserPass,
+        ArcGISTokenSession,
+        CountResponse,
+        CrawlError,
+        CrawlReport,
+        CrawlServiceEntry,
+        Directory,
+        ErrorInfo,
+        ErrorResponse,
+        Feature,
+        FeatureLayer,
+        FeaturesResponse,
+        FieldSpec,
+        LayerMetadata,
+        ObjectIdsResponse,
+        RestgdfResponseError,
+        ServiceInfo,
+        Settings,
+        TokenResponse,
+        TokenSessionConfig,
+        compat,
+        get_settings,
+        utils,
+    )
+
+
+def test_models_are_pydantic_basemodels() -> None:
+    from pydantic import BaseModel
+
+    model_names = {
+        "AGOLUserPass",
+        "CountResponse",
+        "CrawlError",
+        "CrawlReport",
+        "CrawlServiceEntry",
+        "ErrorInfo",
+        "ErrorResponse",
+        "Feature",
+        "FeaturesResponse",
+        "FieldSpec",
+        "LayerMetadata",
+        "ObjectIdsResponse",
+        "ServiceInfo",
+        "Settings",
+        "TokenResponse",
+        "TokenSessionConfig",
+    }
+    for name in model_names:
+        cls = getattr(restgdf, name)
+        assert issubclass(cls, BaseModel), f"{name} must be a pydantic BaseModel"
+
+
+def test_error_is_exception_subclass() -> None:
+    assert issubclass(restgdf.RestgdfResponseError, Exception)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,197 @@
+"""Tests for :mod:`restgdf._models._settings`.
+
+TDD-first: this file is authored before the module it exercises (S-7).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from restgdf._models import RestgdfResponseError
+from restgdf._models._settings import (
+    Settings,
+    get_settings,
+    reset_settings_cache,
+)
+
+
+# ---------------------------------------------------------------------------
+# Autouse fixture: isolate cache across tests.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    reset_settings_cache()
+    yield
+    reset_settings_cache()
+
+
+# ---------------------------------------------------------------------------
+# Baseline structure
+# ---------------------------------------------------------------------------
+
+
+def test_settings_is_basemodel():
+    assert issubclass(Settings, BaseModel)
+
+
+def test_default_values_are_sensible():
+    s = Settings()
+    assert isinstance(s.chunk_size, int) and s.chunk_size > 0
+    assert isinstance(s.timeout_seconds, float) and s.timeout_seconds > 0
+    # default user_agent derives from restgdf.__version__
+    assert s.user_agent.startswith("restgdf/")
+    assert s.log_level == "WARNING"
+    assert s.token_url.startswith("https://")
+    assert isinstance(s.refresh_threshold_seconds, int)
+    assert s.default_headers_json is None
+
+
+def test_from_env_empty_mapping_equals_defaults():
+    assert Settings.from_env({}).model_dump() == Settings().model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Env var parsing
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_reads_os_environ_by_default(monkeypatch):
+    monkeypatch.setenv("RESTGDF_CHUNK_SIZE", "777")
+    s = Settings.from_env()
+    assert s.chunk_size == 777
+
+
+def test_from_env_chunk_size_coerced_to_int():
+    s = Settings.from_env({"RESTGDF_CHUNK_SIZE": "500"})
+    assert s.chunk_size == 500
+
+
+def test_from_env_chunk_size_bad_value_raises_response_error():
+    with pytest.raises(RestgdfResponseError) as excinfo:
+        Settings.from_env({"RESTGDF_CHUNK_SIZE": "not_a_number"})
+    assert excinfo.value.model_name == "Settings"
+    assert "RESTGDF_CHUNK_SIZE" in str(excinfo.value)
+
+
+def test_from_env_timeout_coerced_to_float():
+    s = Settings.from_env({"RESTGDF_TIMEOUT_SECONDS": "5.5"})
+    assert s.timeout_seconds == 5.5
+
+
+def test_from_env_timeout_bad_value_raises():
+    with pytest.raises(RestgdfResponseError):
+        Settings.from_env({"RESTGDF_TIMEOUT_SECONDS": "abc"})
+
+
+def test_from_env_refresh_threshold_coerced_to_int():
+    s = Settings.from_env({"RESTGDF_REFRESH_THRESHOLD": "120"})
+    assert s.refresh_threshold_seconds == 120
+
+
+def test_from_env_refresh_threshold_bad_value_raises():
+    with pytest.raises(RestgdfResponseError):
+        Settings.from_env({"RESTGDF_REFRESH_THRESHOLD": "nope"})
+
+
+def test_from_env_user_agent_override():
+    s = Settings.from_env({"RESTGDF_USER_AGENT": "my-agent/1.0"})
+    assert s.user_agent == "my-agent/1.0"
+
+
+def test_from_env_token_url_override():
+    s = Settings.from_env({"RESTGDF_TOKEN_URL": "https://example.com/token"})
+    assert s.token_url == "https://example.com/token"
+
+
+def test_from_env_log_level_override():
+    s = Settings.from_env({"RESTGDF_LOG_LEVEL": "DEBUG"})
+    assert s.log_level == "DEBUG"
+
+
+def test_from_env_default_headers_json_passthrough():
+    raw = '{"X-Foo": "bar"}'
+    s = Settings.from_env({"RESTGDF_DEFAULT_HEADERS_JSON": raw})
+    assert s.default_headers_json == raw
+
+
+# ---------------------------------------------------------------------------
+# Case sensitivity — env keys must match exactly (uppercase RESTGDF_ prefix).
+# ---------------------------------------------------------------------------
+
+
+def test_from_env_is_case_sensitive():
+    s = Settings.from_env({"restgdf_chunk_size": "999"})
+    # lowercase key must be ignored; defaults apply
+    assert s.chunk_size == Settings().chunk_size
+
+
+# ---------------------------------------------------------------------------
+# Validation via pydantic is also wrapped as RestgdfResponseError.
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_field_value_via_direct_construction_raises_validation_error():
+    with pytest.raises(ValidationError):
+        Settings(chunk_size=-1)
+
+
+def test_from_env_wraps_validation_error_as_response_error():
+    # chunk_size must be positive; supply 0 via env → RestgdfResponseError.
+    with pytest.raises(RestgdfResponseError):
+        Settings.from_env({"RESTGDF_CHUNK_SIZE": "0"})
+
+
+def test_invalid_log_level_rejected():
+    with pytest.raises(ValidationError):
+        Settings(log_level="LOUD")
+
+
+def test_log_level_is_normalized_to_upper():
+    assert Settings(log_level="debug").log_level == "DEBUG"
+
+
+def test_invalid_token_url_scheme_rejected():
+    with pytest.raises(ValidationError):
+        Settings(token_url="ftp://example.com")
+
+
+# ---------------------------------------------------------------------------
+# Immutability — Settings is frozen.
+# ---------------------------------------------------------------------------
+
+
+def test_settings_is_frozen():
+    s = Settings()
+    with pytest.raises(ValidationError):
+        s.chunk_size = 123  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# get_settings caching behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_get_settings_returns_cached_instance():
+    a = get_settings()
+    b = get_settings()
+    assert a is b
+
+
+def test_reset_settings_cache_forces_new_instance(monkeypatch):
+    a = get_settings()
+    monkeypatch.setenv("RESTGDF_CHUNK_SIZE", "321")
+    # Without reset, cached value persists.
+    assert get_settings() is a
+    reset_settings_cache()
+    b = get_settings()
+    assert b is not a
+    assert b.chunk_size == 321
+
+
+def test_get_settings_reads_current_env_on_first_call(monkeypatch):
+    monkeypatch.setenv("RESTGDF_USER_AGENT", "probe/9.9")
+    s = get_settings()
+    assert s.user_agent == "probe/9.9"

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -105,7 +105,7 @@ def test_token_needs_update_branching():
 
     token_session = ArcGISTokenSession(
         session=RecordingTokenSession(),
-        credentials=AGOLUserPass("user", "password"),
+        credentials=AGOLUserPass(username="user", password="password"),
     )
     assert token_session.token_needs_update() is True
 
@@ -127,7 +127,7 @@ def test_token_needs_update_branching():
 async def test_update_token_if_needed_only_refreshes_when_required():
     token_session = ArcGISTokenSession(
         session=RecordingTokenSession(),
-        credentials=AGOLUserPass("user", "password"),
+        credentials=AGOLUserPass(username="user", password="password"),
         token="abc123",
         expires=32503680000000,
     )
@@ -175,7 +175,7 @@ async def test_arcgistokensession_refreshes_and_injects_auth():
 async def test_arcgistokensession_context_manager_updates_token():
     token_session = ArcGISTokenSession(
         session=RecordingTokenSession(),
-        credentials=AGOLUserPass("user", "password"),
+        credentials=AGOLUserPass(username="user", password="password"),
     )
 
     async with token_session as active_session:
@@ -190,7 +190,7 @@ async def test_arcgistokensession_respects_explicit_token_in_request():
     session = RecordingTokenSession()
     token_session = ArcGISTokenSession(
         session=session,
-        credentials=AGOLUserPass("user", "password"),
+        credentials=AGOLUserPass(username="user", password="password"),
     )
 
     await token_session.post(

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,119 +1,83 @@
-"""Phase 3 contract tests for :mod:`restgdf._types`.
+"""Deprecation contract for :mod:`restgdf._types`.
 
-These pin the shape of the public TypedDicts so that parsers
-in :mod:`restgdf.utils._metadata`, :mod:`restgdf.utils._query`, and the
-orchestrators in :mod:`restgdf.utils.getinfo` have a single source of
-truth for the ArcGIS REST response shapes they consume.
-
-TypedDicts are dicts at runtime; these tests verify:
-* The symbols are importable from ``restgdf._types``.
-* Each TypedDict declares the keys the parsers actually access.
-* Real ArcGIS-shaped payloads satisfy the schemas when passed through
-  the parsers that were retrofit to consume them.
+The TypedDicts that used to live in this module are replaced by pydantic
+models in :mod:`restgdf._models`. ``restgdf._types`` is retained as a
+lazy-deprecation shim: importing any legacy name emits a
+``DeprecationWarning`` and returns the pydantic replacement.
 """
 
 from __future__ import annotations
 
+import importlib
+import warnings
+
 import pytest
+
+pytestmark = pytest.mark.compat
+
+
+_LEGACY_NAMES = (
+    "FieldSpec",
+    "LayerMetadata",
+    "ServiceInfo",
+    "CountResponse",
+    "ObjectIdsResponse",
+    "Feature",
+    "FeaturesResponse",
+    "ErrorInfo",
+    "ErrorResponse",
+    "CrawlError",
+    "CrawlServiceEntry",
+    "CrawlReport",
+)
 
 
 def test_types_module_importable() -> None:
     import restgdf._types as t  # noqa: F401
 
 
-def test_public_typed_dicts_exist() -> None:
-    from restgdf import _types as t
+@pytest.mark.parametrize("name", _LEGACY_NAMES)
+def test_legacy_name_emits_deprecation_warning(name: str) -> None:
+    import restgdf._types as t
 
-    for name in (
-        "FieldSpec",
-        "LayerMetadata",
-        "ServiceInfo",
-        "CountResponse",
-        "ObjectIdsResponse",
-        "Feature",
-        "FeaturesResponse",
-        "ErrorInfo",
-        "ErrorResponse",
-    ):
-        assert hasattr(t, name), f"restgdf._types.{name} missing"
+    with pytest.warns(DeprecationWarning, match=rf"restgdf\._types\.{name}"):
+        obj = getattr(t, name)
+    assert obj is not None
 
 
-def test_field_spec_required_keys() -> None:
-    from restgdf._types import FieldSpec
+@pytest.mark.parametrize("name", _LEGACY_NAMES)
+def test_legacy_name_resolves_to_pydantic_model(name: str) -> None:
+    from pydantic import BaseModel
 
-    required: frozenset[str] = getattr(FieldSpec, "__required_keys__", frozenset())
-    assert {"name", "type"}.issubset(required)
+    import restgdf._types as t
 
-
-def test_layer_metadata_optional_keys_include_url_and_feature_count() -> None:
-    from restgdf._types import LayerMetadata
-
-    optional: frozenset[str] = getattr(LayerMetadata, "__optional_keys__", frozenset())
-    assert "url" in optional
-    assert "feature_count" in optional
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        obj = getattr(t, name)
+    assert isinstance(obj, type)
+    assert issubclass(obj, BaseModel)
 
 
-def test_count_response_requires_count_key() -> None:
-    from restgdf._types import CountResponse
+def test_unknown_attribute_raises_attribute_error() -> None:
+    import restgdf._types as t
 
-    required: frozenset[str] = getattr(CountResponse, "__required_keys__", frozenset())
-    assert "count" in required
-
-
-def test_object_ids_response_requires_both_keys() -> None:
-    from restgdf._types import ObjectIdsResponse
-
-    required: frozenset[str] = getattr(
-        ObjectIdsResponse,
-        "__required_keys__",
-        frozenset(),
-    )
-    assert {"objectIdFieldName", "objectIds"}.issubset(required)
+    with pytest.raises(AttributeError):
+        _ = t.DoesNotExist  # type: ignore[attr-defined]
 
 
-def test_feature_requires_attributes_key() -> None:
-    from restgdf._types import Feature
+def test_legacy_names_match_public_api_models() -> None:
+    """Every legacy alias must resolve to the canonical public-API class."""
+    import restgdf
+    import restgdf._types as t
 
-    required: frozenset[str] = getattr(Feature, "__required_keys__", frozenset())
-    assert "attributes" in required
-
-
-def test_typed_dicts_are_dict_instances_at_runtime() -> None:
-    from restgdf._types import CountResponse, FieldSpec
-
-    fs: FieldSpec = {"name": "OBJECTID", "type": "esriFieldTypeOID"}
-    cr: CountResponse = {"count": 42}
-    assert isinstance(fs, dict)
-    assert isinstance(cr, dict)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        for name in _LEGACY_NAMES:
+            legacy = getattr(t, name)
+            canonical = getattr(restgdf, name)
+            assert legacy is canonical, f"{name}: legacy alias drifted"
 
 
-@pytest.mark.compat
-def test_metadata_parsers_still_accept_arcgis_shaped_dicts() -> None:
-    from restgdf._types import LayerMetadata
-    from restgdf.utils._metadata import (
-        get_max_record_count,
-        get_name,
-        get_object_id_field,
-        getfields,
-        getfields_df,
-        supports_pagination,
-    )
-
-    layer: LayerMetadata = {
-        "name": "Some Layer",
-        "type": "Feature Layer",
-        "maxRecordCount": 2000,
-        "supportsPagination": True,
-        "advancedQueryCapabilities": {"supportsPagination": True},
-        "fields": [
-            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
-            {"name": "FOO", "type": "esriFieldTypeString"},
-        ],
-    }
-
-    assert get_name(layer) == "Some Layer"
-    assert get_max_record_count(layer) == 2000
-    assert get_object_id_field(layer) == "OBJECTID"
-    assert supports_pagination(layer) is True
-    assert getfields(layer) == ["OBJECTID", "FOO"]
-    assert list(getfields_df(layer).columns) == ["name", "type"]
+def test_module_all_lists_legacy_names() -> None:
+    mod = importlib.import_module("restgdf._types")
+    assert set(mod.__all__) == set(_LEGACY_NAMES)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,24 @@
+"""restgdf v2.0.0 version contract."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import restgdf
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - fallback for 3.9/3.10
+    import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+
+
+def test_version_is_v2() -> None:
+    assert restgdf.__version__ == "2.0.0"
+
+
+def test_version_matches_pyproject() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    pyproject = tomllib.loads((repo_root / "pyproject.toml").read_text())
+    assert pyproject["project"]["version"] == restgdf.__version__
+    assert pyproject["tool"]["bumpver"]["current_version"] == restgdf.__version__


### PR DESCRIPTION
## Summary

Comprehensive integration of pydantic 2.13.3 — ships as `restgdf 2.0.0` (breaking change).

Every ArcGIS response path is now routed through typed pydantic models with two-tier validation:
- `PermissiveModel` (`extra=allow` + drift logging) for vendor variance
- `StrictModel` (`extra=ignore` + typed `RestgdfResponseError`) for operation-critical envelopes

## What's new

**Public types in `restgdf/_models/`:**
- Responses: `LayerMetadata`, `ServiceInfo`, `FieldSpec`, `Feature`, `FeaturesResponse`, `CountResponse`, `ObjectIdsResponse`, `TokenResponse`, `ErrorResponse`
- Crawl: `CrawlReport`, `CrawlServiceEntry`, `CrawlError`
- Credentials: `AGOLUserPass` (`SecretStr` password), `TokenSessionConfig`
- Config: `Settings` + `get_settings()` (`RESTGDF_*` env vars — no `pydantic-settings` dep)

**Infrastructure:**
- `restgdf.schema_drift` logger — silent by default, opt-in DEBUG for vendor-variance observability
- `RestgdfResponseError(ValueError)` with `model_name`/`context`/`raw`
- `restgdf.compat.as_dict` / `as_json_dict` — migration helpers for downstream callers

## Breaking changes

| API | 1.x | 2.0 |
|---|---|---|
| `FeatureLayer.metadata` | `dict` | `LayerMetadata` |
| `Directory.metadata` | `dict` | `LayerMetadata` |
| `Directory.services` | `list[dict]` | `list[CrawlServiceEntry]` |
| `Directory.report` | — | `Optional[CrawlReport]` (new) |
| `Directory.crawl()` | `list[dict]` | `list[CrawlServiceEntry]` |
| `get_metadata()` | `dict` | `LayerMetadata` |
| `restgdf._types.*` | `TypedDict` | deprecated aliases resolving to pydantic models (`DeprecationWarning` on import) |

See `MIGRATION.md` for a full guide with before/after snippets.

## Test plan

- **419 tests pass**, 2 skipped (up from 235 on `main`)
- **Coverage 99%** (gate 97%)
- **Pre-commit all green** (ruff, mypy, black, bandit, pyupgrade)

## Docs

- `MIGRATION.md` — 1.x → 2.0 migration guide
- `CHANGELOG.md` — 2.0.0 release notes
- `docs/migration.rst`, `docs/models.rst` — Sphinx pages
- `README.md` — "What's new in 2.0" section

## Implementation approach

Delivered as 11 vertical TDD slices (S-0 foundation → S-10 verification) executed via a fleet of parallel sub-agents. Each slice wrote tests first, migrated one concern, and validated gates before proceeding.