### PR TITLE
Revamp discoverability metadata for 2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
-## [2.0.0]
+## [2.0.0] - 2026-04-20
 
 **Major release — pydantic 2.13 integration.** See
 [`MIGRATION.md`](./MIGRATION.md) for a complete breaking-changes table and
@@ -52,7 +52,9 @@ migration recipes.
 
 - Added `pydantic>=2.13.3,<3`.
 
-## [1.x]
+## 1.x
 
-Earlier releases were not formally tracked here. See the Git tag history
-and PyPI release notes for pre-2.0 changes.
+Earlier releases were not formally tracked here. See the
+[Git tag history](https://github.com/joshuasundance-swca/restgdf/tags) and
+[PyPI release notes](https://pypi.org/project/restgdf/#history) for pre-2.0
+changes.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,27 @@
+cff-version: 1.2.0
+message: "If you use restgdf in academic or research work, please cite it as below."
+type: software
+title: restgdf
+abstract: >-
+  Async-first Python library for reading ArcGIS/Esri REST FeatureServer and
+  MapServer layers into GeoPandas GeoDataFrames, with pydantic-validated
+  response models and automatic pagination past the server maxRecordCount.
+authors:
+  - family-names: Bailey
+    given-names: Joshua Sundance
+repository-code: "https://github.com/joshuasundance-swca/restgdf"
+url: "https://restgdf.readthedocs.io/"
+license: MIT
+version: 2.0.0
+date-released: "2026-04-20"
+keywords:
+  - geopandas
+  - esri
+  - arcgis
+  - async
+  - aiohttp
+  - pydantic
+  - rest
+  - gis
+  - featureserver
+  - mapserver

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Joshua Sundance Bailey
+Copyright (c) 2023-present Joshua Sundance Bailey
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -3,31 +3,34 @@
 improved esri rest io for geopandas
 
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/license/bsd-3-clause/)
-[![python](https://img.shields.io/badge/Python-3.9+-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
-[![dev python](https://img.shields.io/badge/Dev%2FCI%20Python-3.14-3776AB.svg?style=flat&logo=python&logoColor=white)](https://www.python.org)
+<!-- Package -->
+[![PyPI version](https://img.shields.io/pypi/v/restgdf.svg)](https://pypi.org/project/restgdf/)
+[![Python versions](https://img.shields.io/pypi/pyversions/restgdf.svg)](https://pypi.org/project/restgdf/)
+[![Downloads](https://static.pepy.tech/badge/restgdf/month)](https://pepy.tech/project/restgdf)
+[![License](https://img.shields.io/github/license/joshuasundance-swca/restgdf.svg)](https://github.com/joshuasundance-swca/restgdf/blob/main/LICENSE)
 
+<!-- Build & coverage -->
+[![CI](https://img.shields.io/github/actions/workflow/status/joshuasundance-swca/restgdf/pytest.yml?event=pull_request&label=CI&logo=github)](https://github.com/joshuasundance-swca/restgdf/actions/workflows/pytest.yml)
 [![Publish to PyPI](https://github.com/joshuasundance-swca/restgdf/actions/workflows/publish_on_pypi.yml/badge.svg)](https://github.com/joshuasundance-swca/restgdf/actions/workflows/publish_on_pypi.yml)
-![GitHub tag (with filter)](https://img.shields.io/github/v/tag/joshuasundance-swca/restgdf)
+[![coverage](https://raw.githubusercontent.com/joshuasundance-swca/restgdf/main/coverage.svg)](https://github.com/joshuasundance-swca/restgdf/blob/main/COVERAGE.md)
+
+<!-- Docs & discovery -->
 [![Read the Docs](https://img.shields.io/readthedocs/restgdf)](https://restgdf.readthedocs.io/en/latest/)
+[![llms.txt](https://img.shields.io/badge/llms.txt-green)](https://restgdf.readthedocs.io/en/latest/llms.txt)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/joshuasundance-swca/restgdf)
 
-![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/joshuasundance-swca/restgdf)
-![Code Climate issues](https://img.shields.io/codeclimate/issues/joshuasundance-swca/restgdf)
-![Code Climate technical debt](https://img.shields.io/codeclimate/tech-debt/joshuasundance-swca/restgdf)
-[![coverage](coverage.svg)](./COVERAGE.md)
-
+<!-- Built with & code quality -->
+[![Pydantic v2](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v1.json)](https://github.com/charliermarsh/ruff)
-[![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v1.json)](https://github.com/astral-sh/ruff)
+[![Checked with mypy](https://www.mypy-lang.org/static/mypy_badge.svg)](https://mypy-lang.org/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
-![Known Vulnerabilities](https://snyk.io/test/github/joshuasundance-swca/restgdf/badge.svg)
 
 ## What's new in 2.0
 
 restgdf 2.0 is a **major release** built on [pydantic 2.13](https://docs.pydantic.dev/).
-See [`MIGRATION.md`](./MIGRATION.md) for the full breaking-changes table and
+See [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md) for the full breaking-changes table and
 code-rewrite recipes.
 
 - **Typed responses.** `FeatureLayer.metadata`, `Directory.metadata` /
@@ -163,12 +166,31 @@ name, max_record_count, arcgis_dict = asyncio.run(main())
 ```
 
 Need a plain dict during a transitional migration? Use
-`restgdf.compat.as_dict(md)`. See [`MIGRATION.md`](./MIGRATION.md) for
+`restgdf.compat.as_dict(md)`. See [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md) for
 the full 1.x → 2.0 rewrite table.
 
 # Documentation
 
-https://restgdf.readthedocs.io/
+Full docs live at **<https://restgdf.readthedocs.io/>** (hosted by Read the Docs).
+
+## Docs for humans *and* LLMs
+
+Every page is published in three formats so you can feed it to a teammate
+*or* to a language model without any preprocessing:
+
+| Format                  | URL                                                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- |
+| Rendered HTML           | <https://restgdf.readthedocs.io/en/latest/>                                                              |
+| Plain Markdown (per page) | append `.md` to any page — e.g. <https://restgdf.readthedocs.io/en/latest/quickstart.html.md>            |
+| [llms.txt][llmstxt] index | <https://restgdf.readthedocs.io/en/latest/llms.txt>                                                      |
+| llms-full.txt (all pages) | <https://restgdf.readthedocs.io/en/latest/llms-full.txt>                                                 |
+| Ask DeepWiki           | <https://deepwiki.com/joshuasundance-swca/restgdf>                                                       |
+
+[llmstxt]: https://llmstxt.org/
+
+Point your coding agent or RAG pipeline at `llms-full.txt` for the entire
+reference in a single file, or at `llms.txt` for a concise table of
+contents.
 
 # Uses
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor release line of `restgdf` receives security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+| < 1.0   | :x:                |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.**
+
+Report vulnerabilities privately via GitHub's
+[private vulnerability reporting](https://github.com/joshuasundance-swca/restgdf/security/advisories/new)
+feature.
+
+You should receive an initial acknowledgement within **72 hours**. If the
+issue is confirmed, we will work with you on a coordinated disclosure and
+release a patch as quickly as is practical.
+
+## Supply-chain integrity
+
+`restgdf` releases are published to PyPI via
+[Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC — no
+long-lived API tokens) and every release artifact is signed with
+[Sigstore](https://www.sigstore.dev/). The `.sigstore` bundles are attached to
+the corresponding
+[GitHub release](https://github.com/joshuasundance-swca/restgdf/releases) and
+can be verified with the
+[`sigstore` CLI](https://pypi.org/project/sigstore/):
+
+```bash
+python -m pip install sigstore
+python -m sigstore verify identity \
+  --cert-identity "https://github.com/joshuasundance-swca/restgdf/.github/workflows/publish_on_pypi.yml@refs/tags/<TAG>" \
+  --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
+  <file>
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   restgdf:
     image: restgdf

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,15 +3,43 @@ restgdf
 
    *Improved Esri REST I/O for GeoPandas.*
 
+.. Package
 .. image:: https://img.shields.io/pypi/v/restgdf.svg
    :target: https://pypi.org/project/restgdf/
    :alt: PyPI version
-.. image:: https://img.shields.io/badge/Python-3.9+-3776AB.svg?style=flat&logo=python&logoColor=white
-   :target: https://www.python.org
+.. image:: https://img.shields.io/pypi/pyversions/restgdf.svg
+   :target: https://pypi.org/project/restgdf/
    :alt: Python versions
-.. image:: https://img.shields.io/readthedocs/restgdf
-   :target: https://restgdf.readthedocs.io/
-   :alt: Read the Docs
+.. image:: https://static.pepy.tech/badge/restgdf/month
+   :target: https://pepy.tech/project/restgdf
+   :alt: Downloads
+.. image:: https://img.shields.io/github/license/joshuasundance-swca/restgdf.svg
+   :target: https://github.com/joshuasundance-swca/restgdf/blob/main/LICENSE
+   :alt: License
+
+.. Build & coverage
+.. image:: https://img.shields.io/github/actions/workflow/status/joshuasundance-swca/restgdf/pytest.yml?event=pull_request&label=CI&logo=github
+   :target: https://github.com/joshuasundance-swca/restgdf/actions/workflows/pytest.yml
+   :alt: CI
+.. image:: https://github.com/joshuasundance-swca/restgdf/actions/workflows/publish_on_pypi.yml/badge.svg
+   :target: https://github.com/joshuasundance-swca/restgdf/actions/workflows/publish_on_pypi.yml
+   :alt: Publish to PyPI
+.. image:: https://raw.githubusercontent.com/joshuasundance-swca/restgdf/main/coverage.svg
+   :target: https://github.com/joshuasundance-swca/restgdf/blob/main/COVERAGE.md
+   :alt: coverage
+
+.. Docs & discovery (RTD badge omitted -- you're reading RTD)
+.. image:: https://img.shields.io/badge/llms.txt-green
+   :target: https://restgdf.readthedocs.io/en/latest/llms.txt
+   :alt: llms.txt
+.. image:: https://deepwiki.com/badge.svg
+   :target: https://deepwiki.com/joshuasundance-swca/restgdf
+   :alt: Ask DeepWiki
+
+.. Built with
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json
+   :target: https://docs.pydantic.dev/latest/contributing/#badges
+   :alt: Pydantic v2
 
 ``restgdf`` is an async-first wrapper around Esri/ArcGIS REST Feature and Map
 services. It reads *all* features past the server's ``maxRecordCount``, returns
@@ -76,6 +104,13 @@ Explore the docs
       :link-type: doc
 
       Upgrading from restgdf 1.x? The breaking-changes table and rewrite recipes live here.
+
+   .. grid-item-card:: 🤖 Docs for LLMs
+      :link: https://restgdf.readthedocs.io/en/latest/llms.txt
+      :link-type: url
+
+      Every page is also published as plain Markdown (append ``.md`` to any URL),
+      plus ``llms.txt`` / ``llms-full.txt`` indexes for RAG pipelines and coding agents.
 
 .. toctree::
    :hidden:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ build-backend = "setuptools.build_meta"
 include = ["restgdf*"]
 exclude = ["tests*"]
 
+[tool.setuptools.package-data]
+restgdf = ["py.typed"]
+
 [project]
 name = "restgdf"
 version = "2.0.0"
@@ -24,6 +27,12 @@ dependencies = [
 license = "MIT"
 license-files = ["LICENSE"]
 classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: AsyncIO",
+    "Framework :: Pydantic",
+    "Framework :: Pydantic :: 2",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
@@ -33,11 +42,32 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Topic :: Scientific/Engineering :: GIS",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
-keywords = ["geopandas", "esri", "arcgis"]
+keywords = [
+    "geopandas",
+    "esri",
+    "arcgis",
+    "async",
+    "aiohttp",
+    "pydantic",
+    "rest",
+    "gis",
+    "featureserver",
+    "mapserver",
+]
 requires-python = ">=3.9"
 [project.urls]
 Homepage = "https://github.com/joshuasundance-swca/restgdf"
+Documentation = "https://restgdf.readthedocs.io/"
+Repository = "https://github.com/joshuasundance-swca/restgdf"
+Issues = "https://github.com/joshuasundance-swca/restgdf/issues"
+Changelog = "https://github.com/joshuasundance-swca/restgdf/blob/main/CHANGELOG.md"
+"Security Policy" = "https://github.com/joshuasundance-swca/restgdf/security/policy"
+"Ask DeepWiki" = "https://deepwiki.com/joshuasundance-swca/restgdf"
+"llms.txt" = "https://restgdf.readthedocs.io/en/latest/llms.txt"
 
 
 [project.optional-dependencies]
@@ -73,6 +103,7 @@ push = true
 [tool.bumpver.file_patterns]
 "pyproject.toml" = ['current_version = "{version}"', 'version = "{version}"']
 "restgdf/__init__.py" = ['__version__ = "{version}"']
+"CITATION.cff" = ['version: {version}']
 
 
 [tool.coverage.run]


### PR DESCRIPTION
Final PR before the 2.0.0 release — discoverability metadata + community files + pre-release audit.

## Badges & docs
- **README** + **docs/index.rst**: reorganized into 4 logical groups (Package / Build & coverage / Docs & discovery / Built with & code quality).
- Dropped stale Code Climate (retired → Qlty) + broken Snyk; added DeepWiki, llms.txt, PyPI suite, pepy.tech downloads, Pydantic v2 endpoint, Ruff, https mypy.
- Switched all image/doc URLs to absolute so they render correctly on PyPI.
- Docs variant omits the self-referential RTD badge and the contributor-noise tooling row.
- Added a `Docs for humans *and* LLMs` section advertising llms.txt + the markdown docs surface.

## Packaging metadata (`pyproject.toml`)
- 16 classifiers (Dev Status 5 :: Production/Stable, Typing :: Typed, Framework :: Pydantic :: 2).
- 10 keywords.
- 7 `project.urls` including Security Policy, DeepWiki, llms.txt, Changelog.
- `[tool.setuptools.package-data]` ships the new `py.typed` marker.
- `CITATION.cff` added to `[tool.bumpver.file_patterns]` so `version:` auto-syncs on future bumps.

## Community files
- **SECURITY.md** — supported versions, GitHub private vulnerability reporting link, sigstore/trusted-publishing verification command.
- **CITATION.cff** — CFF v1.2.0 (GitHub `Cite this repository` + Zenodo).
- **restgdf/py.typed** — PEP 561 marker.
- **LICENSE** — `2023` → `2023-present`.
- **CHANGELOG.md** — dated `2.0.0` as `2026-04-20`, fixed broken `[1.x]` link.
- **docker-compose.yml** — dropped deprecated `version:` key.

## Verification
- 419 tests pass (`pytest -q -m 'not network'`)
- pre-commit clean on all changed files
- `python -m build` + `twine check` PASSED on sdist and wheel
- Versions aligned: `pyproject.toml` / `__init__.py` / `CITATION.cff` all `2.0.0`

## Release-day (manual, post-merge)
1. `git tag 2.0.0 && git push --tags` → fires `publish_on_pypi.yml` (trusted publishing → PyPI, sigstore-signed GitHub release).
2. Optionally polish auto-generated release notes to highlight `MIGRATION.md`.

## Known non-blocking flag
`CITATION.cff` `date-released:` is manual (same rhythm as CHANGELOG heading) — bumpver only auto-syncs the `version:` field.
