### PR TITLE
fix(ci): install all runtime extras in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
         cache: pip
     - name: Install Python libraries
       run: |
-        pip install --user -r requirements.txt "setuptools>=61" ".[dev]"
+        pip install --user -r requirements.txt "setuptools>=61" ".[dev,geo,resilience,telemetry]"
     - name: "Run coverage"
       run: |
         coverage run


### PR DESCRIPTION
Post-merge fix for the `coverage` workflow failure on main ([run 24805903414](https://github.com/joshuasundance-swca/restgdf/actions/runs/24805903414)).

## Root cause

`tests/test_resilience_retry.py` imports `restgdf.resilience.ResilientSession` at module level, which requires the `[resilience]` extra (`stamina`). The coverage workflow was installing only `.[dev]`, so test collection failed with:

```
ModuleNotFoundError: No module named 'stamina'
restgdf.errors.OptionalDependencyError:
    The resilience extra is required: pip install restgdf[resilience]
```

## Fix

Align the coverage workflow's install command with the main `pytest` job in `.github/workflows/pytest.yml` (line 59):

```diff
-    pip install --user -r requirements.txt "setuptools>=61" ".[dev]"
+    pip install --user -r requirements.txt "setuptools>=61" ".[dev,geo,resilience,telemetry]"
```

This mirrors the test matrix, so coverage numbers include resilience / telemetry / geo paths instead of under-reporting due to uncollected modules.

## Validation

- Local `pytest -q -m "not network"` passes (1045 passed, 2 deselected) — confirmed during PR #164.
- No source changes; one-line workflow edit.
- The workflow will re-run on merge and regenerate `coverage.svg` / `COVERAGE.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>