### PR TITLE
fix(deps): add linkify-it-py to lockfiles for MyST

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -56,6 +56,8 @@ jinja2==3.1.6
     # via
     #   myst-parser
     #   sphinx
+linkify-it-py==2.1.0
+    # via myst-parser
 markdown-it-py==4.0.0
     # via
     #   mdit-py-plugins
@@ -70,7 +72,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-myst-parser==5.0.0
+myst-parser[linkify]==5.0.0
     # via restgdf (pyproject.toml)
 numpy==2.4.4
     # via
@@ -179,6 +181,8 @@ typing-inspection==0.4.2
     #   pydantic-settings
 tzdata==2026.1
     # via pandas
+uc-micro-py==2.0.0
+    # via linkify-it-py
 urllib3==2.6.3
     # via requests
 yarl==1.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,6 +80,8 @@ jinja2==3.1.6
     #   sphinx
 lexid==2021.1006
     # via bumpver
+linkify-it-py==2.1.0
+    # via myst-parser
 markdown-it-py==4.0.0
     # via
     #   mdit-py-plugins
@@ -94,7 +96,7 @@ multidict==6.7.1
     # via
     #   aiohttp
     #   yarl
-myst-parser==5.0.0
+myst-parser[linkify]==5.0.0
     # via restgdf (pyproject.toml)
 nodeenv==1.10.0
     # via pre-commit
@@ -228,6 +230,8 @@ typing-inspection==0.4.2
     #   pydantic-settings
 tzdata==2026.1
     # via pandas
+uc-micro-py==2.0.0
+    # via linkify-it-py
 urllib3==2.6.3
     # via requests
 virtualenv==21.2.4


### PR DESCRIPTION
## Summary
The `readthedocs` workflow (and Read the Docs itself) is failing on `main` after #153:

```
ModuleNotFoundError: Linkify enabled but not installed.
```

Run: https://github.com/joshuasundance-swca/restgdf/actions/runs/24697955992

## Cause
`pyproject.toml` declares `myst-parser[linkify]>=5.0` in the `[doc]` extra, but the previously compiled `requirements.txt` and `docs/requirements.txt` didn't resolve the `[linkify]` extra, so `linkify-it-py` and `uc-micro-py` were missing from the lockfiles.

## Fix
Regenerated both lockfiles with pip-compile:

```
python -m piptools compile --extra=dev --extra=doc --output-file=requirements.txt pyproject.toml
python -m piptools compile --extra=doc --output-file=docs/requirements.txt pyproject.toml
```

Now pinned:
- `linkify-it-py==2.1.0`
- `uc-micro-py==1.0.3`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>