### PR TITLE
Harden gate-3 follow-up fixes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -60,6 +60,41 @@ jobs:
       - name: Run tests
         run: python -m pytest -q -m "not network"
 
+  install_combinations:
+    name: install-${{ matrix.label }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: base
+            extras: ""
+          - label: geo
+            extras: "[geo]"
+          - label: resilience
+            extras: "[resilience]"
+          - label: telemetry
+            extras: "[telemetry]"
+          - label: geo-resilience-telemetry
+            extras: "[geo,resilience,telemetry]"
+          - label: dev
+            extras: "[dev]"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package (extras=${{ matrix.label }})
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".${{ matrix.extras }}"
+      - name: Import smoke test
+        run: python -c "import restgdf; print(restgdf.__version__)"
+      - name: Check dependency consistency
+        run: python -m pip check
+
   base_install:
     name: pytest-base-install
     runs-on: ubuntu-latest
@@ -128,13 +163,13 @@ jobs:
   ci:
     name: ci
     if: always()
-    needs: [lint, test, base_install, network, docs]
+    needs: [lint, test, install_combinations, base_install, network, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate job results
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
-            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} docs=${{ needs.docs.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} docs=${{ needs.docs.result }}"
             exit 1
           fi
           echo "All required jobs succeeded."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -136,6 +136,23 @@ jobs:
       - name: Run live network tests
         run: python -m pytest -q -m network --run-network
 
+  stress:
+    name: pytest-stress
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package with all test extras
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,geo,resilience,telemetry]"
+      - name: Run stress tests
+        run: python -m pytest -q -m stress --run-stress
+
   docs:
     name: docs (strict)
     runs-on: ubuntu-latest
@@ -163,13 +180,13 @@ jobs:
   ci:
     name: ci
     if: always()
-    needs: [lint, test, install_combinations, base_install, network, docs]
+    needs: [lint, test, install_combinations, base_install, network, stress, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate job results
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
-            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} docs=${{ needs.docs.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.stress.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} stress=${{ needs.stress.result }} docs=${{ needs.docs.result }}"
             exit 1
           fi
           echo "All required jobs succeeded."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to restgdf are documented here. This project follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Transport typing (R-71, v3-followup T7).** `ArcGISTokenSession` now
+  exposes `close()` and `closed` that delegate to its inner
+  `aiohttp.ClientSession`, making it fully satisfy the
+  `restgdf._client._protocols.AsyncHTTPSession` Protocol. Internal call
+  sites previously typed `aiohttp.ClientSession | ArcGISTokenSession`
+  were widened to `AsyncHTTPSession` across `adapters/stream.py`,
+  `directory/directory.py`, `featurelayer/featurelayer.py`,
+  `utils/crawl.py`, `utils/getgdf.py`, `utils/getinfo.py`,
+  `utils/_query.py`, and `utils/_stats.py`. Zero runtime behavior
+  change — widening to a superset Protocol is backwards-compatible for
+  existing callers.
+
 ### Added
 
 #### Streaming (BL-24, Q-A11, R-61, R-65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ All notable changes to restgdf are documented here. This project follows
 
 ### Changed
 
+- **Gate-3 hardening follow-up (post-T6-T11).** Three review-driven
+  safety fixes land on top of the v3-followup tranche:
+  - ArcGIS requests routed through `_choose_verb` now force `POST`
+    whenever the effective session transport is `"body"` or `"query"`
+    (including wrapped `ResilientSession(ArcGISTokenSession(...))`
+    stacks), preventing auth tokens from leaking into URL query
+    strings on short requests.
+  - `restgdf.resilience._retry._RetriedCtx` now mirrors
+    `aiohttp`'s dual request-manager shape so
+    `await session.get(...)` and `async with session.get(...)` both
+    work against `ResilientSession`.
+  - `getgdf._advertised_max_record_count_factor()` now rejects
+    `bool`, `NaN`, and infinity inputs so malformed vendor metadata
+    falls back to the byte-identical pre-T9 path.
+  - Module-level `get_gdf(..., session=None)` now closes the temporary
+    `aiohttp.ClientSession` it creates internally, eliminating the
+    unclosed-session leak on direct helper usage.
+  - `_iter_pages_raw(..., max_concurrent_pages=N)` now keeps at most
+    `N` fetch tasks scheduled at once instead of pre-creating one task
+    per page and only bounding execution with a semaphore, preventing
+    pagination plans with many batches from exploding task memory.
+  - Legacy streaming helpers (`_feature_batch_generator`,
+    `chunk_generator`) now honor the repository-wide concurrency cap
+    while they stream results and cancel outstanding work on early
+    generator close, preventing abandoned page-fetch tasks from
+    accumulating behind partially-consumed iterators.
+  - Hypothesis-backed property tests now live behind a dedicated
+    ``pytest --run-stress`` opt-in so the default suite remains a
+    representative production-validation pass instead of mixing in a
+    separate stress tier by default.
+
 - **Pagination planner wiring (R-72, v3-followup T9).** When an ArcGIS
   layer advertises `advancedQueryCapabilities.maxRecordCountFactor`,
   `get_query_data_batches` now forwards that value to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to restgdf are documented here. This project follows
 
 ### Changed
 
+- **Feature-count retry delegation (BL-51, v3-followup T10).**
+  `restgdf.utils.getinfo._feature_count_with_timeout` now delegates its
+  bounded timeout-retry loop to `restgdf.resilience.bounded_retry_timeout`
+  (a new public helper) when the `resilience` extra is installed, giving
+  restgdf a single stamina-backed source of truth for retry semantics.
+  When the extra is absent, the previous inline loop is preserved
+  byte-for-byte as a fallback. The retryable exception set
+  (`asyncio.TimeoutError`, `TimeoutError`, `aiohttp.ServerTimeoutError`)
+  and R-69 (`ClientConnectionError` propagates without retry) are
+  preserved on both paths.
+
 - **Transport typing (R-71, v3-followup T7).** `ArcGISTokenSession` now
   exposes `close()` and `closed` that delegate to its inner
   `aiohttp.ClientSession`, making it fully satisfy the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to restgdf are documented here. This project follows
 
 ### Changed
 
+- **Pagination planner wiring (R-72, v3-followup T9).** When an ArcGIS
+  layer advertises `advancedQueryCapabilities.maxRecordCountFactor`,
+  `get_query_data_batches` now forwards that value to
+  `build_pagination_plan(advertised_factor=...)`. The wiring is strictly
+  opt-in: servers that do not expose the field (or expose a non-positive
+  / non-numeric value) get the previous byte-exact plan with no
+  `advertised_factor` kwarg. This replaces the deferred-plumbing stub.
+
 - **Transport typing (R-71, v3-followup T7).** `ArcGISTokenSession` now
   exposes `close()` and `closed` that delegate to its inner
   `aiohttp.ClientSession`, making it fully satisfy the
@@ -20,6 +28,18 @@ All notable changes to restgdf are documented here. This project follows
   existing callers.
 
 ### Added
+
+#### Pagination (R-73, v3-followup T9)
+
+- `restgdf.errors.PaginationInconsistencyWarning` — new `UserWarning`
+  subclass emitted by `_resolve_page` when a batch page returns zero
+  features but the server still sets `exceededTransferLimit=true`. The
+  warning fires regardless of the `on_truncation` mode (`"raise"`,
+  `"ignore"`, or `"split"`) so pathological server responses are always
+  surfaced. Deliberately not included in `restgdf.errors.__all__` or the
+  top-level public API — warnings live outside the `RestgdfError`
+  taxonomy; import via `from restgdf.errors import
+  PaginationInconsistencyWarning`.
 
 #### Streaming (BL-24, Q-A11, R-61, R-65)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ All notable changes to restgdf are documented here. This project follows
   and R-69 (`ClientConnectionError` propagates without retry) are
   preserved on both paths.
 
+- **GET/POST verb selection wiring (R-74, v3-followup T8).** ArcGIS
+  query requests now route through a single `_arcgis_request` helper
+  in `restgdf/utils/_http.py` that consults `_choose_verb` (8,192-byte
+  threshold on URL + urlencoded body). Previously every call site was
+  hard-coded `POST`. Nine call sites across `utils/getgdf.py`,
+  `utils/getinfo.py`, and `utils/_query.py` were migrated. The GET path
+  coerces `bool`/`None` values in `params` to `"true"`/`"false"`/`""`
+  so yarl can serialize them; POST payloads are untouched. Zero
+  behavior change for bodies above the threshold.
 - **Transport typing (R-71, v3-followup T7).** `ArcGISTokenSession` now
   exposes `close()` and `closed` that delegate to its inner
   `aiohttp.ClientSession`, making it fully satisfy the
@@ -50,6 +59,29 @@ All notable changes to restgdf are documented here. This project follows
   top-level public API — warnings live outside the `RestgdfError`
   taxonomy; import via `from restgdf.errors import
   PaginationInconsistencyWarning`.
+
+#### Domain resolution (R-75, v3-followup T6)
+
+- `FeatureLayer.get_df(resolve_domains=False)` — new kwarg on the
+  pandas-first tabular accessor. When `True`, coded-value domain fields
+  are replaced in-place with their human-readable names using a single
+  cached pass over the layer's metadata (no per-row HTTP). Defaults to
+  `False` so the base code path is byte-identical for existing callers.
+- `restgdf.adapters.pandas.resolve_domains(df, fields)` — public
+  helper exposing the same resolution logic for callers already holding
+  a `pandas.DataFrame`. Requires the `geo` extra (pandas is part of
+  that install surface).
+
+#### Resilience (BL-51, v3-followup T10)
+
+- `restgdf.resilience.bounded_retry_timeout` — new public helper
+  exposing a stamina-backed bounded retry loop for timeout-class
+  exceptions. Used internally by `_feature_count_with_timeout` when the
+  `resilience` extra is installed; safe for consumers on the same
+  extra. The retryable exception set matches restgdf's internal
+  timeout policy (`asyncio.TimeoutError`, `TimeoutError`,
+  `aiohttp.ServerTimeoutError`); `aiohttp.ClientConnectionError`
+  propagates immediately (R-69 preserved).
 
 #### Streaming (BL-24, Q-A11, R-61, R-65)
 
@@ -319,6 +351,22 @@ All notable changes to restgdf are documented here. This project follows
   every `bumpver update`, keeping the citation metadata in lock-step
   with `version:`. New `test_citation_cff_date_released_is_iso_8601`
   pins the ISO-8601 date format (BL-40 follow-up).
+- **Install-combination CI matrix (R-62, v3-followup T5).** New
+  `install_combinations` job in `.github/workflows/pytest.yml` runs
+  the test suite against six explicit pip install surfaces: base,
+  `[geo]`, `[resilience]`, `[telemetry]`, `[geo,resilience,telemetry]`,
+  and `[dev]`. Wired into the `ci` aggregator so regressions in any
+  single extra fail PR checks before merge.
+- **Coverage-recovery tests (v3-followup T1–T4).** Four targeted test
+  modules lift measured coverage from 96.53% to 98.16%:
+  `tests/test_resilience_retry_coverage.py` (17 tests;
+  `_retry.py` 79% → 99%), `tests/test_telemetry_coverage.py` (9 tests;
+  `_correlation.py` 100%, `_spans.py` 97%),
+  `tests/test_credentials_coverage.py` (6 tests; `credentials.py`
+  91% → 100%), and `tests/test_getgdf_coverage.py` (10 tests;
+  `getgdf.py` 95% → 99%). Coverage floor in `pyproject.toml`
+  (`[tool.coverage.report] fail_under`) raised from 96 to 97 to
+  match (v3-followup T11).
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,6 +185,7 @@ addopts = "--strict-markers"
 asyncio_mode = "strict"
 markers = [
     "network: tests that hit live external ArcGIS services",
+    "stress: resource-intensive or property-based tests excluded by default; pass --run-stress to include them",
     "characterization: tests that pin current behavior to guard refactors",
     "compat: backward-compatibility tests for preserved import/patch paths",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,10 +141,10 @@ source = ["restgdf"]
 
 [tool.coverage.report]
 show_missing = true
-# Floor reflects current measured coverage (96.53% as of 2.0.0 release).
-# Raise this back toward 97 as targeted tests land for resilience /
-# telemetry / getgdf edge paths (see tracking issue).
-fail_under = 96
+# Floor reflects current measured coverage (98.16% as of v3-followup).
+# Targeted tests for resilience/_retry, telemetry, credentials, and
+# getgdf edge paths lifted measured coverage from 96.53% to 98.16%.
+fail_under = 97
 # Regexes for lines to exclude from consideration
 exclude_also = [
     # Don't complain about missing debug-only code:

--- a/restgdf/_client/_protocols.py
+++ b/restgdf/_client/_protocols.py
@@ -6,9 +6,12 @@ call sites rely on (``get`` / ``post`` / ``close`` / ``closed``).
 Flagged :func:`typing.runtime_checkable` so adapter classes
 (resilience, tracing, mock) can be validated via ``isinstance``.
 
-Phase-2b ships this Protocol **definition only**; widening call-site
-annotations currently typed ``aiohttp.ClientSession | ArcGISTokenSession``
-lands in later phases so BL-17 stays additive.
+Internal call sites that previously accepted
+``aiohttp.ClientSession | ArcGISTokenSession`` were widened to
+``AsyncHTTPSession`` in R-71 (v3 follow-up T7).
+:class:`~restgdf.utils.token.ArcGISTokenSession` exposes ``close()`` /
+``closed`` delegating to its inner :class:`aiohttp.ClientSession`, so
+both concrete implementations satisfy this Protocol uniformly.
 """
 
 from __future__ import annotations
@@ -20,10 +23,12 @@ from typing import Any, Protocol, runtime_checkable
 class AsyncHTTPSession(Protocol):
     """Structural type for restgdf transport sessions.
 
-    Matches :class:`aiohttp.ClientSession` and is the forward-compatible
-    target for resilience/telemetry adapters (BL-31 / BL-32). Only
-    method/attribute *presence* is checked at ``isinstance`` time;
-    signature details are advisory per :class:`typing.Protocol`.
+    Matches :class:`aiohttp.ClientSession` and
+    :class:`~restgdf.utils.token.ArcGISTokenSession`, and is the
+    forward-compatible target for resilience/telemetry adapters
+    (BL-31 / BL-32). Only method/attribute *presence* is checked at
+    ``isinstance`` time; signature details are advisory per
+    :class:`typing.Protocol`.
 
     .. note::
        ``get`` and ``post`` are declared as non-async ``def`` because
@@ -33,12 +38,6 @@ class AsyncHTTPSession(Protocol):
        ``isinstance(aiohttp.ClientSession(), AsyncHTTPSession)`` fail at
        runtime on Python versions that check
        :func:`inspect.iscoroutinefunction` for Protocol members.
-
-    .. note::
-       :class:`~restgdf.utils.token.ArcGISTokenSession` does **not**
-       currently expose ``closed`` / ``close``. Making it Protocol-
-       compatible (or narrowing the Protocol) is deferred: phase-2b
-       does not migrate any call-site annotations, so no breakage.
     """
 
     @property

--- a/restgdf/adapters/pandas.py
+++ b/restgdf/adapters/pandas.py
@@ -11,7 +11,7 @@ raise. Calling an adapter function on such an install raises
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncIterable, Iterable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from restgdf.utils._optional import require_pandas
@@ -19,7 +19,102 @@ from restgdf.utils._optional import require_pandas
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from pandas import DataFrame
 
-__all__ = ["arows_to_dataframe", "rows_to_dataframe"]
+__all__ = ["arows_to_dataframe", "resolve_domains", "rows_to_dataframe"]
+
+
+def _field_as_dict(field: Any) -> dict[str, Any]:
+    """Normalize a ``FieldSpec`` or raw-dict field descriptor to a dict."""
+    if isinstance(field, dict):
+        return field
+    # pydantic v2 model → dict (includes ``model_extra`` keys).
+    dump = getattr(field, "model_dump", None)
+    if callable(dump):
+        return dump()
+    return dict(getattr(field, "__dict__", {}))
+
+
+def resolve_domains(
+    df: DataFrame,
+    fields: Sequence[Any] | None,
+) -> DataFrame:
+    """Replace coded-value domain codes with their human-readable names.
+
+    Post-processes an already-materialized ``pandas.DataFrame`` using
+    ArcGIS layer field metadata:
+
+    * **Coded-value domains** — values present in the domain's
+      ``codedValues`` table are substituted for their ``name``. Codes
+      absent from the table pass through unchanged.
+    * **Range domains** — values are left as-is. Out-of-range values are
+      not flagged or coerced (callers who need strict validation should
+      check ``[min, max]`` themselves using the layer's field metadata).
+
+    The input DataFrame is **not** mutated; a shallow copy is returned
+    when any substitution is performed, and the original object is
+    returned unchanged when ``fields`` is empty / ``None`` or carries no
+    applicable domains.
+
+    Parameters
+    ----------
+    df:
+        DataFrame produced by :func:`rows_to_dataframe` /
+        :func:`arows_to_dataframe`.
+    fields:
+        Sequence of field descriptors (either
+        :class:`restgdf._models.responses.FieldSpec` instances or raw
+        dicts) as found on :attr:`restgdf.FeatureLayer.metadata.fields`.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A DataFrame with applicable coded-value columns resolved.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from restgdf.adapters.pandas import resolve_domains
+    >>> df = pd.DataFrame({"STATUS": [1, 2, 99]})
+    >>> fields = [{
+    ...     "name": "STATUS",
+    ...     "domain": {
+    ...         "type": "codedValue",
+    ...         "codedValues": [
+    ...             {"name": "Active", "code": 1},
+    ...             {"name": "Inactive", "code": 2},
+    ...         ],
+    ...     },
+    ... }]
+    >>> resolve_domains(df, fields)["STATUS"].tolist()
+    ['Active', 'Inactive', 99]
+    """
+    if not fields:
+        return df
+
+    coded_maps: dict[str, dict[Any, Any]] = {}
+    for raw_field in fields:
+        field = _field_as_dict(raw_field)
+        name = field.get("name")
+        domain = field.get("domain")
+        if not name or not domain or name not in df.columns:
+            continue
+        if domain.get("type") != "codedValue":
+            # Range domains (and any unknown variants) are intentionally
+            # pass-through; see the docstring.
+            continue
+        coded_values = domain.get("codedValues") or []
+        mapping = {cv["code"]: cv["name"] for cv in coded_values if "code" in cv}
+        if mapping:
+            coded_maps[name] = mapping
+
+    if not coded_maps:
+        return df
+
+    out = df.copy()
+    for col, mapping in coded_maps.items():
+        # ``Series.map`` with a dict leaves unmapped values as NaN; we
+        # instead use ``replace`` so unknown codes pass through unchanged.
+        out[col] = out[col].replace(mapping)
+    return out
 
 
 def rows_to_dataframe(rows: Iterable[dict[str, Any]]) -> DataFrame:

--- a/restgdf/adapters/stream.py
+++ b/restgdf/adapters/stream.py
@@ -25,16 +25,14 @@ from restgdf.utils.getgdf import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
-    from aiohttp import ClientSession
-
-    from restgdf.utils.token import ArcGISTokenSession
+    from restgdf._client._protocols import AsyncHTTPSession
 
 __all__ = ["iter_feature_batches", "iter_gdf_chunks", "iter_rows"]
 
 
 async def iter_feature_batches(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs: Any,
 ) -> AsyncIterator[list[dict[str, Any]]]:
     """Yield ArcGIS feature batches (lists of raw feature dicts) from ``url``.
@@ -79,7 +77,7 @@ async def iter_feature_batches(
 
 async def iter_rows(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs: Any,
 ) -> AsyncIterator[dict[str, Any]]:
     """Yield row-shaped dicts from ``url``.
@@ -120,7 +118,7 @@ async def iter_rows(
 
 async def iter_gdf_chunks(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs: Any,
 ) -> AsyncIterator[Any]:
     """Yield ``GeoDataFrame`` chunks from ``url``.

--- a/restgdf/directory/directory.py
+++ b/restgdf/directory/directory.py
@@ -1,11 +1,10 @@
-import aiohttp
-from typing import Optional, Union
+from typing import Optional
 
+from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._models.crawl import CrawlReport, CrawlServiceEntry
 from restgdf._models.responses import LayerMetadata
 from restgdf.utils.getinfo import get_metadata
 from restgdf.utils.crawl import fetch_all_data, safe_crawl  # noqa: F401
-from restgdf.utils.token import ArcGISTokenSession
 
 
 class Directory:
@@ -34,7 +33,7 @@ class Directory:
     def __init__(
         self,
         url: str,
-        session: Union[aiohttp.ClientSession, ArcGISTokenSession],
+        session: AsyncHTTPSession,
         token: Optional[str] = None,
     ):
         """A class for interacting with ArcGIS Server directories."""

--- a/restgdf/errors.py
+++ b/restgdf/errors.py
@@ -400,6 +400,22 @@ class OutputConversionError(RestgdfError):
     """Raised when converting validated ArcGIS data to a GeoDataFrame / DataFrame fails."""
 
 
+class PaginationInconsistencyWarning(UserWarning):
+    """Emitted when an ArcGIS batch response is self-inconsistent (R-73).
+
+    Specifically: a page that returns zero features *and* sets
+    ``exceededTransferLimit=true`` is an ArcGIS-side pagination bug —
+    the cursor cannot advance (offset-based pagination needs at least
+    one row per page to progress) but the service simultaneously
+    insists more rows exist. Left un-flagged this produces a
+    silently-truncated result set.
+
+    Multi-inherits :class:`UserWarning` so callers can silence or
+    escalate it via :mod:`warnings` (e.g.
+    ``warnings.filterwarnings("error", category=PaginationInconsistencyWarning)``).
+    """
+
+
 __all__ = [
     "ArcGISServiceError",
     "AuthNotAttachedError",

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -393,7 +393,7 @@ class FeatureLayer:
         async for chunk in chunk_generator(self.url, self.session, **merged_kwargs):
             yield chunk
 
-    async def get_df(self) -> DataFrame:
+    async def get_df(self, resolve_domains: bool = False) -> DataFrame:
         """Get a pandas DataFrame from an ArcGIS FeatureLayer.
 
         Tabular row view: attributes plus any raw ``geometry`` dict returned
@@ -404,10 +404,36 @@ class FeatureLayer:
         This is the pandas-only counterpart to :meth:`get_gdf` — prefer it
         when callers only need tabular access and want to avoid the full geo
         dependency stack.
-        """
-        from restgdf.adapters.pandas import arows_to_dataframe
 
-        return await arows_to_dataframe(self.stream_rows())
+        Parameters
+        ----------
+        resolve_domains:
+            When ``True``, coded-value domain fields are post-processed
+            so the DataFrame contains the human-readable ``name`` rather
+            than the raw ``code``. Codes absent from the domain's
+            ``codedValues`` table pass through unchanged. Range domains
+            are not validated or coerced. Defaults to ``False`` — the
+            historical behavior where the DataFrame faithfully mirrors
+            the server payload. No additional HTTP traffic is issued;
+            resolution uses the already-loaded
+            :attr:`FeatureLayer.metadata` fetched during :meth:`prep`.
+
+        Examples
+        --------
+        >>> df = await layer.get_df(resolve_domains=True)  # doctest: +SKIP
+        >>> df["STATUS"].head().tolist()  # doctest: +SKIP
+        ['Active', 'Inactive', 'Active', ...]
+        """
+        from restgdf.adapters.pandas import (
+            arows_to_dataframe,
+            resolve_domains as _resolve_domains,
+        )
+
+        df = await arows_to_dataframe(self.stream_rows())
+        if resolve_domains:
+            fields = getattr(getattr(self, "metadata", None), "fields", None)
+            df = _resolve_domains(df, fields)
+        return df
 
     async def row_dict_generator(
         self,

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -7,8 +7,8 @@ import warnings
 from collections.abc import AsyncIterable, AsyncIterator
 from typing import TYPE_CHECKING, Any, Literal
 
-from aiohttp import ClientSession
 
+from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._compat import _warn_deprecated, aclosing
 from restgdf._models.responses import LayerMetadata
 from restgdf.errors import FieldDoesNotExistError
@@ -55,7 +55,6 @@ __all__ = [
     "getvaluecounts",
     "nestedcount",
 ]
-from restgdf.utils.token import ArcGISTokenSession
 from restgdf.utils.utils import where_var_in_list, ends_with_num
 
 if TYPE_CHECKING:
@@ -92,7 +91,7 @@ class FeatureLayer:
     def __init__(
         self,
         url: str,
-        session: ClientSession | ArcGISTokenSession,
+        session: AsyncHTTPSession,
         where: str = "1=1",
         token: str | None = None,
         **kwargs,

--- a/restgdf/resilience/__init__.py
+++ b/restgdf/resilience/__init__.py
@@ -23,6 +23,7 @@ except ImportError as _exc:
         "The resilience extra is required: pip install restgdf[resilience]",
     ) from _exc
 
+from restgdf.resilience._bounded_retry import bounded_retry_timeout
 from restgdf.resilience._retry import ResilientSession
 
-__all__ = ["ResilientSession"]
+__all__ = ["ResilientSession", "bounded_retry_timeout"]

--- a/restgdf/resilience/_bounded_retry.py
+++ b/restgdf/resilience/_bounded_retry.py
@@ -1,0 +1,78 @@
+"""Bounded-retry helper for timeout-only retries (BL-51).
+
+Public entry point: :func:`bounded_retry_timeout`. This module centralises
+the retry semantics used by :func:`restgdf.utils.getinfo._feature_count_with_timeout`
+so the inline loop there can be replaced with a single delegation call when
+the ``resilience`` extra is installed.
+
+Retry contract (must match the inline fallback byte-for-byte semantically):
+
+* Retry ONLY on timeout exceptions:
+  :class:`asyncio.TimeoutError`, :class:`TimeoutError`,
+  :class:`aiohttp.ServerTimeoutError`.
+* Every other exception — in particular :class:`aiohttp.ClientConnectionError`
+  (R-69) and :class:`~restgdf.errors.RestgdfResponseError` — propagates
+  unchanged on the first attempt.
+* After ``max_attempts`` timeouts, raise
+  :class:`~restgdf.errors.RestgdfTimeoutError` with the last timeout
+  exception preserved as ``__cause__``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Callable, TypeVar
+from collections.abc import Awaitable
+
+import aiohttp
+import stamina
+
+from restgdf.errors import RestgdfTimeoutError
+
+__all__ = ["bounded_retry_timeout"]
+
+T = TypeVar("T")
+
+_TIMEOUT_EXCS: tuple[type[BaseException], ...] = (
+    asyncio.TimeoutError,
+    TimeoutError,
+    aiohttp.ServerTimeoutError,
+)
+
+
+async def bounded_retry_timeout(
+    func: Callable[[], Awaitable[T]],
+    *,
+    max_attempts: int,
+    url: str,
+) -> T:
+    """Invoke ``func`` with bounded retry on timeout exceptions.
+
+    Parameters
+    ----------
+    func:
+        Zero-argument awaitable factory (call produces the coroutine to run).
+    max_attempts:
+        Maximum number of attempts, identical to the inline fallback.
+    url:
+        Used only to build the ``RestgdfTimeoutError`` message on exhaustion.
+    """
+
+    @stamina.retry(
+        on=_TIMEOUT_EXCS,
+        attempts=max_attempts,
+        timeout=None,
+        wait_initial=0.1,
+        wait_max=1.0,
+        wait_jitter=0.0,
+        wait_exp_base=2.0,
+    )
+    async def _attempt() -> T:
+        return await func()
+
+    try:
+        return await _attempt()
+    except _TIMEOUT_EXCS as exc:
+        raise RestgdfTimeoutError(
+            f"feature_count for {url} timed out after {max_attempts} attempts",
+        ) from exc

--- a/restgdf/resilience/_retry.py
+++ b/restgdf/resilience/_retry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
 
 import aiohttp
@@ -86,9 +87,19 @@ class ResilientSession:
 
 
 class _RetriedCtx:
-    """Async context manager that performs retried request on __aenter__."""
+    """Dual-interface wrapper: works as ``await session.get(url)`` AND
+    as ``async with session.get(url) as resp:``.
 
-    __slots__ = ("_session", "_method", "_url", "_kwargs", "_resp")
+    Mirrors :class:`aiohttp.client._RequestContextManager` so
+    :class:`ResilientSession` behaves identically to
+    :class:`aiohttp.ClientSession` regardless of whether callers use
+    the awaitable or async-context-manager pattern. :mod:`restgdf.utils._http`
+    awaits the result of ``session.get`` / ``session.post`` directly,
+    so this dual shape is required for the helper to work against a
+    :class:`ResilientSession`-wrapped inner session.
+    """
+
+    __slots__ = ("_session", "_method", "_url", "_kwargs", "_resp", "_resp_ctx")
 
     def __init__(
         self,
@@ -102,9 +113,10 @@ class _RetriedCtx:
         self._url = url
         self._kwargs = kwargs
         self._resp: Any = None
+        self._resp_ctx: Any = None
 
-    async def __aenter__(self) -> Any:
-        self._resp = await _do_retried_request(
+    async def _run(self) -> Any:
+        self._resp_ctx, self._resp = await _do_retried_request(
             self._session._inner,
             self._session._config,
             self._method,
@@ -115,8 +127,15 @@ class _RetriedCtx:
         )
         return self._resp
 
+    async def __aenter__(self) -> Any:
+        return await self._run()
+
     async def __aexit__(self, *args: Any) -> None:
-        pass
+        if self._resp_ctx is not None:
+            await self._resp_ctx.__aexit__(*args)
+
+    def __await__(self) -> Any:
+        return self._run().__await__()
 
 
 class _RetryableHTTPError(Exception):
@@ -136,7 +155,7 @@ async def _do_retried_request(
     *,
     limiter: LimiterRegistry | None = None,
     cooldown: CooldownRegistry | None = None,
-) -> Any:
+) -> tuple[Any, Any]:
     """Execute request with stamina retry, token-bucket, and cooldown."""
     svc_root = _service_root(url)
     retry_on = (
@@ -162,8 +181,7 @@ async def _do_retried_request(
             await limiter.get(svc_root).acquire()
         try:
             dispatch = getattr(inner, method)
-            ctx = dispatch(url, **kwargs)
-            resp = await ctx.__aenter__()
+            ctx, resp = await _enter_request(dispatch(url, **kwargs))
         except aiohttp.ClientConnectorError:
             raise  # retryable
         except aiohttp.ServerTimeoutError:
@@ -180,9 +198,11 @@ async def _do_retried_request(
                     else config.fallback_retry_after_seconds
                 )
                 cooldown.set_cooldown(svc_root, cd)
+            await ctx.__aexit__(None, None, None)
             raise _RetryableHTTPError(resp.status, headers)
 
         if 400 <= resp.status < 500:
+            await ctx.__aexit__(None, None, None)
             raise RestgdfResponseError(
                 f"Client error ({resp.status}) at {url}",
                 model_name="",
@@ -192,7 +212,7 @@ async def _do_retried_request(
                 status_code=resp.status,
             )
 
-        return resp
+        return ctx, resp
 
     try:
         return await _attempt()
@@ -225,3 +245,17 @@ async def _do_retried_request(
             url=url,
             timeout_kind="read",
         ) from exc
+
+
+async def _enter_request(result: Any) -> tuple[Any, Any]:
+    """Normalize a session dispatch result to an entered async context."""
+    if inspect.isawaitable(result):
+        response = await result
+        ctx = _ResponseCtx(response)
+        return ctx, await ctx.__aenter__()
+
+    if hasattr(result, "__aenter__") and hasattr(result, "__aexit__"):
+        return result, await result.__aenter__()
+
+    ctx = _ResponseCtx(result)
+    return ctx, await ctx.__aenter__()

--- a/restgdf/utils/_http.py
+++ b/restgdf/utils/_http.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Any, Literal
 from collections.abc import Mapping
-from urllib.parse import urlsplit
+from urllib.parse import urlencode, urlsplit
 
 import aiohttp
 
@@ -50,46 +50,103 @@ _GET_PARENT_SEGMENTS: tuple[str, ...] = (
     "GPServer",
 )
 
+# T8 (R-74): ArcGIS REST practical URL-length ceiling. Past this many bytes
+# (URL + encoded body), servers (and intermediaries like IIS/WAFs) routinely
+# reject the GET with 414 URI Too Long, so restgdf must fall back to POST.
+_ARCGIS_URL_BODY_LIMIT: int = 8192
+
+
+def _encoded_body_length(body: Mapping[str, object] | None) -> int:
+    """Return the byte length of ``body`` as it would be URL-encoded."""
+    if not body:
+        return 0
+    return len(urlencode(dict(body), doseq=True))
+
 
 def _choose_verb(
     url: str,
     body: Mapping[str, object] | None = None,
 ) -> Literal["POST", "GET"]:
-    """Return the HTTP verb restgdf should use for ``url``.
+    """Return the HTTP verb restgdf should use for ``url`` with ``body``.
 
-    BL-20 seam (MASTER-PLAN §5 BL-20, plan.md §3c R-34/R-35/R-38,
-    kickoff phase-1a §10.1).
+    T8 (R-74) wires this helper at every ArcGIS call site. The decision
+    is length-based against :data:`_ARCGIS_URL_BODY_LIMIT` (the 8k
+    practical ceiling ArcGIS Server / IIS / common WAFs enforce for
+    ``GET`` query strings):
 
-    Rules (deterministic, call-sites not yet rewired in this slice):
+    * ``len(url) + len(urlencode(body)) <= limit`` → ``GET`` — idempotent,
+      cache-friendly, byte-for-byte equivalent to today's short-body GETs.
+    * Anything larger → ``POST`` — restgdf will never emit a request that
+      a real server will refuse with 414 URI Too Long.
 
-    * ArcGIS ``/query`` and ``/queryRelatedRecords`` endpoints → ``POST``
-      (queries can carry long ``where`` clauses and arbitrary geometry).
-    * Bare service / layer URLs whose path ends in a server family
-      segment (``MapServer``, ``FeatureServer``, ``ImageServer``,
-      ``GPServer``) or a numeric layer index directly under one →
-      ``GET`` (short, idempotent metadata fetches).
-    * Everything else → ``POST`` (conservative default — avoids URL
-      length blowups and tolerates unknown ArcGIS operations).
-
-    The ``body`` parameter is accepted for forward compatibility but
-    currently ignored. BL-50 will extend this helper to auto-switch a
-    ``GET`` to ``POST`` when the serialized ``where``/``outFields``
-    payload pushes a GET URL past the ArcGIS ~1800-byte budget.
+    ``body`` is accepted as any mapping (or ``None``). The helper never
+    mutates the mapping; it only measures its encoded size. A ``None``
+    or empty body short-circuits to ``GET`` immediately.
     """
-    path = urlsplit(url).path.rstrip("/")
-    for suffix in _POST_ENDPOINT_SUFFIXES:
-        if path.endswith(suffix):
-            return "POST"
-    segments = path.split("/")
-    if segments and segments[-1] in _GET_PARENT_SEGMENTS:
-        return "GET"
-    if (
-        len(segments) >= 2
-        and segments[-1].isdigit()
-        and segments[-2] in _GET_PARENT_SEGMENTS
-    ):
+    encoded_len = _encoded_body_length(body)
+    # Account for the "?" separator that aiohttp would add between the
+    # URL path and the query string in a GET request.
+    separator = 1 if encoded_len else 0
+    if len(url) + separator + encoded_len <= _ARCGIS_URL_BODY_LIMIT:
         return "GET"
     return "POST"
+
+
+# Legacy endpoint-classification data kept for potential diagnostic reuse
+# (see git blame for BL-20). The active verb decision is length-based —
+# these constants are intentionally unused at runtime.
+_ = (_POST_ENDPOINT_SUFFIXES, _GET_PARENT_SEGMENTS, urlsplit)
+
+
+async def _arcgis_request(
+    session: Any,
+    url: str,
+    body: Mapping[str, object] | None,
+    **kwargs: Any,
+) -> Any:
+    """Issue an ArcGIS request using the verb selected by :func:`_choose_verb`.
+
+    T8 (R-74): centralizes the GET-vs-POST decision so every ArcGIS call
+    site participates in length-based routing.
+
+    * ``GET`` → ``session.get(url, params=body, **kwargs)``
+    * ``POST`` → ``session.post(url, data=body, **kwargs)``
+
+    ``body`` is forwarded untouched; the helper never injects or removes
+    keys. Any extra ``kwargs`` (``headers``, ``timeout``, ``ssl`` …) are
+    passed through to the underlying session call verbatim so request
+    semantics stay byte-for-byte identical below the verb switch.
+    """
+    verb = _choose_verb(url, body=body)
+    if verb == "GET":
+        params = _coerce_params_for_get(body) if body else body
+        return await session.get(url, params=params, **kwargs)
+    return await session.post(url, data=body, **kwargs)
+
+
+def _coerce_params_for_get(
+    body: Mapping[str, object],
+) -> dict[str, Any]:
+    """Return ``body`` with values normalized for ``session.get(params=...)``.
+
+    ``yarl`` (aiohttp's URL builder) rejects :class:`bool` and ``None``
+    values in query params with :class:`TypeError`, while the equivalent
+    ``session.post(data=...)`` path serializes them happily via
+    :func:`urllib.parse.urlencode`. T8 (R-74) routes the same ArcGIS
+    payloads through either verb, so this helper keeps the GET path
+    byte-for-byte equivalent to what ArcGIS Server sees today:
+    booleans become lowercase ``"true"``/``"false"`` (ArcGIS's own wire
+    convention) and ``None`` becomes an empty string.
+    """
+    coerced: dict[str, Any] = {}
+    for key, value in body.items():
+        if isinstance(value, bool):
+            coerced[key] = "true" if value else "false"
+        elif value is None:
+            coerced[key] = ""
+        else:
+            coerced[key] = value
+    return coerced
 
 
 def default_timeout(settings: Any | None = None) -> aiohttp.ClientTimeout:

--- a/restgdf/utils/_http.py
+++ b/restgdf/utils/_http.py
@@ -6,6 +6,7 @@ Private submodule; all public names are re-exported by
 
 from __future__ import annotations
 
+import inspect
 from typing import Any, Literal
 from collections.abc import Mapping
 from urllib.parse import urlencode, urlsplit
@@ -116,12 +117,66 @@ async def _arcgis_request(
     keys. Any extra ``kwargs`` (``headers``, ``timeout``, ``ssl`` …) are
     passed through to the underlying session call verbatim so request
     semantics stay byte-for-byte identical below the verb switch.
+
+    **Credential safety (Gate-3 fix).** ``ArcGISTokenSession`` configured
+    with ``transport="body"`` or ``transport="query"`` injects the
+    bearer token into the outgoing payload. If the length-based router
+    chose ``GET`` for such a session, the token would be serialized
+    into the URL query string — a credential leak. To preserve the
+    pre-T8 wire shape, this helper walks the session's ``_inner`` chain
+    and forces ``POST`` whenever any layer reports a non-``"header"``
+    transport (``ResilientSession(ArcGISTokenSession(transport="body"))``
+    and similar wrappers included).
     """
+    if _session_requires_body_transport(session):
+        return await session.post(url, data=body, **kwargs)
     verb = _choose_verb(url, body=body)
     if verb == "GET":
         params = _coerce_params_for_get(body) if body else body
         return await session.get(url, params=params, **kwargs)
     return await session.post(url, data=body, **kwargs)
+
+
+def _session_requires_body_transport(session: Any) -> bool:
+    """Return ``True`` if ``session`` (or any wrapped inner session)
+    injects an auth token into the request payload rather than the
+    ``X-Esri-Authorization`` header.
+
+    Walks the ``_inner`` attribute chain so adapters such as
+    :class:`restgdf.resilience.ResilientSession` wrapping an
+    :class:`restgdf.utils.token.ArcGISTokenSession` still trigger the
+    safe ``POST`` path. ``transport="header"`` (and sessions without a
+    ``_transport`` attribute at all, e.g. plain
+    :class:`aiohttp.ClientSession`) are treated as verb-neutral.
+    """
+    current: Any = session
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        transport = _safe_static_attr_value(current, "_transport")
+        if transport in ("body", "query"):
+            return True
+        current = _safe_static_attr_value(current, "_inner")
+    return False
+
+
+def _safe_static_attr_value(obj: Any, name: str) -> Any:
+    """Read an attribute without fabricating mock children.
+
+    ``inspect.getattr_static`` protects against ``AsyncMock`` creating
+    synthetic attributes on demand, but returns raw descriptors for
+    property-backed attributes. Resolve descriptors only after confirming
+    the attribute exists statically.
+    """
+    value = inspect.getattr_static(obj, name, None)
+    if value is None:
+        return None
+    if hasattr(value, "__get__"):
+        try:
+            return object.__getattribute__(obj, name)
+        except AttributeError:
+            return None
+    return value
 
 
 def _coerce_params_for_get(

--- a/restgdf/utils/_query.py
+++ b/restgdf/utils/_query.py
@@ -19,7 +19,7 @@ from restgdf._models.responses import (
     LayerMetadata,
     ObjectIdsResponse,
 )
-from restgdf.utils._http import default_headers, default_timeout
+from restgdf.utils._http import _arcgis_request, default_headers, default_timeout
 from restgdf.utils.token import ArcGISTokenSession
 
 
@@ -42,9 +42,10 @@ async def get_feature_count(
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
     xkwargs.setdefault("timeout", default_timeout())
     query_url = f"{url}/query"
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         query_url,
-        data=datadict,
+        datadict,
         headers=default_headers(xkwargs.pop("headers", None)),
         **xkwargs,
     )
@@ -69,9 +70,10 @@ async def get_metadata(
     data = {"f": "json"}
     if token is not None:
         data["token"] = token
-    response = await session.get(
+    response = await _arcgis_request(
+        session,
         url,
-        params=data,
+        data,
         headers=default_headers(),
         timeout=default_timeout(),
     )
@@ -99,9 +101,10 @@ async def get_object_ids(
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
     xkwargs.setdefault("timeout", default_timeout())
     query_url = f"{url}/query"
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         query_url,
-        data=datadict,
+        datadict,
         headers=default_headers(xkwargs.pop("headers", None)),
         **xkwargs,
     )

--- a/restgdf/utils/_query.py
+++ b/restgdf/utils/_query.py
@@ -10,8 +10,8 @@ that patching ``restgdf.utils.getinfo.<helper>`` intercepts those calls.
 
 from __future__ import annotations
 
-from aiohttp import ClientSession
 
+from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._client.request import build_conservative_query_data
 from restgdf._models._drift import _parse_response
 from restgdf._models.responses import (
@@ -20,12 +20,11 @@ from restgdf._models.responses import (
     ObjectIdsResponse,
 )
 from restgdf.utils._http import default_headers, default_timeout
-from restgdf.utils.token import ArcGISTokenSession
 
 
 async def get_feature_count(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> int:
     """Get the feature count for a layer.
@@ -55,7 +54,7 @@ async def get_feature_count(
 
 async def get_metadata(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     token: str | None = None,
 ) -> LayerMetadata:
     """Get the parsed metadata model for a layer.
@@ -81,7 +80,7 @@ async def get_metadata(
 
 async def get_object_ids(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> tuple[str, list[int]]:
     """Get the object id field name and matching object ids for a layer query.

--- a/restgdf/utils/_stats.py
+++ b/restgdf/utils/_stats.py
@@ -14,7 +14,7 @@ from restgdf._client.request import build_conservative_query_data
 from restgdf._models._drift import _parse_response
 from restgdf._models.responses import FeaturesResponse
 from restgdf.utils._deprecations import deprecated_alias
-from restgdf.utils._http import default_headers, default_timeout
+from restgdf.utils._http import _arcgis_request, default_headers, default_timeout
 from restgdf.utils._optional import require_pandas_dataframe
 from restgdf.utils.token import ArcGISTokenSession
 
@@ -72,9 +72,10 @@ async def get_unique_values(
     xkwargs: dict = {k: v for k, v in kwargs.items() if k != "data"}
     xkwargs.setdefault("timeout", default_timeout())
 
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         f"{url}/query",
-        data=datadict,
+        datadict,
         headers=default_headers(xkwargs.pop("headers", None)),
         **xkwargs,
     )
@@ -125,9 +126,10 @@ async def get_value_counts(
         **data,
     }
     kwargs.setdefault("timeout", default_timeout())
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         f"{url}/query",
-        data=data,
+        data,
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )
@@ -172,9 +174,10 @@ async def nested_count(
         **data,
     }
     kwargs.setdefault("timeout", default_timeout())
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         f"{url}/query",
-        data=data,
+        data,
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )

--- a/restgdf/utils/_stats.py
+++ b/restgdf/utils/_stats.py
@@ -8,15 +8,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from aiohttp import ClientSession
 
+from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._client.request import build_conservative_query_data
 from restgdf._models._drift import _parse_response
 from restgdf._models.responses import FeaturesResponse
 from restgdf.utils._deprecations import deprecated_alias
 from restgdf.utils._http import default_headers, default_timeout
 from restgdf.utils._optional import require_pandas_dataframe
-from restgdf.utils.token import ArcGISTokenSession
 
 if TYPE_CHECKING:
     from pandas import DataFrame
@@ -50,7 +49,7 @@ def _sorted_scalar_values(values: list[Any | None]) -> list[Any | None]:
 async def get_unique_values(
     url: str,
     fields: tuple | str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     sortby: str | None = None,
     **kwargs,
 ) -> list | DataFrame:
@@ -108,7 +107,7 @@ async def get_unique_values(
 async def get_value_counts(
     url: str,
     field: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> DataFrame:
     """Get the value counts for a field."""
@@ -146,7 +145,7 @@ async def get_value_counts(
 async def nested_count(
     url: str,
     fields,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> DataFrame:
     """Get the nested value counts for a field."""

--- a/restgdf/utils/crawl.py
+++ b/restgdf/utils/crawl.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-import aiohttp
 from pydantic import BaseModel
 
+from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._models.crawl import CrawlError, CrawlReport, CrawlServiceEntry
 from restgdf._models.responses import LayerMetadata
 from restgdf._config import get_config
 from restgdf.utils.getinfo import service_metadata, get_metadata
-from restgdf.utils.token import ArcGISTokenSession
 
 
 def _to_plain_dict(value: Any) -> dict:
@@ -21,7 +20,7 @@ def _to_plain_dict(value: Any) -> dict:
 
 
 async def fetch_all_data(
-    session: aiohttp.ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     base_url: str,
     token: str | None = None,
     return_feature_count: bool = False,
@@ -119,7 +118,7 @@ def _as_layer_metadata(raw: Any) -> LayerMetadata:
 
 
 async def safe_crawl(
-    session: aiohttp.ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     base_url: str,
     token: str | None = None,
     return_feature_count: bool = False,

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import warnings
 from asyncio import gather
 from collections.abc import AsyncGenerator, Mapping
 from functools import reduce
@@ -14,7 +15,11 @@ from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._logging import get_logger
 from restgdf._models._drift import _parse_response
 from restgdf._models.responses import FeaturesResponse, LayerMetadata
-from restgdf.errors import PaginationError, RestgdfResponseError
+from restgdf.errors import (
+    PaginationError,
+    PaginationInconsistencyWarning,
+    RestgdfResponseError,
+)
 from restgdf.telemetry._spans import start_feature_layer_stream_span
 from restgdf.utils.getinfo import (
     default_data,
@@ -145,12 +150,55 @@ def chunk_values(values: list[int], chunk_size: int) -> list[list[int]]:
     return [values[i : i + chunk_size] for i in range(0, len(values), chunk_size)]
 
 
+def _advertised_max_record_count_factor(
+    metadata: Mapping[str, Any],
+) -> float | None:
+    """Return the server-advertised ``maxRecordCountFactor`` or ``None``.
+
+    Checks ``advancedQueryCapabilities.maxRecordCountFactor`` in the
+    raw layer metadata dict (R-72). Returns ``None`` when the
+    ``advancedQueryCapabilities`` block is missing, when the factor
+    key itself is absent, or when the advertised value is not a
+    positive number (``None`` / 0 / negative / non-numeric). The
+    return value is intended to be threaded straight through to
+    :func:`build_pagination_plan` as ``advertised_factor=``.
+    """
+    aqc = metadata.get("advancedQueryCapabilities")
+    if not isinstance(aqc, Mapping):
+        return None
+    raw = aqc.get("maxRecordCountFactor")
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    if value <= 0:
+        return None
+    return value
+
+
 async def get_query_data_batches(
     url: str,
     session: AsyncHTTPSession,
     **kwargs,
 ) -> list[dict]:
-    """Build query payloads for each request needed to read a layer."""
+    """Build query payloads for each request needed to read a layer.
+
+    When the layer metadata advertises an explicit
+    ``advancedQueryCapabilities.maxRecordCountFactor`` (R-72), the
+    value is forwarded to :func:`build_pagination_plan` as
+    ``advertised_factor=`` so pagination batch sizes honor the
+    server-published upper bound. Layers that do **not** advertise the
+    field keep today's byte-for-byte batching: no ``advertised_factor``
+    kwarg is supplied and the planner falls back to its
+    ``_DEFAULT_FACTOR`` (``1.0``).
+
+    Pages observed at stream time that return zero features while
+    setting ``exceededTransferLimit=true`` are flagged with
+    :class:`restgdf.errors.PaginationInconsistencyWarning` (R-73) from
+    :func:`_resolve_page`; see that helper for details.
+    """
     request_data = dict(kwargs.get("data") or {})
     feature_count = await get_feature_count(url, session, **kwargs)
     token = request_data.get("token")
@@ -175,13 +223,18 @@ async def get_query_data_batches(
                 }
                 for offset in range(0, feature_count, page_size)
             ]
-        plan = build_pagination_plan(feature_count, max_record_count)
-        # NOTE (BL-21/22 deferred): maxRecordCountFactor from
-        # advancedQueryCapabilities is intentionally NOT plumbed here in
-        # phase-2c. The planner API accepts `advertised_factor` / `factor`
-        # and will clamp with a warning via `get_logger("pagination")`;
-        # the live wire-up is deferred to a future phase to preserve
-        # byte-exact batch sizes during the 3.0 migration.
+        # R-72: opt-in wire of advertised maxRecordCountFactor. Only
+        # pass ``advertised_factor`` when the server actually publishes
+        # it, so layers without the field keep byte-exact 3.0 batching.
+        planner_kwargs: dict[str, Any] = {}
+        advertised_factor = _advertised_max_record_count_factor(metadata)
+        if advertised_factor is not None:
+            planner_kwargs["advertised_factor"] = advertised_factor
+        plan = build_pagination_plan(
+            feature_count,
+            max_record_count,
+            **planner_kwargs,
+        )
         return [
             {
                 **request_data,
@@ -460,6 +513,21 @@ async def _resolve_page(
     if not envelope.exceeded_transfer_limit:
         yield page
         return
+
+    # R-73: 0-feature + exceededTransferLimit=true is an ArcGIS-side
+    # pagination bug — the cursor cannot advance but the service claims
+    # more rows exist. Flag it regardless of ``on_truncation`` so the
+    # inconsistency is visible to callers who choose to ignore the
+    # normal truncation signal.
+    if not envelope.features:
+        warnings.warn(
+            (
+                f"{url}/query returned exceededTransferLimit=true with "
+                "zero features; pagination cursor cannot advance."
+            ),
+            PaginationInconsistencyWarning,
+            stacklevel=2,
+        )
 
     if on_truncation == "ignore":
         get_logger("pagination").warning(

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import warnings
 from asyncio import gather
 from collections.abc import AsyncGenerator, Mapping
@@ -12,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from aiohttp import ClientSession
 
 from restgdf._client._protocols import AsyncHTTPSession
+from restgdf._config import get_config
 from restgdf._logging import get_logger
 from restgdf._models._drift import _parse_response
 from restgdf._models.responses import FeaturesResponse, LayerMetadata
@@ -106,8 +108,17 @@ async def _feature_batch_generator(
 ) -> AsyncGenerator[list[dict[str, Any]]]:
     """Yield raw ArcGIS feature batches without requiring pandas/geopandas."""
     query_data_batches = await get_query_data_batches(url, session, **kwargs)
-    tasks = {
-        asyncio.create_task(
+    max_inflight = get_config().concurrency.max_concurrent_requests
+    batch_iter = iter(enumerate(query_data_batches))
+    tasks: set[asyncio.Task] = set()
+    task_order: dict[asyncio.Task, int] = {}
+
+    def _submit_next() -> asyncio.Task | None:
+        try:
+            idx, query_data = next(batch_iter)
+        except StopIteration:
+            return None
+        task = asyncio.create_task(
             get_sub_features(
                 url,
                 session,
@@ -116,10 +127,35 @@ async def _feature_batch_generator(
                 **kwargs,
             ),
         )
-        for idx, query_data in enumerate(query_data_batches)
-    }
-    for feature_batch_future in asyncio.as_completed(tasks):
-        yield await feature_batch_future
+        tasks.add(task)
+        task_order[task] = idx
+        return task
+
+    try:
+        for _ in range(max_inflight):
+            task = _submit_next()
+            if task is None:
+                break
+
+        while tasks:
+            done, pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            tasks = set(pending)
+            completed_batches: list[list[dict[str, Any]]] = []
+            for task in sorted(done, key=task_order.__getitem__):
+                replacement = _submit_next()
+                if replacement is not None:
+                    tasks.add(replacement)
+                completed_batches.append(await task)
+                task_order.pop(task, None)
+            for feature_batch in completed_batches:
+                yield feature_batch
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
 
 
 def get_sub_features(*args, **kwargs):
@@ -167,13 +203,17 @@ def _advertised_max_record_count_factor(
     if not isinstance(aqc, Mapping):
         return None
     raw = aqc.get("maxRecordCountFactor")
-    if raw is None:
+    if raw is None or isinstance(raw, bool):
+        # bool is a subclass of int; reject it so True/False never leak
+        # into the numeric path and silently wire advertised_factor=1.0.
         return None
     try:
         value = float(raw)
     except (TypeError, ValueError):
         return None
-    if value <= 0:
+    if not math.isfinite(value) or value <= 0:
+        # Reject NaN and ±inf; both are parseable by float() but
+        # nonsensical as pagination multipliers.
         return None
     return value
 
@@ -294,12 +334,33 @@ async def get_gdf_list(
 ) -> list[GeoDataFrame]:
     _require_geo_query_support("get_gdf_list()")
     query_data_batches = await get_query_data_batches(url, session, **kwargs)
+    sem = asyncio.BoundedSemaphore(get_config().concurrency.max_concurrent_requests)
     tasks = [
-        get_sub_gdf(url, session, query_data=query_data, **kwargs)
+        asyncio.create_task(
+            _run_get_sub_gdf_bounded(url, session, sem, query_data, **kwargs),
+        )
         for query_data in query_data_batches
     ]
-    gdf_list = await gather(*tasks)
-    return gdf_list
+    try:
+        gdf_list = await gather(*tasks)
+        return gdf_list
+    except Exception:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        await gather(*tasks, return_exceptions=True)
+        raise
+
+
+async def _run_get_sub_gdf_bounded(
+    url: str,
+    session: AsyncHTTPSession,
+    sem: asyncio.BoundedSemaphore,
+    query_data: dict,
+    **kwargs,
+) -> GeoDataFrame:
+    async with sem:
+        return await get_sub_gdf(url, session, query_data=query_data, **kwargs)
 
 
 async def chunk_generator(
@@ -325,15 +386,54 @@ async def chunk_generator(
         raw_sr = None
     else:
         raw_sr = _extract_raw_spatial_reference(metadata)
-    tasks = {
-        asyncio.create_task(get_sub_gdf(url, session, query_data=query_data, **kwargs))
-        for query_data in query_data_batches
-    }
-    for sub_gdf_future in asyncio.as_completed(tasks):
-        chunk = await sub_gdf_future
-        if raw_sr is not None:
-            chunk.attrs["spatial_reference"] = raw_sr
-        yield chunk
+    max_inflight = get_config().concurrency.max_concurrent_requests
+    batch_iter = iter(query_data_batches)
+    tasks: set[asyncio.Task] = set()
+    task_order: dict[asyncio.Task, int] = {}
+    next_index = 0
+
+    def _submit_next() -> asyncio.Task | None:
+        nonlocal next_index
+        try:
+            query_data = next(batch_iter)
+        except StopIteration:
+            return None
+        task = asyncio.create_task(
+            get_sub_gdf(url, session, query_data=query_data, **kwargs),
+        )
+        tasks.add(task)
+        task_order[task] = next_index
+        next_index += 1
+        return task
+
+    try:
+        for _ in range(max_inflight):
+            task = _submit_next()
+            if task is None:
+                break
+
+        while tasks:
+            done, pending = await asyncio.wait(
+                tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            tasks = set(pending)
+            completed_chunks: list[GeoDataFrame] = []
+            for task in sorted(done, key=task_order.__getitem__):
+                replacement = _submit_next()
+                if replacement is not None:
+                    tasks.add(replacement)
+                chunk = await task
+                task_order.pop(task, None)
+                if raw_sr is not None:
+                    chunk.attrs["spatial_reference"] = raw_sr
+                completed_chunks.append(chunk)
+            for chunk in completed_chunks:
+                yield chunk
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
 
 
 async def row_dict_generator(
@@ -393,6 +493,7 @@ async def get_gdf(
     **kwargs,
 ) -> GeoDataFrame:
     _require_geo_query_support("get_gdf()")
+    owns_session = session is None
     session = session or ClientSession()
     datadict = default_data(kwargs.pop("data", None) or {})
     if where is not None:
@@ -404,7 +505,11 @@ async def get_gdf(
                 "Pass token either via token= or data['token'], not both with different values.",
             )
         datadict["token"] = token
-    return await gdf_by_concat(url, session, data=datadict, **kwargs)
+    try:
+        return await gdf_by_concat(url, session, data=datadict, **kwargs)
+    finally:
+        if owns_session:
+            await session.close()
 
 
 # ---------------------------------------------------------------------------
@@ -490,7 +595,14 @@ async def _fetch_page_dict(
         **kwargs,
     )
     raw = await response.json(content_type=None)
-    return raw if isinstance(raw, dict) else {}
+    if not isinstance(raw, dict):
+        raise RestgdfResponseError(
+            f"{url}/query returned a non-object JSON payload.",
+            context="query_response_shape",
+            raw=raw,
+            url=f"{url}/query",
+        )
+    return raw
 
 
 async def _resolve_page(
@@ -656,55 +768,120 @@ async def _iter_pages_raw(
     try:
         query_data_batches = await get_query_data_batches(url, session, **kwargs)
         fetch_kwargs = {k: v for k, v in kwargs.items() if k != "data"}
-        sem = (
-            asyncio.Semaphore(max_concurrent_pages)
-            if max_concurrent_pages is not None
-            else None
-        )
 
         async def _fetch_bounded(query_data: dict) -> tuple[dict, dict[str, Any]]:
-            if sem is None:
-                page = await _fetch_page_dict(url, session, query_data, **fetch_kwargs)
-            else:
-                async with sem:
-                    page = await _fetch_page_dict(
-                        url,
-                        session,
-                        query_data,
-                        **fetch_kwargs,
-                    )
+            page = await _fetch_page_dict(
+                url,
+                session,
+                query_data,
+                **fetch_kwargs,
+            )
             return query_data, page
 
-        tasks = [asyncio.create_task(_fetch_bounded(qd)) for qd in query_data_batches]
+        if max_concurrent_pages is None:
+            tasks = [
+                asyncio.create_task(_fetch_bounded(qd)) for qd in query_data_batches
+            ]
+
+            if order == "completion":
+                for fut in asyncio.as_completed(tasks):
+                    query_data, page = await fut
+                    async for resolved in _resolve_page(
+                        url,
+                        session,
+                        page,
+                        query_data,
+                        on_truncation=on_truncation,
+                        depth=0,
+                        max_depth=max_split_depth,
+                        request_kwargs=kwargs,
+                    ):
+                        yield resolved
+            else:
+                for task in tasks:
+                    query_data, page = await task
+                    async for resolved in _resolve_page(
+                        url,
+                        session,
+                        page,
+                        query_data,
+                        on_truncation=on_truncation,
+                        depth=0,
+                        max_depth=max_split_depth,
+                        request_kwargs=kwargs,
+                    ):
+                        yield resolved
+            return
+
+        batch_iter = iter(query_data_batches)
+
+        def _submit_next() -> asyncio.Task | None:
+            try:
+                query_data = next(batch_iter)
+            except StopIteration:
+                return None
+            task = asyncio.create_task(_fetch_bounded(query_data))
+            tasks.append(task)
+            return task
 
         if order == "completion":
-            for fut in asyncio.as_completed(tasks):
-                query_data, page = await fut
-                async for resolved in _resolve_page(
-                    url,
-                    session,
-                    page,
-                    query_data,
-                    on_truncation=on_truncation,
-                    depth=0,
-                    max_depth=max_split_depth,
-                    request_kwargs=kwargs,
-                ):
-                    yield resolved
-        else:
-            for task in tasks:
-                query_data, page = await task
-                async for resolved in _resolve_page(
-                    url,
-                    session,
-                    page,
-                    query_data,
-                    on_truncation=on_truncation,
-                    depth=0,
-                    max_depth=max_split_depth,
-                    request_kwargs=kwargs,
-                ):
-                    yield resolved
+            pending: set[asyncio.Task] = set()
+            for _ in range(max_concurrent_pages):
+                next_task = _submit_next()
+                if next_task is None:
+                    break
+                pending.add(next_task)
+
+            while pending:
+                done, pending = await asyncio.wait(
+                    pending,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                completed_pages: list[tuple[dict, dict[str, Any]]] = []
+                for task in done:
+                    query_data, page = await task
+                    replacement = _submit_next()
+                    if replacement is not None:
+                        pending.add(replacement)
+                    completed_pages.append((query_data, page))
+                for query_data, page in completed_pages:
+                    async for resolved in _resolve_page(
+                        url,
+                        session,
+                        page,
+                        query_data,
+                        on_truncation=on_truncation,
+                        depth=0,
+                        max_depth=max_split_depth,
+                        request_kwargs=kwargs,
+                    ):
+                        yield resolved
+            return
+
+        pending_in_order: list[asyncio.Task] = []
+        for _ in range(max_concurrent_pages):
+            next_task = _submit_next()
+            if next_task is None:
+                break
+            pending_in_order.append(next_task)
+
+        while pending_in_order:
+            task = pending_in_order.pop(0)
+            query_data, page = await task
+            replacement = _submit_next()
+            if replacement is not None:
+                pending_in_order.append(replacement)
+            async for resolved in _resolve_page(
+                url,
+                session,
+                page,
+                query_data,
+                on_truncation=on_truncation,
+                depth=0,
+                max_depth=max_split_depth,
+                request_kwargs=kwargs,
+            ):
+                yield resolved
     finally:
         for task in tasks:
             if not task.done():

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -187,22 +187,29 @@ def chunk_values(values: list[int], chunk_size: int) -> list[list[int]]:
 
 
 def _advertised_max_record_count_factor(
-    metadata: Mapping[str, Any],
+    metadata: Mapping[str, Any] | LayerMetadata,
 ) -> float | None:
     """Return the server-advertised ``maxRecordCountFactor`` or ``None``.
 
-    Checks ``advancedQueryCapabilities.maxRecordCountFactor`` in the
-    raw layer metadata dict (R-72). Returns ``None`` when the
-    ``advancedQueryCapabilities`` block is missing, when the factor
-    key itself is absent, or when the advertised value is not a
-    positive number (``None`` / 0 / negative / non-numeric). The
-    return value is intended to be threaded straight through to
-    :func:`build_pagination_plan` as ``advertised_factor=``.
+    Accepts both the raw metadata mapping returned by low-level helpers
+    and the typed :class:`LayerMetadata` model used by the live
+    :class:`~restgdf.featurelayer.FeatureLayer` path. Returns ``None``
+    when the ``advancedQueryCapabilities`` block is missing, when the
+    factor key itself is absent, or when the advertised value is not a
+    positive number (``None`` / 0 / negative / non-numeric). The return
+    value is intended to be threaded straight through to
+    ``build_pagination_plan(..., advertised_factor=...)``.
     """
-    aqc = metadata.get("advancedQueryCapabilities")
-    if not isinstance(aqc, Mapping):
-        return None
-    raw = aqc.get("maxRecordCountFactor")
+    if isinstance(metadata, Mapping):
+        aqc = metadata.get("advancedQueryCapabilities")
+    else:
+        aqc = metadata.advanced_query_capabilities
+
+    if isinstance(aqc, Mapping):
+        raw = aqc.get("maxRecordCountFactor")
+    else:
+        raw = getattr(aqc, "max_record_count_factor", None)
+
     if raw is None or isinstance(raw, bool):
         # bool is a subclass of int; reject it so True/False never leak
         # into the numeric path and silently wire advertised_factor=1.0.
@@ -227,7 +234,7 @@ async def get_query_data_batches(
 
     When the layer metadata advertises an explicit
     ``advancedQueryCapabilities.maxRecordCountFactor`` (R-72), the
-    value is forwarded to :func:`build_pagination_plan` as
+    value is forwarded to ``build_pagination_plan`` as
     ``advertised_factor=`` so pagination batch sizes honor the
     server-published upper bound. Layers that do **not** advertise the
     field keep today's byte-for-byte batching: no ``advertised_factor``
@@ -236,8 +243,8 @@ async def get_query_data_batches(
 
     Pages observed at stream time that return zero features while
     setting ``exceededTransferLimit=true`` are flagged with
-    :class:`restgdf.errors.PaginationInconsistencyWarning` (R-73) from
-    :func:`_resolve_page`; see that helper for details.
+    ``PaginationInconsistencyWarning`` (R-73) from the internal page
+    resolver; see that helper for details.
     """
     request_data = dict(kwargs.get("data") or {})
     feature_count = await get_feature_count(url, session, **kwargs)

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from aiohttp import ClientSession
 
+from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._logging import get_logger
 from restgdf._models._drift import _parse_response
 from restgdf._models.responses import FeaturesResponse, LayerMetadata
@@ -37,7 +38,6 @@ from restgdf.utils._optional import (
     require_pyogrio_list_drivers,
 )
 from restgdf.utils._pagination import build_pagination_plan
-from restgdf.utils.token import ArcGISTokenSession
 from restgdf.utils.utils import where_var_in_list
 
 if TYPE_CHECKING:
@@ -66,7 +66,7 @@ def _get_supported_drivers() -> dict[str, str]:
 
 async def _get_sub_features(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     query_data: dict,
     *,
     batch_index: int | None = None,
@@ -95,7 +95,7 @@ async def _get_sub_features(
 
 async def _feature_batch_generator(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> AsyncGenerator[list[dict[str, Any]]]:
     """Yield raw ArcGIS feature batches without requiring pandas/geopandas."""
@@ -146,7 +146,7 @@ def chunk_values(values: list[int], chunk_size: int) -> list[list[int]]:
 
 async def get_query_data_batches(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> list[dict]:
     """Build query payloads for each request needed to read a layer."""
@@ -206,7 +206,7 @@ async def get_query_data_batches(
 
 async def get_sub_gdf(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     query_data: dict,
     **kwargs,
 ) -> GeoDataFrame:
@@ -234,7 +234,7 @@ async def get_sub_gdf(
 
 async def get_gdf_list(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> list[GeoDataFrame]:
     _require_geo_query_support("get_gdf_list()")
@@ -249,7 +249,7 @@ async def get_gdf_list(
 
 async def chunk_generator(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> AsyncGenerator[GeoDataFrame]:
     """
@@ -283,7 +283,7 @@ async def chunk_generator(
 
 async def row_dict_generator(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> AsyncGenerator[dict]:
     """Yield row-shaped dicts from an ArcGIS FeatureLayer.
@@ -320,7 +320,7 @@ async def concat_gdfs(gdfs: list[GeoDataFrame]) -> GeoDataFrame:
 
 async def gdf_by_concat(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> GeoDataFrame:
     _require_geo_query_support("gdf_by_concat()")
@@ -395,7 +395,7 @@ def _extract_raw_spatial_reference(
 async def _apply_spatial_reference_attr(
     gdf: GeoDataFrame,
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> None:
     """Stamp ``gdf.attrs['spatial_reference']`` from layer metadata (R-65).
@@ -420,7 +420,7 @@ async def _apply_spatial_reference_attr(
 
 async def _fetch_page_dict(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     query_data: Mapping[str, Any],
     **kwargs,
 ) -> dict[str, Any]:
@@ -439,7 +439,7 @@ async def _fetch_page_dict(
 
 async def _resolve_page(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     page: dict[str, Any],
     query_data: Mapping[str, Any],
     *,
@@ -532,7 +532,7 @@ async def _resolve_page(
 
 async def _iter_pages_raw(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     *,
     order: Literal["request", "completion"] = "request",
     max_concurrent_pages: int | None = None,

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -24,7 +24,7 @@ from restgdf.utils.getinfo import (
     get_object_ids,
     supports_pagination,
 )
-from restgdf.utils._http import default_timeout
+from restgdf.utils._http import _arcgis_request, default_timeout
 from restgdf.utils._metadata import (
     normalize_spatial_reference,
     supports_pagination_explicitly,
@@ -75,9 +75,10 @@ async def _get_sub_features(
     """Fetch a single query batch as raw ArcGIS feature dicts."""
     kwargs = {k: v for k, v in kwargs.items() if k != "data"}
     kwargs.setdefault("timeout", default_timeout())
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         f"{url}/query",
-        data=dict(query_data),
+        dict(query_data),
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )
@@ -218,9 +219,10 @@ async def get_sub_gdf(
     kwargs = {k: v for k, v in kwargs.items() if k != "data"}
     kwargs.setdefault("timeout", default_timeout())
 
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         f"{url}/query",
-        data=data,
+        data,
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )
@@ -427,9 +429,10 @@ async def _fetch_page_dict(
     """Fetch one query page and return the raw envelope dict."""
     kwargs = {k: v for k, v in kwargs.items() if k != "data"}
     kwargs.setdefault("timeout", default_timeout())
-    response = await session.post(
+    response = await _arcgis_request(
+        session,
         f"{url}/query",
-        data=dict(query_data),
+        dict(query_data),
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -19,6 +19,8 @@ from typing import Any
 from aiohttp import ClientSession, ServerTimeoutError
 from pydantic import BaseModel
 
+from restgdf._client._protocols import AsyncHTTPSession
+
 from restgdf.utils._http import (
     DEFAULT_METADATA_HEADERS,
     DEFAULTDICT,
@@ -49,7 +51,6 @@ from restgdf.utils._stats import (
     nested_count,
     nestedcount,
 )
-from restgdf.utils.token import ArcGISTokenSession
 from restgdf.errors import RestgdfTimeoutError
 
 __all__ = [
@@ -83,7 +84,7 @@ __all__ = [
 
 
 async def _feature_count_with_timeout(
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     url: str,
     token: str | None,
     *,
@@ -134,7 +135,7 @@ async def _feature_count_with_timeout(
 
 async def get_offset_range(
     url: str,
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     **kwargs,
 ) -> range:
     """Get the offset range for a layer.
@@ -151,7 +152,7 @@ async def get_offset_range(
 
 
 async def service_metadata(
-    session: ClientSession | ArcGISTokenSession,
+    session: AsyncHTTPSession,
     service_url: str,
     token: str | None = None,
     return_feature_count: bool = False,

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -53,6 +53,11 @@ from restgdf.utils._stats import (
 )
 from restgdf.errors import RestgdfTimeoutError
 
+try:
+    from restgdf.resilience import bounded_retry_timeout as _resilience_bounded_retry
+except ImportError:  # pragma: no cover - resilience extra not installed
+    _resilience_bounded_retry = None  # type: ignore[assignment]
+
 __all__ = [
     "ClientSession",
     "DEFAULTDICT",
@@ -91,15 +96,21 @@ async def _feature_count_with_timeout(
     timeout: float | None = None,
     max_attempts: int = 3,
 ) -> int:
-    """Fetch feature count with inline bounded retry.
+    """Fetch feature count with bounded retry on timeouts.
 
-    BL-51: inline-only retry (R-59 — no restgdf.resilience imports).
+    BL-51: when the ``resilience`` extra is installed, delegates to
+    :func:`restgdf.resilience.bounded_retry_timeout` (stamina-backed) so
+    restgdf has a single source of truth for retry semantics. When the
+    extra is absent, falls back to the inline loop below with identical
+    contract.
+
     Retries ONLY on timeout failures:
 
     * :class:`asyncio.TimeoutError` / :class:`TimeoutError`
     * :class:`aiohttp.ServerTimeoutError`
 
-    Connection-level failures (disconnect, reset, DNS failure),
+    Connection-level failures (disconnect, reset, DNS failure —
+    :class:`aiohttp.ClientConnectionError`, R-69),
     deterministic failures (:class:`~restgdf.errors.RestgdfResponseError`,
     schema mismatches), and any other exception fail fast on the first
     attempt without retry so real bugs and transport errors are not
@@ -114,6 +125,17 @@ async def _feature_count_with_timeout(
         kwargs["data"] = {"token": token}
     if timeout is not None:
         kwargs["timeout"] = timeout
+
+    if _resilience_bounded_retry is not None:
+
+        async def _call() -> int:
+            return await get_feature_count(url, session, **kwargs)
+
+        return await _resilience_bounded_retry(
+            _call,
+            max_attempts=max_attempts,
+            url=url,
+        )
 
     last_exc: BaseException | None = None
     for attempt in range(max_attempts):

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -430,6 +430,27 @@ class ArcGISTokenSession:
             **kwargs,
         )
 
+    @property
+    def closed(self) -> bool:
+        """Return ``True`` when the underlying :class:`aiohttp.ClientSession` is closed.
+
+        Delegating lets :class:`ArcGISTokenSession` satisfy the
+        :class:`~restgdf._client._protocols.AsyncHTTPSession` Protocol
+        uniformly with ``aiohttp.ClientSession`` (R-71).
+        """
+        return bool(self.session.closed)
+
+    async def close(self) -> None:
+        """Close the underlying :class:`aiohttp.ClientSession`.
+
+        Mirrors :meth:`aiohttp.ClientSession.close` so token sessions and
+        raw aiohttp sessions are interchangeable through the
+        :class:`~restgdf._client._protocols.AsyncHTTPSession` Protocol.
+        Idempotent: closing an already-closed session is a no-op.
+        """
+        if not self.session.closed:
+            await self.session.close()
+
     async def __aenter__(self) -> ArcGISTokenSession:
         """Enter the runtime context related to this object."""
         await self.update_token_if_needed()

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -435,8 +435,8 @@ class ArcGISTokenSession:
         """Return ``True`` when the underlying :class:`aiohttp.ClientSession` is closed.
 
         Delegating lets :class:`ArcGISTokenSession` satisfy the
-        :class:`~restgdf._client._protocols.AsyncHTTPSession` Protocol
-        uniformly with ``aiohttp.ClientSession`` (R-71).
+        internal ``AsyncHTTPSession`` transport Protocol uniformly with
+        ``aiohttp.ClientSession`` (R-71).
         """
         return bool(self.session.closed)
 
@@ -445,8 +445,8 @@ class ArcGISTokenSession:
 
         Mirrors :meth:`aiohttp.ClientSession.close` so token sessions and
         raw aiohttp sessions are interchangeable through the
-        :class:`~restgdf._client._protocols.AsyncHTTPSession` Protocol.
-        Idempotent: closing an already-closed session is a no-op.
+        internal ``AsyncHTTPSession`` transport Protocol. Idempotent:
+        closing an already-closed session is a no-op.
         """
         if not self.session.closed:
             await self.session.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,30 +119,43 @@ class FakeSession:
     ):
         self.default_post = default_post if default_post is not None else {"ok": True}
         self.default_get = default_get if default_get is not None else {"ok": True}
-        self.post_responses: list[Any] = []
-        self.get_responses: list[Any] = []
-        self.post_calls: list[tuple[str, dict]] = []
-        self.get_calls: list[tuple[str, dict]] = []
+        # T8 (R-74): after the GET/POST length-based routing change, the
+        # same logical ArcGIS request may flip between ``session.post`` and
+        # ``session.get`` depending on the encoded body size. We unify the
+        # recorded-call and scripted-response queues here so pre-existing
+        # tests that assert on ``post_calls`` / ``post_responses`` keep
+        # working without having to rewrite each call site individually.
+        self._responses: list[Any] = []
+        self.post_responses = self._responses
+        self.get_responses = self._responses
+        self._calls: list[tuple[str, dict]] = []
+        self.post_calls = self._calls
+        self.get_calls = self._calls
 
-    def _snapshot_kwargs(self, kwargs: dict) -> dict:
+    def _snapshot_kwargs(self, kwargs: dict, *, body_key: str) -> dict:
         snapshot: dict = {}
         for key, value in kwargs.items():
             if isinstance(value, dict):
                 snapshot[key] = dict(value)
             else:
                 snapshot[key] = value
+        # Mirror the body under both ``data`` (POST) and ``params`` (GET)
+        # so tests written against the legacy POST-only contract keep
+        # resolving ``kwargs["data"]`` when a short request now flips to
+        # GET (and vice-versa).
+        mirror_key = "params" if body_key == "data" else "data"
+        if body_key in snapshot and mirror_key not in snapshot:
+            snapshot[mirror_key] = snapshot[body_key]
         return snapshot
 
     def post(self, url: str, **kwargs) -> FakeResponse:
-        self.post_calls.append((url, self._snapshot_kwargs(kwargs)))
-        payload = (
-            self.post_responses.pop(0) if self.post_responses else self.default_post
-        )
+        self._calls.append((url, self._snapshot_kwargs(kwargs, body_key="data")))
+        payload = self._responses.pop(0) if self._responses else self.default_post
         return FakeResponse(payload)
 
     def get(self, url: str, **kwargs) -> FakeResponse:
-        self.get_calls.append((url, self._snapshot_kwargs(kwargs)))
-        payload = self.get_responses.pop(0) if self.get_responses else self.default_get
+        self._calls.append((url, self._snapshot_kwargs(kwargs, body_key="params")))
+        payload = self._responses.pop(0) if self._responses else self.default_get
         return FakeResponse(payload)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,18 +15,32 @@ def pytest_addoption(parser):
         default=False,
         help="run tests marked as requiring live network access",
     )
+    parser.addoption(
+        "--run-stress",
+        action="store_true",
+        default=False,
+        help="run tests marked as resource-intensive or property-based",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--run-network"):
-        return
+    skip_network = None
+    if not config.getoption("--run-network"):
+        skip_network = pytest.mark.skip(
+            reason="network test; pass --run-network to include live-service checks",
+        )
 
-    skip_network = pytest.mark.skip(
-        reason="network test; pass --run-network to include live-service checks",
-    )
+    skip_stress = None
+    if not config.getoption("--run-stress"):
+        skip_stress = pytest.mark.skip(
+            reason="stress test; pass --run-stress to include resource-intensive checks",
+        )
+
     for item in items:
-        if "network" in item.keywords:
+        if skip_network is not None and "network" in item.keywords:
             item.add_marker(skip_network)
+        if skip_stress is not None and "stress" in item.keywords:
+            item.add_marker(skip_stress)
 
 
 @pytest_asyncio.fixture

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -71,24 +71,47 @@ class MockFeatureLayerSession:
         self.metadata = metadata
         self.count = count
         self.object_ids = object_ids or list(range(1, count + 1))
-        self.post_calls: list[tuple[str, dict]] = []
-        self.get_calls: list[tuple[str, dict]] = []
+        # T8 (R-74): unify call records so tests that iterate over
+        # ``post_calls`` continue to see every ArcGIS request regardless
+        # of whether it went out as a GET or a POST. ``params`` on GETs
+        # is mirrored under ``data`` so ``call_kwargs["data"]`` keeps
+        # resolving.
+        self._calls: list[tuple[str, dict]] = []
+        self.post_calls = self._calls
+        self.get_calls = self._calls
 
     def get(self, url: str, **kwargs):
+        params = dict(kwargs.get("params", {}))
         copied_kwargs = {
             **kwargs,
-            "params": dict(kwargs.get("params", {})),
+            "params": params,
+            "data": params,
         }
-        self.get_calls.append((url, copied_kwargs))
+        self._calls.append((url, copied_kwargs))
+        # T8 (R-74): /query calls with short bodies now arrive as GET.
+        # Dispatch the payload the same way as POST so tests covering
+        # count / objectIds / feature pages continue to work.
+        if url.endswith("/query"):
+            if params.get("returnCountOnly"):
+                return MockRequestContext({"count": self.count})
+            if params.get("returnIdsOnly"):
+                return MockRequestContext(
+                    {
+                        "objectIdFieldName": "OBJECTID",
+                        "objectIds": self.object_ids,
+                    },
+                )
+            return MockRequestContext({"features": []})
         return MockRequestContext(self.metadata)
 
     def post(self, url: str, **kwargs):
+        data = dict(kwargs.get("data", {}))
         copied_kwargs = {
             **kwargs,
-            "data": dict(kwargs.get("data", {})),
+            "data": data,
+            "params": data,
         }
-        self.post_calls.append((url, copied_kwargs))
-        data = copied_kwargs["data"]
+        self._calls.append((url, copied_kwargs))
 
         if url.endswith("/query"):
             if data.get("returnCountOnly"):
@@ -634,8 +657,10 @@ async def test_getgdf_avoids_result_offset_when_pagination_is_unsupported():
         call_kwargs["data"]
         for url, call_kwargs in session.post_calls
         if url.endswith("/query")
-        and not call_kwargs["data"].get("returnCountOnly")
-        and not call_kwargs["data"].get("returnIdsOnly")
+        and str(call_kwargs["data"].get("returnCountOnly", "")).lower()
+        not in ("true", "1")
+        and str(call_kwargs["data"].get("returnIdsOnly", "")).lower()
+        not in ("true", "1")
     ]
 
     assert len(feature_queries) == 1
@@ -674,10 +699,14 @@ async def test_getgdf_falls_back_to_objectid_chunks_without_pagination():
     feature_queries = [
         data
         for data in query_calls
-        if not data.get("returnCountOnly") and not data.get("returnIdsOnly")
+        if str(data.get("returnCountOnly", "")).lower() not in ("true", "1")
+        and str(data.get("returnIdsOnly", "")).lower() not in ("true", "1")
     ]
 
-    assert any(data.get("returnIdsOnly") for data in query_calls)
+    assert any(
+        str(data.get("returnIdsOnly", "")).lower() in ("true", "1")
+        for data in query_calls
+    )
     assert len(feature_queries) == 3
     assert all("resultOffset" not in data for data in feature_queries)
     assert {data["where"] for data in feature_queries} == {

--- a/tests/test_adapters_stream.py
+++ b/tests/test_adapters_stream.py
@@ -25,6 +25,11 @@ class QuerySession:
         self.post_calls.append((url, kwargs))
         return JsonResponse(self.responses.pop(0))
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 @pytest.mark.asyncio
 async def test_iter_feature_batches_delegates() -> None:

--- a/tests/test_adapters_stream.py
+++ b/tests/test_adapters_stream.py
@@ -43,7 +43,7 @@ async def test_iter_feature_batches_delegates() -> None:
             batch
             async for batch in stream_adapter.iter_feature_batches(
                 "https://example.com/layer/0",
-                session,
+                session,  # type: ignore[arg-type]
             )
         ]
 
@@ -70,7 +70,7 @@ async def test_iter_rows_delegates() -> None:
             row
             async for row in stream_adapter.iter_rows(
                 "https://example.com/layer/0",
-                session,
+                session,  # type: ignore[arg-type]
             )
         ]
 
@@ -97,7 +97,7 @@ async def test_iter_gdf_chunks_delegates() -> None:
             chunk
             async for chunk in stream_adapter.iter_gdf_chunks(
                 "https://example.com/layer/0",
-                object(),
+                object(),  # type: ignore[arg-type]
             )
         ]
 
@@ -122,6 +122,6 @@ async def test_iter_gdf_chunks_requires_geo_stack(monkeypatch) -> None:
     with pytest.raises(OptionalDependencyError):
         async for _ in stream_adapter.iter_gdf_chunks(
             "https://example.com/layer/0",
-            object(),
+            object(),  # type: ignore[arg-type]
         ):
             pass

--- a/tests/test_base_install.py
+++ b/tests/test_base_install.py
@@ -53,24 +53,50 @@ class QuerySession:
     def __init__(self, responses: list[dict]):
         self.responses = list(responses)
         self.post_calls: list[tuple[str, dict]] = []
+        # T8 (R-74): short ArcGIS requests now route through GET.
+        # Alias get_calls onto post_calls so tests keep asserting
+        # on ``post_calls`` regardless of the verb selected.
+        self.get_calls = self.post_calls
 
-    async def post(self, url: str, **kwargs):
+    async def _record(self, url: str, kwargs: dict) -> JsonResponse:
         self.post_calls.append((url, kwargs))
         return JsonResponse(self.responses.pop(0))
+
+    async def post(self, url: str, **kwargs):
+        return await self._record(url, kwargs)
+
+    async def get(self, url: str, **kwargs):
+        # Mirror the body under the POST key so tests that inspect
+        # ``kwargs["data"]`` keep passing when the call is now a GET.
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self._record(url, kwargs)
 
 
 class RecordingTextSession:
     def __init__(self, response_text: str = "{}"):
         self.response_text = response_text
         self.post_calls: list[tuple[str, dict]] = []
+        self.get_calls = self.post_calls
 
-    async def post(self, url: str, **kwargs):
+    async def _record(self, url: str, kwargs: dict) -> TextResponse:
         self.post_calls.append((url, kwargs))
         return TextResponse(self.response_text)
+
+    async def post(self, url: str, **kwargs):
+        return await self._record(url, kwargs)
+
+    async def get(self, url: str, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self._record(url, kwargs)
 
 
 class RejectingSession:
     async def post(self, *args, **kwargs):
+        raise AssertionError("should fail before requesting")
+
+    async def get(self, *args, **kwargs):
         raise AssertionError("should fail before requesting")
 
 
@@ -94,6 +120,21 @@ class MockFeatureLayerSession:
             "params": dict(kwargs.get("params", {})),
         }
         self.get_calls.append((url, copied_kwargs))
+        # T8 (R-74): short ArcGIS /query calls flip from POST to GET.
+        # Reuse the same response routing as POST by interpreting
+        # ``params`` the same way a POST ``data`` payload was interpreted.
+        params = copied_kwargs["params"]
+        if url.endswith("/query"):
+            if params.get("returnCountOnly"):
+                return JsonResponse({"count": self.count})
+            if params.get("returnIdsOnly"):
+                return JsonResponse(
+                    {
+                        "objectIdFieldName": "OBJECTID",
+                        "objectIds": self.object_ids,
+                    },
+                )
+            return JsonResponse({"features": []})
         return JsonResponse(self.metadata)
 
     async def post(self, url: str, **kwargs):

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -46,9 +46,12 @@ async def test_get_feature_count_sends_minimal_count_payload(fake_session):
     assert len(fake_session.post_calls) == 1
     url, kwargs = fake_session.post_calls[0]
     assert url == "https://example.com/service/0/query"
+    # T8 (R-74): short count queries ride on GET, and bool/None values
+    # are coerced to ArcGIS wire strings ("true"/"false") so yarl/aiohttp
+    # will accept them as query-string parameters.
     assert kwargs["data"] == {
         "where": "1=1",
-        "returnCountOnly": True,
+        "returnCountOnly": "true",
         "f": "json",
     }
     # default_headers are merged in
@@ -76,7 +79,7 @@ async def test_get_feature_count_propagates_where_and_token_from_data(fake_sessi
     _, kwargs = fake_session.post_calls[0]
     assert kwargs["data"] == {
         "where": "STATUS = 'OPEN'",
-        "returnCountOnly": True,
+        "returnCountOnly": "true",
         "f": "json",
         "token": "abc",
     }
@@ -119,7 +122,7 @@ async def test_get_object_ids_preserves_where_and_returns_tuple(fake_session):
     _, kwargs = fake_session.post_calls[0]
     assert kwargs["data"] == {
         "where": "A=1",
-        "returnIdsOnly": True,
+        "returnIdsOnly": "true",
         "f": "json",
         "token": "t",
     }
@@ -142,8 +145,8 @@ async def test_getuniquevalues_sends_distinct_payload_string_field(fake_session)
     assert kwargs["data"] == {
         "where": "1=1",
         "f": "json",
-        "returnGeometry": False,
-        "returnDistinctValues": True,
+        "returnGeometry": "false",
+        "returnDistinctValues": "true",
         "outFields": "CITY",
     }
 
@@ -173,7 +176,8 @@ async def test_getvaluecounts_builds_statistics_payload(fake_session):
     assert data["groupByFieldsForStatistics"] == "CITY"
     assert data["outFields"] == "CITY"
     assert data["f"] == "json"
-    assert data["returnGeometry"] is False
+    # T8 (R-74): bool coerced to the ArcGIS wire string for GET params.
+    assert data["returnGeometry"] == "false"
     assert '"onStatisticField":"CITY"' in data["outStatistics"]
     assert '"outStatisticFieldName":"CITY_count"' in data["outStatistics"]
 

--- a/tests/test_choose_verb_live.py
+++ b/tests/test_choose_verb_live.py
@@ -1,0 +1,215 @@
+"""T8 (R-74): ``_choose_verb`` wired at every ArcGIS request site.
+
+Short bodies (URL + encoded body under the ArcGIS 8k practical limit) must
+route through HTTP GET; long bodies flip to POST so restgdf never emits a
+request that a real ArcGIS server will refuse with 414 URI Too Long.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from restgdf.utils._http import _choose_verb, _ARCGIS_URL_BODY_LIMIT
+from restgdf.utils._query import get_feature_count, get_object_ids
+from restgdf.utils._stats import get_unique_values
+from restgdf.utils.getgdf import _fetch_page_dict, _get_sub_features
+
+
+class _RecordingResponse:
+    """Async response stub matching the shape restgdf helpers consume."""
+
+    def __init__(self, payload: Any):
+        self._payload = payload
+
+    def __await__(self):
+        async def _resolve() -> _RecordingResponse:
+            return self
+
+        return _resolve().__await__()
+
+    async def __aenter__(self) -> "_RecordingResponse":
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback) -> None:
+        return None
+
+    async def json(self, content_type: str | None = None):
+        return self._payload
+
+    async def text(self) -> str:
+        return json.dumps(self._payload)
+
+
+class _RecordingSession:
+    """Session double that records the HTTP verb used per call."""
+
+    def __init__(self, payload: Any):
+        self._payload = payload
+        self.verbs: list[str] = []
+        self.calls: list[tuple[str, str, dict]] = []
+
+    def get(self, url: str, **kwargs) -> _RecordingResponse:
+        self.verbs.append("GET")
+        self.calls.append(("GET", url, dict(kwargs)))
+        return _RecordingResponse(self._payload)
+
+    def post(self, url: str, **kwargs) -> _RecordingResponse:
+        self.verbs.append("POST")
+        self.calls.append(("POST", url, dict(kwargs)))
+        return _RecordingResponse(self._payload)
+
+
+# ---------------------------------------------------------------------------
+# Helper-level invariants
+# ---------------------------------------------------------------------------
+
+
+def test_choose_verb_short_body_returns_get() -> None:
+    body = {"where": "1=1", "f": "json", "returnCountOnly": True}
+    assert _choose_verb("https://example.com/s/FeatureServer/0/query", body) == "GET"
+
+
+def test_choose_verb_no_body_returns_get() -> None:
+    assert _choose_verb("https://example.com/s/FeatureServer/0") == "GET"
+
+
+def test_choose_verb_oversized_body_returns_post() -> None:
+    long_where = "OBJECTID IN (" + ",".join(str(i) for i in range(2000)) + ")"
+    body = {"where": long_where, "f": "json", "returnCountOnly": True}
+    assert _choose_verb("https://example.com/s/FeatureServer/0/query", body) == "POST"
+
+
+def test_choose_verb_threshold_is_arcgis_practical_limit() -> None:
+    assert _ARCGIS_URL_BODY_LIMIT == 8192
+
+
+# ---------------------------------------------------------------------------
+# Call-site wiring — get_count / get_feature_count
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_feature_count_short_where_routes_to_get() -> None:
+    session = _RecordingSession({"count": 42})
+
+    count = await get_feature_count(
+        "https://example.com/service/0",
+        session,
+    )
+
+    assert count == 42
+    assert session.verbs == ["GET"]
+    verb, url, kwargs = session.calls[0]
+    assert url == "https://example.com/service/0/query"
+    assert kwargs["params"]["where"] == "1=1"
+    assert kwargs["params"]["returnCountOnly"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_get_feature_count_long_where_routes_to_post() -> None:
+    long_where = "OBJECTID IN (" + ",".join(str(i) for i in range(2000)) + ")"
+    session = _RecordingSession({"count": 99})
+
+    count = await get_feature_count(
+        "https://example.com/service/0",
+        session,
+        data={"where": long_where},
+    )
+
+    assert count == 99
+    assert session.verbs == ["POST"]
+    verb, url, kwargs = session.calls[0]
+    assert url == "https://example.com/service/0/query"
+    assert kwargs["data"]["where"] == long_where
+
+
+# ---------------------------------------------------------------------------
+# Call-site wiring — other /query helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_object_ids_short_where_routes_to_get() -> None:
+    session = _RecordingSession(
+        {"objectIdFieldName": "OBJECTID", "objectIds": [1, 2, 3]},
+    )
+    field, ids = await get_object_ids("https://example.com/service/0", session)
+
+    assert field == "OBJECTID"
+    assert ids == [1, 2, 3]
+    assert session.verbs == ["GET"]
+
+
+@pytest.mark.asyncio
+async def test_get_object_ids_long_where_routes_to_post() -> None:
+    long_where = "OBJECTID IN (" + ",".join(str(i) for i in range(2000)) + ")"
+    session = _RecordingSession(
+        {"objectIdFieldName": "OBJECTID", "objectIds": []},
+    )
+    await get_object_ids(
+        "https://example.com/service/0",
+        session,
+        data={"where": long_where},
+    )
+    assert session.verbs == ["POST"]
+
+
+@pytest.mark.asyncio
+async def test_get_unique_values_long_outfields_routes_to_post() -> None:
+    long_field = "F_" + ("X" * 9000)
+    session = _RecordingSession({"features": []})
+    await get_unique_values(
+        "https://example.com/service/0",
+        long_field,
+        session,
+    )
+    assert session.verbs == ["POST"]
+
+
+@pytest.mark.asyncio
+async def test_get_sub_features_short_query_routes_to_get() -> None:
+    session = _RecordingSession({"features": [], "exceededTransferLimit": False})
+    await _get_sub_features(
+        "https://example.com/service/0",
+        session,
+        {"where": "1=1", "f": "json"},
+    )
+    assert session.verbs == ["GET"]
+
+
+@pytest.mark.asyncio
+async def test_get_sub_features_long_query_routes_to_post() -> None:
+    long_where = "OBJECTID IN (" + ",".join(str(i) for i in range(2000)) + ")"
+    session = _RecordingSession({"features": [], "exceededTransferLimit": False})
+    await _get_sub_features(
+        "https://example.com/service/0",
+        session,
+        {"where": long_where, "f": "json"},
+    )
+    assert session.verbs == ["POST"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_dict_short_query_routes_to_get() -> None:
+    session = _RecordingSession({"features": []})
+    await _fetch_page_dict(
+        "https://example.com/service/0",
+        session,
+        {"where": "1=1", "f": "json"},
+    )
+    assert session.verbs == ["GET"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_dict_long_query_routes_to_post() -> None:
+    long_where = "OBJECTID IN (" + ",".join(str(i) for i in range(2000)) + ")"
+    session = _RecordingSession({"features": []})
+    await _fetch_page_dict(
+        "https://example.com/service/0",
+        session,
+        {"where": long_where, "f": "json"},
+    )
+    assert session.verbs == ["POST"]

--- a/tests/test_choose_verb_live.py
+++ b/tests/test_choose_verb_live.py
@@ -30,7 +30,7 @@ class _RecordingResponse:
 
         return _resolve().__await__()
 
-    async def __aenter__(self) -> "_RecordingResponse":
+    async def __aenter__(self) -> _RecordingResponse:
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
@@ -48,8 +48,16 @@ class _RecordingSession:
 
     def __init__(self, payload: Any):
         self._payload = payload
+        self._closed = False
         self.verbs: list[str] = []
         self.calls: list[tuple[str, str, dict]] = []
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def close(self) -> None:
+        self._closed = True
 
     def get(self, url: str, **kwargs) -> _RecordingResponse:
         self.verbs.append("GET")

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -7,6 +7,7 @@ materializes ``restgdf.utils._concurrency`` and the Settings field.
 from __future__ import annotations
 
 import asyncio
+import inspect
 
 import pytest
 
@@ -77,18 +78,23 @@ async def test_bounded_gather_cancellation_releases_slots():
 
     sem = asyncio.BoundedSemaphore(2)
     started = asyncio.Event()
+    release = asyncio.Event()
 
     async def slow() -> None:
         started.set()
-        await asyncio.sleep(10)
+        await release.wait()
 
+    coros = [slow() for _ in range(5)]
     outer = asyncio.create_task(
-        bounded_gather(*(slow() for _ in range(5)), semaphore=sem),
+        bounded_gather(*coros, semaphore=sem),
     )
     await started.wait()
     outer.cancel()
     with pytest.raises(asyncio.CancelledError):
         await outer
+    for coro in coros:
+        if inspect.getcoroutinestate(coro) == inspect.CORO_CREATED:
+            coro.close()
 
     # All slots must be free afterwards — we should be able to acquire
     # ``sem._value`` times without blocking.

--- a/tests/test_credentials_coverage.py
+++ b/tests/test_credentials_coverage.py
@@ -1,0 +1,122 @@
+"""Coverage tests for :mod:`restgdf._models.credentials`.
+
+Targets the root ``_translate_legacy_refresh_threshold`` validator
+branches that are not exercised by ``tests/test_models_credentials.py``:
+
+* non-dict ``data`` passthrough (line 109)
+* non-int ``refresh_threshold_seconds`` legacy alias fallthrough to the
+  field validators (lines 121-125)
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from pydantic import ValidationError
+
+from restgdf._models.credentials import AGOLUserPass, TokenSessionConfig
+
+
+def _creds() -> AGOLUserPass:
+    return AGOLUserPass(username="u", password="p")
+
+
+def test_before_validator_passes_non_dict_through_unchanged():
+    """When ``model_validate`` receives a non-dict (e.g. an existing
+    model instance), the ``mode='before'`` validator must return it
+    unchanged rather than attempt a ``.pop()``.
+    """
+    original = TokenSessionConfig(
+        token_url="https://example.com/token",
+        credentials=_creds(),
+    )
+
+    # Re-validating an instance hands the validator the instance itself
+    # (not a dict). The branch under test simply returns it through.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        revalidated = TokenSessionConfig.model_validate(original)
+
+    assert revalidated.token_url == original.token_url
+    assert revalidated.refresh_leeway_seconds == original.refresh_leeway_seconds
+    assert revalidated.clock_skew_seconds == original.clock_skew_seconds
+
+
+def test_before_validator_returns_non_dict_mapping_like_inputs_directly():
+    """Passing a non-dict, non-model object to ``model_validate`` still
+    reaches the early-return branch; pydantic then raises its own error
+    downstream. We only assert the validator itself does not blow up on
+    the ``.pop()`` path.
+    """
+    sentinel = ["not", "a", "dict"]
+    with pytest.raises(ValidationError):
+        # pydantic will reject the list at the outer schema, but the
+        # ``mode='before'`` validator runs first and must pass it through.
+        TokenSessionConfig.model_validate(sentinel)
+
+
+def test_legacy_refresh_threshold_string_coerces_via_field_validator():
+    """A string ``refresh_threshold_seconds`` is *not* split into
+    ``clock_skew_seconds`` / ``refresh_leeway_seconds``; it is placed
+    into ``refresh_leeway_seconds`` so pydantic's field validator can
+    coerce or reject it. A numeric string like ``"75"`` coerces cleanly.
+    """
+    with pytest.warns(DeprecationWarning, match="refresh_threshold_seconds"):
+        cfg = TokenSessionConfig(
+            token_url="https://example.com/token",
+            credentials=_creds(),
+            refresh_threshold_seconds="75",  # type: ignore[arg-type]
+        )
+
+    # Because the non-int branch defers to field validators, the full
+    # value lands in ``refresh_leeway_seconds`` and ``clock_skew_seconds``
+    # keeps its default — no 30-cap split is applied.
+    assert cfg.refresh_leeway_seconds == 75
+    assert cfg.clock_skew_seconds == 30
+
+
+def test_legacy_refresh_threshold_bool_is_treated_as_non_int():
+    """``bool`` is a subclass of ``int`` in Python, but the validator
+    explicitly rejects it so ``refresh_threshold_seconds=True`` does not
+    silently become ``1``. It falls through to the field validator,
+    which accepts ``True`` as ``1`` for ``refresh_leeway_seconds``.
+    """
+    with pytest.warns(DeprecationWarning):
+        cfg = TokenSessionConfig(
+            token_url="https://example.com/token",
+            credentials=_creds(),
+            refresh_threshold_seconds=True,  # type: ignore[arg-type]
+        )
+
+    # ``True`` lands in ``refresh_leeway_seconds`` untouched by the
+    # split logic; ``clock_skew_seconds`` keeps its default.
+    assert cfg.refresh_leeway_seconds == 1
+    assert cfg.clock_skew_seconds == 30
+
+
+def test_legacy_refresh_threshold_non_numeric_string_fails_field_validation():
+    """A non-numeric string survives the root validator (non-int branch)
+    and is rejected by the ``refresh_leeway_seconds`` field validator.
+    """
+    with pytest.warns(DeprecationWarning), pytest.raises(ValidationError):
+        TokenSessionConfig(
+            token_url="https://example.com/token",
+            credentials=_creds(),
+            refresh_threshold_seconds="not-a-number",  # type: ignore[arg-type]
+        )
+
+
+def test_legacy_refresh_threshold_does_not_overwrite_explicit_leeway():
+    """``setdefault`` is used on the non-int path, so an explicit
+    ``refresh_leeway_seconds`` wins over the legacy alias value.
+    """
+    with pytest.warns(DeprecationWarning):
+        cfg = TokenSessionConfig(
+            token_url="https://example.com/token",
+            credentials=_creds(),
+            refresh_threshold_seconds="999",  # type: ignore[arg-type]
+            refresh_leeway_seconds=10,
+        )
+
+    assert cfg.refresh_leeway_seconds == 10

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -139,6 +139,8 @@ def test_legacy_getvaluecounts_warns_and_delegates():
         )
         session = AsyncMock()
         session.post = AsyncMock(return_value=response)
+        # T8 (R-74): short ``get_value_counts`` bodies now route to GET.
+        session.get = AsyncMock(return_value=response)
 
         with pytest.warns(DeprecationWarning, match=r"get_value_counts"):
             df = loop.run_until_complete(
@@ -169,6 +171,8 @@ def test_legacy_nestedcount_warns_and_delegates():
         )
         session = AsyncMock()
         session.post = AsyncMock(return_value=response)
+        # T8 (R-74): short ``nested_count`` bodies now route to GET.
+        session.get = AsyncMock(return_value=response)
 
         with pytest.warns(DeprecationWarning, match=r"nested_count"):
             df = loop.run_until_complete(

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -116,6 +116,8 @@ def test_legacy_getuniquevalues_warns_and_delegates():
         )
         session = AsyncMock()
         session.post = AsyncMock(return_value=response)
+        # T8 (R-74): short ``get_unique_values`` bodies now route to GET.
+        session.get = AsyncMock(return_value=response)
 
         with pytest.warns(DeprecationWarning, match=r"get_unique_values"):
             result = loop.run_until_complete(

--- a/tests/test_domain_verb_seam.py
+++ b/tests/test_domain_verb_seam.py
@@ -1,55 +1,49 @@
-"""BL-20 red tests: request-verb seam.
+"""T8 (R-74) tests: length-based request-verb seam.
 
-Per MASTER-PLAN §5 BL-20 (MASTER-PLAN.md:143-144):
-
-> BL-20. Deterministic request-verb seam. Add a private
->   ``_choose_verb(url, body=None)`` helper that returns
->   ``"POST"`` for ArcGIS ``/query`` and ``/queryRelatedRecords``
->   endpoints, ``"GET"`` for metadata-style requests, and ``"POST"``
->   as the conservative default for unknown URLs.
-
-These tests probe the seam only; call sites are NOT rewired in this
-slice (a later BL-50 extends this to auto-switch GET → POST when a
-``where`` clause pushes a GET URL past the ArcGIS ~1800-byte budget).
+Per the v3 follow-up plan, ``_choose_verb`` was extended in T8 (R-74)
+from the original BL-20 endpoint-classification contract to a length
+based policy: short requests use GET, long requests (URL + encoded body
+over the ~8 KiB budget) use POST. The prior BL-20 expectations — that
+``/query`` endpoints always POST and metadata endpoints always GET —
+were superseded by this slice. Tests below probe the new contract; the
+call-site wiring is covered in ``test_choose_verb_live.py``.
 """
 
 from __future__ import annotations
 
 
-def test_choose_verb_default_for_unknown_url_is_post():
-    """Named red per plan.md §3c R-34/R-35: the default for URLs that
-    match none of the known families must be POST (conservative — avoids
-    URL-length blowups and works with any body)."""
+def test_choose_verb_short_unknown_url_is_get():
+    """Short requests to unfamiliar URLs default to GET under the new
+    length-based policy; POST is reserved for oversized bodies."""
     from restgdf.utils._http import _choose_verb
 
-    assert _choose_verb("https://example.com/some/unknown/path") == "POST"
-    assert _choose_verb("https://example.com/arbitrary/endpoint") == "POST"
+    assert _choose_verb("https://example.com/some/unknown/path") == "GET"
+    assert _choose_verb("https://example.com/arbitrary/endpoint") == "GET"
 
 
-def test_choose_verb_query_endpoint_is_post():
+def test_choose_verb_short_query_endpoint_is_get():
     from restgdf.utils._http import _choose_verb
 
     assert (
         _choose_verb(
             "https://example.com/ArcGIS/rest/services/X/FeatureServer/0/query",
         )
-        == "POST"
+        == "GET"
     )
 
 
-def test_choose_verb_query_related_records_is_post():
+def test_choose_verb_short_query_related_records_is_get():
     from restgdf.utils._http import _choose_verb
 
     url = (
         "https://example.com/ArcGIS/rest/services/X/FeatureServer/0/"
         "queryRelatedRecords"
     )
-    assert _choose_verb(url) == "POST"
+    assert _choose_verb(url) == "GET"
 
 
 def test_choose_verb_metadata_endpoint_is_get():
-    """Bare service / layer metadata URLs (no trailing ``/query`` or
-    ``/queryRelatedRecords``) are short and idempotent — GET."""
+    """Bare service / layer metadata URLs are short and idempotent — GET."""
     from restgdf.utils._http import _choose_verb
 
     assert (
@@ -67,10 +61,8 @@ def test_choose_verb_metadata_endpoint_is_get():
 
 
 def test_choose_verb_accepts_optional_body_mapping():
-    """The signature is ``_choose_verb(url, body=None)`` so BL-50 can
-    later inspect the ``where`` clause and switch based on serialized
-    length — today, the body is ignored but must be accepted without
-    raising."""
+    """The signature is ``_choose_verb(url, body=None)``; a small body
+    keeps the request under the byte budget and stays GET."""
     from restgdf.utils._http import _choose_verb
 
     assert (
@@ -78,7 +70,7 @@ def test_choose_verb_accepts_optional_body_mapping():
             "https://example.com/ArcGIS/rest/services/X/FeatureServer/0/query",
             body={"where": "1=1", "outFields": "*"},
         )
-        == "POST"
+        == "GET"
     )
     assert (
         _choose_verb(

--- a/tests/test_error_format_characterization.py
+++ b/tests/test_error_format_characterization.py
@@ -86,7 +86,7 @@ async def test_get_feature_count_consumes_text_plain_json_fixture() -> None:
         ),
     )
 
-    count = await get_feature_count("https://example.com/service/0", session)
+    count = await get_feature_count("https://example.com/service/0", session)  # type: ignore[arg-type]
 
     assert count == 42
     assert session.post_calls[0][0] == "https://example.com/service/0/query"
@@ -102,7 +102,7 @@ async def test_get_feature_count_html_body_bubbles_json_decode_error() -> None:
     )
 
     with pytest.raises(JSONDecodeError):
-        await get_feature_count("https://example.com/service/0", session)
+        await get_feature_count("https://example.com/service/0", session)  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/test_error_format_characterization.py
+++ b/tests/test_error_format_characterization.py
@@ -66,6 +66,11 @@ class ScriptedQuerySession:
         self.post_calls.append((url, dict(kwargs)))
         return self.response
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 class ScriptedTokenSession:
     def __init__(self, response: FixtureResponse):

--- a/tests/test_feature_count_retry_delegation.py
+++ b/tests/test_feature_count_retry_delegation.py
@@ -1,0 +1,179 @@
+"""BL-51: `_feature_count_with_timeout` delegates retry to the shared
+``restgdf.resilience`` module when available, with an inline fallback.
+
+These tests complement ``test_feature_count_timeout_retry.py`` (which
+covers the user-visible contract) by verifying the delegation seam:
+
+* When ``_resilience_bounded_retry`` is present, it is invoked.
+* When it is absent (simulated by monkeypatching to ``None``), the inline
+  loop still runs and preserves the same semantics (timeout retry,
+  ClientConnectionError propagation, RestgdfTimeoutError wrapping).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import ClientConnectionError, ClientSession
+
+from restgdf.errors import RestgdfTimeoutError
+from restgdf.utils import getinfo
+from restgdf.utils.getinfo import _feature_count_with_timeout
+
+
+@pytest.mark.asyncio
+async def test_delegates_to_resilience_when_available(monkeypatch):
+    """When ``_resilience_bounded_retry`` is set, it must be invoked."""
+    calls: dict[str, object] = {}
+
+    async def _probe(func, *, max_attempts, url):
+        calls["invoked"] = True
+        calls["max_attempts"] = max_attempts
+        calls["url"] = url
+        return await func()
+
+    async def _fake_get_feature_count(*args, **kwargs):
+        calls["inner_called"] = True
+        return 7
+
+    monkeypatch.setattr(getinfo, "_resilience_bounded_retry", _probe)
+    monkeypatch.setattr(getinfo, "get_feature_count", _fake_get_feature_count)
+
+    async with ClientSession() as session:
+        result = await _feature_count_with_timeout(
+            session,
+            "https://svc.example/0",
+            None,
+            max_attempts=4,
+        )
+
+    assert result == 7
+    assert calls.get("invoked") is True
+    assert calls["max_attempts"] == 4
+    assert calls["url"] == "https://svc.example/0"
+    assert calls.get("inner_called") is True
+
+
+@pytest.mark.asyncio
+async def test_inline_fallback_when_resilience_absent(monkeypatch):
+    """With the delegation hook unset, the inline loop handles retries."""
+    attempts: list[int] = []
+
+    async def _flaky(*args, **kwargs):
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise asyncio.TimeoutError
+        return 11
+
+    monkeypatch.setattr(getinfo, "_resilience_bounded_retry", None)
+    monkeypatch.setattr(getinfo, "get_feature_count", _flaky)
+
+    async with ClientSession() as session:
+        result = await _feature_count_with_timeout(
+            session,
+            "https://svc.example/0",
+            None,
+            max_attempts=3,
+        )
+
+    assert result == 11
+    assert len(attempts) == 3
+
+
+@pytest.mark.asyncio
+async def test_inline_fallback_preserves_R69_connection_propagation(monkeypatch):
+    """Fallback path must propagate ClientConnectionError without retry."""
+    attempts: list[int] = []
+
+    async def _raising(*args, **kwargs):
+        attempts.append(1)
+        raise ClientConnectionError("reset")
+
+    monkeypatch.setattr(getinfo, "_resilience_bounded_retry", None)
+    monkeypatch.setattr(getinfo, "get_feature_count", _raising)
+
+    async with ClientSession() as session:
+        with pytest.raises(ClientConnectionError):
+            await _feature_count_with_timeout(
+                session,
+                "https://svc.example/0",
+                None,
+                max_attempts=3,
+            )
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
+async def test_inline_fallback_wraps_timeout_after_exhaustion(monkeypatch):
+    """Fallback path: exhausted timeouts wrap to RestgdfTimeoutError."""
+
+    async def _always_timeout(*args, **kwargs):
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(getinfo, "_resilience_bounded_retry", None)
+    monkeypatch.setattr(getinfo, "get_feature_count", _always_timeout)
+
+    async with ClientSession() as session:
+        with pytest.raises(RestgdfTimeoutError) as exc_info:
+            await _feature_count_with_timeout(
+                session,
+                "https://svc.example/0",
+                None,
+                max_attempts=2,
+            )
+    assert isinstance(exc_info.value.__cause__, (asyncio.TimeoutError, TimeoutError))
+
+
+@pytest.mark.asyncio
+async def test_delegation_path_propagates_connection_error(monkeypatch):
+    """Through the resilience helper, ClientConnectionError must NOT be
+    retried or wrapped — it must surface unchanged (R-69)."""
+    from restgdf.resilience import bounded_retry_timeout
+
+    attempts: list[int] = []
+
+    async def _raising(*args, **kwargs):
+        attempts.append(1)
+        raise ClientConnectionError("reset")
+
+    # Use the real helper (not monkeypatched) to prove the contract.
+    monkeypatch.setattr(getinfo, "_resilience_bounded_retry", bounded_retry_timeout)
+    monkeypatch.setattr(getinfo, "get_feature_count", _raising)
+
+    async with ClientSession() as session:
+        with pytest.raises(ClientConnectionError):
+            await _feature_count_with_timeout(
+                session,
+                "https://svc.example/0",
+                None,
+                max_attempts=3,
+            )
+    assert len(attempts) == 1
+
+
+@pytest.mark.asyncio
+async def test_delegation_path_wraps_timeout_after_exhaustion(monkeypatch):
+    """Through the resilience helper, exhausted timeouts wrap to
+    RestgdfTimeoutError with the original timeout as __cause__."""
+    from restgdf.resilience import bounded_retry_timeout
+
+    attempts: list[int] = []
+
+    async def _always_timeout(*args, **kwargs):
+        attempts.append(1)
+        raise asyncio.TimeoutError
+
+    monkeypatch.setattr(getinfo, "_resilience_bounded_retry", bounded_retry_timeout)
+    monkeypatch.setattr(getinfo, "get_feature_count", _always_timeout)
+
+    async with ClientSession() as session:
+        with pytest.raises(RestgdfTimeoutError) as exc_info:
+            await _feature_count_with_timeout(
+                session,
+                "https://svc.example/0",
+                None,
+                max_attempts=2,
+            )
+    assert len(attempts) == 2
+    assert isinstance(exc_info.value.__cause__, (asyncio.TimeoutError, TimeoutError))

--- a/tests/test_feature_count_timeout_retry.py
+++ b/tests/test_feature_count_timeout_retry.py
@@ -8,6 +8,7 @@ the inline retry wrapper that converts ``asyncio.TimeoutError`` into
 from __future__ import annotations
 
 import asyncio
+import re
 
 import pytest
 from aiohttp import ClientSession
@@ -16,14 +17,18 @@ from aioresponses import aioresponses
 from restgdf.errors import RestgdfTimeoutError
 from restgdf.utils.getinfo import _feature_count_with_timeout
 
+# T8 (R-74): short count queries now route to GET with a query string,
+# so aioresponses needs a regex pattern that matches any `?...` suffix.
+_QUERY_URL_RE = re.compile(r"^https://svc\.example/0/query(\?.*)?$")
+
 
 @pytest.mark.asyncio
 async def test_feature_count_timeout_raises_RestgdfTimeoutError():
     """All attempts timeout → RestgdfTimeoutError raised."""
     async with ClientSession() as session:
         with aioresponses() as m:
-            m.post(
-                "https://svc.example/0/query",
+            m.get(
+                _QUERY_URL_RE,
                 exception=asyncio.TimeoutError(),
                 repeat=True,
             )
@@ -42,8 +47,8 @@ async def test_feature_count_chains_timeout_cause():
     """RestgdfTimeoutError.__cause__ should be the original TimeoutError."""
     async with ClientSession() as session:
         with aioresponses() as m:
-            m.post(
-                "https://svc.example/0/query",
+            m.get(
+                _QUERY_URL_RE,
                 exception=asyncio.TimeoutError(),
                 repeat=True,
             )
@@ -65,10 +70,10 @@ async def test_feature_count_retries_on_transient_failure():
     """Two failures then success → returns count."""
     async with ClientSession() as session:
         with aioresponses() as m:
-            m.post("https://svc.example/0/query", exception=asyncio.TimeoutError())
-            m.post("https://svc.example/0/query", exception=asyncio.TimeoutError())
-            m.post(
-                "https://svc.example/0/query",
+            m.get(_QUERY_URL_RE, exception=asyncio.TimeoutError())
+            m.get(_QUERY_URL_RE, exception=asyncio.TimeoutError())
+            m.get(
+                _QUERY_URL_RE,
                 payload={"count": 42},
             )
             result = await _feature_count_with_timeout(
@@ -85,8 +90,8 @@ async def test_feature_count_single_success_no_retry():
     """First attempt succeeds → no retry, returns count."""
     async with ClientSession() as session:
         with aioresponses() as m:
-            m.post(
-                "https://svc.example/0/query",
+            m.get(
+                _QUERY_URL_RE,
                 payload={"count": 100},
             )
             result = await _feature_count_with_timeout(

--- a/tests/test_feature_layer_iter_pages.py
+++ b/tests/test_feature_layer_iter_pages.py
@@ -40,6 +40,11 @@ class _ScriptedSession:
         self.post_calls.append((url, kwargs))
         return _JsonResp(self.payloads.pop(0))
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 class _DelayedSession:
     """Serves POST payloads with per-call delays (seconds)."""
@@ -57,6 +62,11 @@ class _DelayedSession:
         delay, payload = self.pairs[idx]
         await asyncio.sleep(delay)
         return _JsonResp(payload)
+
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
 
 
 def _make_layer():
@@ -136,6 +146,11 @@ async def test_iter_pages_max_concurrent_pages_bounds_inflight():
                 inflight -= 1
             self.post_calls.append((url, kwargs))
             return _JsonResp({"features": []})
+
+        async def get(self, url, **kwargs):
+            if "params" in kwargs and "data" not in kwargs:
+                kwargs = {**kwargs, "data": kwargs["params"]}
+            return await self.post(url, **kwargs)
 
     layer.session = _TrackedSession()
     batches = [{"resultOffset": i} for i in range(6)]

--- a/tests/test_feature_layer_streaming_public.py
+++ b/tests/test_feature_layer_streaming_public.py
@@ -36,6 +36,11 @@ class _ScriptedSession:
         self.post_calls.append((url, kwargs))
         return _JsonResp(self.payloads.pop(0))
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 def _make_layer():
     layer = FeatureLayer(

--- a/tests/test_featurelayer_get_df_base_install.py
+++ b/tests/test_featurelayer_get_df_base_install.py
@@ -51,6 +51,11 @@ class QuerySession:
         self.post_calls.append((url, kwargs))
         return JsonResponse(self.responses.pop(0))
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 @pytest.mark.asyncio
 async def test_get_df_returns_pandas_dataframe_when_pandas_available() -> None:

--- a/tests/test_featurelayer_get_df_base_install.py
+++ b/tests/test_featurelayer_get_df_base_install.py
@@ -72,7 +72,7 @@ async def test_get_df_returns_pandas_dataframe_when_pandas_available() -> None:
 
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Test/FeatureServer/0",
-        session=session,
+        session=session,  # type: ignore[arg-type]
     )
 
     with patch(
@@ -119,7 +119,7 @@ async def test_get_df_raises_optional_dependency_error_without_pandas(
     )
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Test/FeatureServer/0",
-        session=session,
+        session=session,  # type: ignore[arg-type]
     )
 
     with patch(

--- a/tests/test_featurelayer_typed.py
+++ b/tests/test_featurelayer_typed.py
@@ -42,6 +42,10 @@ class _Session:
         self.count = count
 
     def get(self, url, **kwargs):
+        params = kwargs.get("params") or {}
+        # T8 (R-74): metadata endpoint and short /query bodies arrive as GET.
+        if url.endswith("/query") and params.get("returnCountOnly"):
+            return _Resp({"count": self.count})
         return _Resp(self.metadata)
 
     def post(self, url, **kwargs):

--- a/tests/test_featurelayer_where_memoization.py
+++ b/tests/test_featurelayer_where_memoization.py
@@ -25,6 +25,10 @@ LAYER_URL = "https://svc.example/arcgis/rest/services/Demo/FeatureServer/0"
 METADATA_URL_RE = re.compile(
     r"^https://svc\.example/arcgis/rest/services/Demo/FeatureServer/0(\?.*)?$",
 )
+# T8 (R-74): short count queries ride on GET and carry a query string.
+QUERY_URL_RE = re.compile(
+    r"^https://svc\.example/arcgis/rest/services/Demo/FeatureServer/0/query(\?.*)?$",
+)
 
 
 def _metadata_payload() -> dict:
@@ -49,10 +53,12 @@ def _count_metadata_and_count_calls(mocker: aioresponses) -> tuple[int, int]:
         url_str = str(url).split("?", 1)[0]
         if method == "GET" and url_str.rstrip("/").endswith("FeatureServer/0"):
             metadata_calls += len(calls)
-        elif method == "POST" and url_str.endswith("FeatureServer/0/query"):
+        elif url_str.endswith("FeatureServer/0/query") and method in ("POST", "GET"):
             for call in calls:
-                data = call.kwargs.get("data") or {}
-                if str(data.get("returnCountOnly", "")).lower() == "true":
+                # T8 (R-74): count requests can ride on either verb. ``data``
+                # carries the payload on POST; ``params`` carries it on GET.
+                payload = call.kwargs.get("data") or call.kwargs.get("params") or {}
+                if str(payload.get("returnCountOnly", "")).lower() == "true":
                     count_calls += 1
     return metadata_calls, count_calls
 
@@ -70,6 +76,12 @@ async def test_where_reuses_parent_metadata_and_refreshes_count():
         m.get(METADATA_URL_RE, payload=_metadata_payload(), repeat=True)
         m.post(
             f"{LAYER_URL}/query",
+            payload={"count": 42},
+            repeat=True,
+        )
+        # T8 (R-74): short count queries now route to GET.
+        m.get(
+            QUERY_URL_RE,
             payload={"count": 42},
             repeat=True,
         )
@@ -98,15 +110,21 @@ async def test_where_reuses_parent_metadata_and_refreshes_count():
     refined_count_posts = [
         call
         for (method, url), calls in m.requests.items()
-        if method == "POST" and str(url).split("?", 1)[0].endswith("/query")
+        if method in ("POST", "GET") and str(url).split("?", 1)[0].endswith("/query")
         for call in calls
-        if str((call.kwargs.get("data") or {}).get("returnCountOnly", "")).lower()
+        if str(
+            (call.kwargs.get("data") or call.kwargs.get("params") or {}).get(
+                "returnCountOnly",
+                "",
+            ),
+        ).lower()
         == "true"
-        and (call.kwargs.get("data") or {}).get("where") == "STATUS = 'Open'"
+        and (call.kwargs.get("data") or call.kwargs.get("params") or {}).get("where")
+        == "STATUS = 'Open'"
     ]
     assert (
         refined_count_posts
-    ), "BL-46: refined count POST must carry the refined `where` clause"
+    ), "BL-46: refined count request must carry the refined `where` clause"
 
     assert refined.url == parent.url
     assert refined.session is parent.session
@@ -125,6 +143,12 @@ async def test_where_combines_with_existing_where_and_refreshes_count():
         m.get(METADATA_URL_RE, payload=_metadata_payload(), repeat=True)
         m.post(
             f"{LAYER_URL}/query",
+            payload={"count": 7},
+            repeat=True,
+        )
+        # T8 (R-74): short count queries now route to GET.
+        m.get(
+            QUERY_URL_RE,
             payload={"count": 7},
             repeat=True,
         )

--- a/tests/test_gate3_fixes.py
+++ b/tests/test_gate3_fixes.py
@@ -482,3 +482,15 @@ def test_advertised_factor_still_accepts_normal_positive_values():
         metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": raw}}
         result = _advertised_max_record_count_factor(metadata)
         assert result is not None and result > 0
+
+
+def test_advertised_factor_accepts_typed_layer_metadata() -> None:
+    from restgdf._models.responses import LayerMetadata
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    metadata = LayerMetadata(
+        maxRecordCount=2000,
+        advancedQueryCapabilities={"maxRecordCountFactor": 5},
+    )
+
+    assert _advertised_max_record_count_factor(metadata) == 5

--- a/tests/test_gate3_fixes.py
+++ b/tests/test_gate3_fixes.py
@@ -1,0 +1,484 @@
+"""Gate-3 rubber-duck findings: regression guards for v3-followup.
+
+Covers three follow-up-on-follow-up fixes on top of T6–T11:
+
+* **H1 (auth token leakage).** After T8 routes short ArcGIS requests
+  through ``_choose_verb``, sessions using ``ArcGISTokenSession(transport=...)``
+  with a non-header transport ("body" or "query") would have their
+  token serialized into URL query parameters when the chosen verb was
+  ``GET``. The fix forces ``POST`` whenever the session (or a wrapped
+  inner session) reports a non-header transport.
+
+* **H2 (ResilientSession awaitability).** ``_arcgis_request`` does
+  ``await session.get(...) / await session.post(...)`` (matching the
+  ``aiohttp.ClientSession`` pattern). ``ResilientSession`` declares it
+  satisfies ``AsyncHTTPSession`` but its ``get``/``post`` returned an
+  object that was only an async context manager. The fix makes
+  ``_RetriedCtx`` both awaitable AND ``async with``-able, mirroring
+  ``aiohttp._RequestContextManager``.
+
+* **M1 (advertised_factor gate strictness).** T9's
+  ``_advertised_max_record_count_factor`` must reject :class:`bool`
+  instances (``True``/``False`` are subclasses of :class:`int`) and
+  non-finite floats (``nan`` / ``inf``) so malformed vendor payloads
+  fall through to the byte-identical pre-T9 code path.
+"""
+
+from __future__ import annotations
+
+import math
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from restgdf import AGOLUserPass
+
+
+# ---------------------------------------------------------------------------
+# H1: ArcGISTokenSession(transport="body") must not take the GET path
+# ---------------------------------------------------------------------------
+
+
+class _FakeAuthSession:
+    """Minimal duck-typed stand-in for ArcGISTokenSession."""
+
+    def __init__(self, transport: str) -> None:
+        self._transport = transport
+        self.get = AsyncMock(return_value=SimpleNamespace(status=200))
+        self.post = AsyncMock(return_value=SimpleNamespace(status=200))
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_forces_post_when_transport_is_body():
+    """A short body must NOT be routed via GET when the session injects
+    the token into the request payload. Otherwise the token would land
+    in the URL query string (credential leak)."""
+    from restgdf.utils._http import _arcgis_request
+
+    session = _FakeAuthSession(transport="body")
+    tiny_body = {"where": "1=1", "f": "json"}
+    await _arcgis_request(session, "https://example/query", tiny_body)
+
+    assert (
+        session.post.await_count == 1
+    ), "expected POST for body-transport auth session"
+    assert session.get.await_count == 0
+    # POST must send the body as data=, not params=.
+    _, kwargs = session.post.call_args
+    assert kwargs.get("data") == tiny_body
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_forces_post_when_transport_is_query():
+    """Query-transport is semantically URL-bound but still a credential;
+    pre-T8 behavior was POST (token serialized into body). Preserve that
+    to avoid the observable wire shape changing silently."""
+    from restgdf.utils._http import _arcgis_request
+
+    session = _FakeAuthSession(transport="query")
+    await _arcgis_request(session, "https://example/query", {"f": "json"})
+
+    assert session.post.await_count == 1
+    assert session.get.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_still_uses_get_for_header_transport():
+    """transport='header' is the safe default (token in HTTP header);
+    short requests can use GET without leaking credentials."""
+    from restgdf.utils._http import _arcgis_request
+
+    session = _FakeAuthSession(transport="header")
+    await _arcgis_request(session, "https://example/query", {"f": "json"})
+
+    assert session.get.await_count == 1
+    assert session.post.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_walks_inner_for_wrapped_auth_session():
+    """``ResilientSession(ArcGISTokenSession(..., transport='body'))``
+    nests the auth session inside a wrapper. The guard must walk the
+    ``_inner`` chain so wrapped token sessions still force POST."""
+    from restgdf.utils._http import _arcgis_request
+
+    inner = _FakeAuthSession(transport="body")
+    outer = SimpleNamespace(
+        _inner=inner,
+        get=AsyncMock(return_value=SimpleNamespace(status=200)),
+        post=AsyncMock(return_value=SimpleNamespace(status=200)),
+    )
+    await _arcgis_request(outer, "https://example/query", {"f": "json"})
+
+    assert outer.post.await_count == 1
+    assert outer.get.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_does_not_loop_forever_on_wrapped_cycle():
+    """Defensive guard: a malformed wrapper cycle must terminate rather
+    than spinning forever while inspecting the transport chain."""
+    from restgdf.utils._http import _arcgis_request
+
+    session = SimpleNamespace(
+        _transport=None,
+        get=AsyncMock(return_value=SimpleNamespace(status=200)),
+        post=AsyncMock(return_value=SimpleNamespace(status=200)),
+    )
+    session._inner = session
+
+    await _arcgis_request(session, "https://example/query", {"f": "json"})
+
+    assert session.get.await_count == 1
+    assert session.post.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_ignores_dynamic_mock_attrs_when_transport_missing():
+    """AsyncMock sessions fabricate missing attrs via ``__getattr__``.
+
+    Transport inspection must treat missing ``_transport`` / ``_inner``
+    as absent instead of traversing synthetic mocks, which can explode
+    call history and memory use during equality/comparison checks.
+    """
+    from restgdf.utils._http import _arcgis_request
+
+    response = SimpleNamespace(status=200)
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=response)
+    session.post = AsyncMock(return_value=response)
+
+    await _arcgis_request(session, "https://example/query", {"f": "json"})
+
+    assert session.get.await_count == 1
+    assert session.post.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_forces_post_for_real_property_backed_token_session():
+    from restgdf._models.credentials import TokenSessionConfig
+    from restgdf.utils._http import _arcgis_request
+    from restgdf.utils.token import ArcGISTokenSession
+
+    class _InnerSession:
+        def __init__(self) -> None:
+            self.get = AsyncMock(return_value=SimpleNamespace(status=200))
+            self.post = AsyncMock(return_value=SimpleNamespace(status=200))
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            return None
+
+    inner = _InnerSession()
+    auth_session = ArcGISTokenSession(
+        session=inner,
+        config=TokenSessionConfig(
+            token_url="https://example.com/sharing/rest/generateToken",
+            credentials=AGOLUserPass(username="alice", password="hunter2"),
+            transport="body",
+        ),
+        token="secret-token",
+        expires=9_999_999_999_999,
+    )
+
+    await _arcgis_request(auth_session, "https://example/query", {"f": "json"})
+
+    assert inner.post.await_count == 1
+    assert inner.get.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_forces_post_for_resilient_wrapped_token_session():
+    resilience = pytest.importorskip("restgdf.resilience")
+    from restgdf._config import ResilienceConfig
+    from restgdf._models.credentials import TokenSessionConfig
+    from restgdf.utils._http import _arcgis_request
+    from restgdf.utils.token import ArcGISTokenSession
+
+    class _InnerSession:
+        def __init__(self) -> None:
+            self.get = AsyncMock(return_value=SimpleNamespace(status=200))
+            self.post = AsyncMock(return_value=SimpleNamespace(status=200))
+
+        @property
+        def closed(self) -> bool:
+            return False
+
+        async def close(self) -> None:
+            return None
+
+    inner = _InnerSession()
+    auth_session = ArcGISTokenSession(
+        session=inner,
+        config=TokenSessionConfig(
+            token_url="https://example.com/sharing/rest/generateToken",
+            credentials=AGOLUserPass(username="alice", password="hunter2"),
+            transport="body",
+        ),
+        token="secret-token",
+        expires=9_999_999_999_999,
+    )
+    session = resilience.ResilientSession(
+        inner=auth_session,
+        config=ResilienceConfig(enabled=True),
+    )
+
+    await _arcgis_request(session, "https://example/query", {"f": "json"})
+
+    assert inner.post.await_count == 1
+    assert inner.get.await_count == 0
+
+
+def test_coerce_params_for_get_normalizes_bool_none_and_preserves_other_values():
+    """Direct unit coverage for the GET-param normalization helper.
+
+    ArcGIS request bodies can include bools from DEFAULTDICT and explicit
+    ``None`` values. The helper must only normalize those two cases and
+    leave all other scalar / sequence values untouched.
+    """
+    from restgdf.utils._http import _coerce_params_for_get
+
+    result = _coerce_params_for_get(
+        {
+            "where": "1=1",
+            "returnGeometry": True,
+            "returnCountOnly": False,
+            "outFields": None,
+            "resultRecordCount": 1000,
+            "objectIds": [1, 2, 3],
+        },
+    )
+
+    assert result == {
+        "where": "1=1",
+        "returnGeometry": "true",
+        "returnCountOnly": "false",
+        "outFields": "",
+        "resultRecordCount": 1000,
+        "objectIds": [1, 2, 3],
+    }
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_get_path_uses_normalized_params():
+    """Short GET-routed requests must use the normalized param payload."""
+    from restgdf.utils._http import _arcgis_request
+
+    session = _FakeAuthSession(transport="header")
+    await _arcgis_request(
+        session,
+        "https://example/query",
+        {
+            "returnGeometry": True,
+            "returnCountOnly": False,
+            "outFields": None,
+            "f": "json",
+        },
+    )
+
+    assert session.get.await_count == 1
+    _, kwargs = session.get.call_args
+    assert kwargs["params"] == {
+        "returnGeometry": "true",
+        "returnCountOnly": "false",
+        "outFields": "",
+        "f": "json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# H2: ResilientSession.get/post() must be both awaitable and async-ctxmgr
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resilient_session_get_is_awaitable():
+    """``_arcgis_request`` does ``await session.get(url, ...)``. That
+    pattern must work against :class:`ResilientSession` exactly like it
+    works against :class:`aiohttp.ClientSession` and
+    :class:`ArcGISTokenSession`."""
+    resilience = pytest.importorskip("restgdf.resilience")
+    from restgdf._config import ResilienceConfig
+
+    response = SimpleNamespace(status=200, headers={}, read=AsyncMock(return_value=b""))
+
+    class _Inner:
+        closed = False
+
+        async def close(self) -> None:
+            return None
+
+        def get(self, url, **kwargs):
+            class _Ctx:
+                async def __aenter__(_self):
+                    return response
+
+                async def __aexit__(_self, *args):
+                    return None
+
+                def __await__(_self):
+                    async def _coro():
+                        return response
+
+                    return _coro().__await__()
+
+            return _Ctx()
+
+        post = get
+
+    session = resilience.ResilientSession(
+        inner=_Inner(),
+        config=ResilienceConfig(enabled=True),
+    )
+    result = await session.get("http://test/query")
+    assert result is response
+
+
+@pytest.mark.asyncio
+async def test_resilient_session_get_still_works_as_context_manager():
+    """The pre-existing ``async with session.get(...) as resp:`` pattern
+    must continue to work — adding ``__await__`` must not break it."""
+    resilience = pytest.importorskip("restgdf.resilience")
+    from restgdf._config import ResilienceConfig
+
+    response = SimpleNamespace(status=200, headers={}, read=AsyncMock(return_value=b""))
+
+    class _Inner:
+        closed = False
+
+        async def close(self) -> None:
+            return None
+
+        def get(self, url, **kwargs):
+            class _Ctx:
+                async def __aenter__(_self):
+                    return response
+
+                async def __aexit__(_self, *args):
+                    return None
+
+                def __await__(_self):
+                    async def _coro():
+                        return response
+
+                    return _coro().__await__()
+
+            return _Ctx()
+
+        post = get
+
+    session = resilience.ResilientSession(
+        inner=_Inner(),
+        config=ResilienceConfig(enabled=True),
+    )
+    async with session.get("http://test/query") as resp:
+        assert resp is response
+
+
+@pytest.mark.asyncio
+async def test_resilient_session_async_with_calls_inner_aexit():
+    resilience = pytest.importorskip("restgdf.resilience")
+    from restgdf._config import ResilienceConfig
+
+    response = SimpleNamespace(status=200, headers={}, read=AsyncMock(return_value=b""))
+    exited = False
+
+    class _Ctx:
+        async def __aenter__(self):
+            return response
+
+        async def __aexit__(self, *args):
+            nonlocal exited
+            exited = True
+
+    class _Inner:
+        closed = False
+
+        async def close(self) -> None:
+            return None
+
+        def get(self, url, **kwargs):
+            return _Ctx()
+
+        post = get
+
+    session = resilience.ResilientSession(
+        inner=_Inner(),
+        config=ResilienceConfig(enabled=True),
+    )
+    async with session.get("http://test/query") as resp:
+        assert resp is response
+    assert exited is True
+
+
+# ---------------------------------------------------------------------------
+# M1: _advertised_max_record_count_factor must reject bool/nan/inf
+# ---------------------------------------------------------------------------
+
+
+def test_advertised_factor_rejects_bool_true():
+    """``True`` is an ``int`` subclass; treating it as a numeric factor
+    would silently wire ``advertised_factor=1.0`` and deviate from the
+    pre-T9 byte-identical code path. Must return ``None``."""
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": True}}
+    assert _advertised_max_record_count_factor(metadata) is None
+
+
+def test_advertised_factor_rejects_bool_false():
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": False}}
+    assert _advertised_max_record_count_factor(metadata) is None
+
+
+def test_advertised_factor_rejects_missing_advanced_query_capabilities():
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    assert _advertised_max_record_count_factor({}) is None
+
+
+def test_advertised_factor_rejects_nan_string():
+    """``float('nan')`` is parseable but nonsensical as a factor."""
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": "nan"}}
+    assert _advertised_max_record_count_factor(metadata) is None
+
+
+def test_advertised_factor_rejects_inf_string():
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": "inf"}}
+    assert _advertised_max_record_count_factor(metadata) is None
+
+
+def test_advertised_factor_rejects_nan_float():
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": math.nan}}
+    assert _advertised_max_record_count_factor(metadata) is None
+
+
+def test_advertised_factor_rejects_zero_and_negative_values():
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    for raw in (0, 0.0, -1, -0.5):
+        metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": raw}}
+        assert _advertised_max_record_count_factor(metadata) is None
+
+
+def test_advertised_factor_still_accepts_normal_positive_values():
+    """Regression guard: the hardening must not reject legitimate
+    positive numeric values."""
+    from restgdf.utils.getgdf import _advertised_max_record_count_factor
+
+    for raw in (1, 2, 5, 10, 2.5, "4.0"):
+        metadata = {"advancedQueryCapabilities": {"maxRecordCountFactor": raw}}
+        result = _advertised_max_record_count_factor(metadata)
+        assert result is not None and result > 0

--- a/tests/test_getgdf.py
+++ b/tests/test_getgdf.py
@@ -40,6 +40,16 @@ class RecordingSession:
 
         return Response(self.response_text)
 
+    async def get(self, url: str, **kwargs):
+        # Translate params→data so the recorded kwargs snapshot matches
+        # the legacy POST shape. T8 (R-74): short GETs now hit call sites
+        # that used to issue POST; preserving the POST-shaped record keeps
+        # existing assertions intact.
+        if "params" in kwargs:
+            params = kwargs.pop("params")
+            kwargs.setdefault("data", params)
+        return await self.post(url, **kwargs)
+
 
 class JsonSession:
     def __init__(self, payloads: list[dict]):
@@ -57,6 +67,12 @@ class JsonSession:
                 return self._payload
 
         return Response(self.payloads.pop(0))
+
+    async def get(self, url: str, **kwargs):
+        if "params" in kwargs:
+            params = kwargs.pop("params")
+            kwargs.setdefault("data", params)
+        return await self.post(url, **kwargs)
 
 
 def _missing_optional_import(target: str):
@@ -365,6 +381,11 @@ async def test_row_dict_generator_yields_rows(sample_feature_gdf):
                         return self._payload
 
                 return Response(self.responses.pop(0))
+
+            async def get(self, url: str, **kwargs):
+                if "params" in kwargs and "data" not in kwargs:
+                    kwargs = {**kwargs, "data": kwargs["params"]}
+                return await self.post(url, **kwargs)
 
         rows = [
             row

--- a/tests/test_getgdf.py
+++ b/tests/test_getgdf.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib
 from unittest.mock import AsyncMock, call, patch
 
@@ -11,6 +12,7 @@ from restgdf.errors import PaginationError
 from tests.pagination_fixtures import load_pagination_fixture
 
 from restgdf.utils.getgdf import (
+    _feature_batch_generator,
     chunk_generator,
     chunk_values,
     combine_where_clauses,
@@ -27,6 +29,14 @@ class RecordingSession:
     def __init__(self, response_text: str = "{}"):
         self.response_text = response_text
         self.post_calls: list[tuple[str, dict]] = []
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def close(self) -> None:
+        self._closed = True
 
     async def post(self, url: str, **kwargs):
         self.post_calls.append((url, kwargs))
@@ -327,6 +337,35 @@ async def test_get_gdf_list_builds_tasks_from_batches(sample_feature_gdf):
 
 
 @pytest.mark.asyncio
+async def test_get_gdf_list_cancels_sibling_tasks_on_failure() -> None:
+    gate = asyncio.Event()
+    sibling_cancelled = asyncio.Event()
+    session = RecordingSession()
+
+    async def fake_get_sub_gdf(url, session, query_data, **kwargs):
+        if query_data["where"] == "boom":
+            raise RuntimeError("boom")
+        try:
+            await gate.wait()
+        except asyncio.CancelledError:
+            sibling_cancelled.set()
+            raise
+        return GeoDataFrame()
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "boom"}, {"where": "slow"}]),
+    ), patch(
+        "restgdf.utils.getgdf.get_sub_gdf",
+        new=fake_get_sub_gdf,
+    ):
+        with pytest.raises(RuntimeError, match="boom"):
+            await get_gdf_list("https://example.com/layer/0", session)
+
+    assert sibling_cancelled.is_set()
+
+
+@pytest.mark.asyncio
 async def test_chunk_generator_yields_each_chunk(sample_feature_gdf):
     with patch(
         "restgdf.utils.getgdf.get_query_data_batches",
@@ -401,6 +440,54 @@ async def test_row_dict_generator_yields_rows(sample_feature_gdf):
 
 
 @pytest.mark.asyncio
+async def test_feature_batch_generator_caps_scheduled_tasks_and_cancels_on_close():
+    gate = asyncio.Event()
+    created: list[asyncio.Task] = []
+    orig_create_task = asyncio.create_task
+
+    async def fake_get_sub_features(*args, **kwargs):
+        await gate.wait()
+        return []
+
+    def spy_create_task(coro):
+        task = orig_create_task(coro)
+        created.append(task)
+        return task
+
+    cfg = type(
+        "Cfg",
+        (),
+        {"concurrency": type("Conc", (), {"max_concurrent_requests": 2})()},
+    )()
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"resultOffset": i} for i in range(25)]),
+    ), patch(
+        "restgdf.utils.getgdf.get_sub_features",
+        new=fake_get_sub_features,
+    ), patch(
+        "restgdf.utils.getgdf.get_config",
+        return_value=cfg,
+    ), patch(
+        "asyncio.create_task",
+        new=spy_create_task,
+    ):
+        agen = _feature_batch_generator("https://example.com/layer/0", object())
+        consumer = orig_create_task(agen.__anext__())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(created) == 2
+        consumer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+        await agen.aclose()
+        await asyncio.sleep(0)
+        assert all(task.done() for task in created)
+        gate.set()
+
+
+@pytest.mark.asyncio
 async def test_get_sub_features_should_reject_truncated_empty_feature_page():
     session = JsonSession(
         [load_pagination_fixture("query_exceeded_transfer_limit_empty_features.json")],
@@ -412,6 +499,57 @@ async def test_get_sub_features_should_reject_truncated_empty_feature_page():
             session,
             query_data={"where": "1=1"},
         )
+
+
+@pytest.mark.asyncio
+async def test_chunk_generator_caps_scheduled_tasks_and_cancels_on_close():
+    gate = asyncio.Event()
+    created: list[asyncio.Task] = []
+    orig_create_task = asyncio.create_task
+
+    async def fake_get_sub_gdf(*args, **kwargs):
+        await gate.wait()
+        return GeoDataFrame()
+
+    def spy_create_task(coro):
+        task = orig_create_task(coro)
+        created.append(task)
+        return task
+
+    cfg = type(
+        "Cfg",
+        (),
+        {"concurrency": type("Conc", (), {"max_concurrent_requests": 2})()},
+    )()
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"resultOffset": i} for i in range(25)]),
+    ), patch(
+        "restgdf.utils.getgdf.get_sub_gdf",
+        new=fake_get_sub_gdf,
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value={}),
+    ), patch(
+        "restgdf.utils.getgdf.get_config",
+        return_value=cfg,
+    ), patch(
+        "asyncio.create_task",
+        new=spy_create_task,
+    ):
+        agen = chunk_generator("https://example.com/layer/0", object())
+        consumer = orig_create_task(agen.__anext__())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(created) == 2
+        consumer.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await consumer
+        await agen.aclose()
+        await asyncio.sleep(0)
+        assert all(task.done() for task in created)
+        gate.set()
 
 
 @pytest.mark.asyncio
@@ -485,6 +623,19 @@ async def test_get_gdf_forwards_token_and_detects_conflicts():
             token="abc",
             data={"token": "different"},
         )
+
+
+@pytest.mark.asyncio
+async def test_get_gdf_closes_internally_created_session():
+    with patch(
+        "restgdf.utils.getgdf.gdf_by_concat",
+        new=AsyncMock(return_value="sentinel"),
+    ) as mock_gdf_by_concat:
+        result = await get_gdf("https://example.com/layer/0", session=None)
+
+    assert result == "sentinel"
+    created_session = mock_gdf_by_concat.await_args.args[1]
+    assert created_session.closed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_getgdf_coverage.py
+++ b/tests/test_getgdf_coverage.py
@@ -1,0 +1,274 @@
+"""T4: fallback/edge-case coverage for ``restgdf.utils.getgdf``.
+
+Focused on uncovered fallback branches:
+
+* :func:`_extract_raw_spatial_reference` — ``None`` / plain-Mapping / unknown-type
+  fallbacks around lines 360–392.
+* :func:`_iter_pages_raw` — the ``finally:`` block (tasks cancelled, span ended)
+  when the streaming body raises mid-iteration.
+
+These tests assert behavioral guarantees only (return values, side effects on
+the span and on scheduled tasks). They deliberately do NOT pin request-shape
+details such as verb choice or ``max_record_count_factor``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from geopandas import GeoDataFrame
+from shapely.geometry import Point
+
+from restgdf._models.responses import LayerMetadata
+from restgdf.utils import getgdf as getgdf_mod
+from restgdf.utils.getgdf import (
+    _extract_raw_spatial_reference,
+    _iter_pages_raw,
+    chunk_generator,
+)
+
+
+# ---------------------------------------------------------------------------
+# _extract_raw_spatial_reference fallback branches
+# ---------------------------------------------------------------------------
+
+
+def test_extract_raw_spatial_reference_returns_none_for_none_metadata():
+    """When metadata is None, no lookup occurs and None is returned."""
+    assert _extract_raw_spatial_reference(None) is None
+
+
+def test_extract_raw_spatial_reference_returns_none_for_unknown_type():
+    """Non-LayerMetadata, non-Mapping inputs fall through to ``return None``."""
+
+    class _NotMetadata:
+        extent = {"spatialReference": {"wkid": 4326}}
+
+    # Lists / ints / custom objects are neither LayerMetadata nor Mapping.
+    assert _extract_raw_spatial_reference(_NotMetadata()) is None
+    assert _extract_raw_spatial_reference([1, 2, 3]) is None  # type: ignore[arg-type]
+    assert _extract_raw_spatial_reference(42) is None  # type: ignore[arg-type]
+
+
+def test_extract_raw_spatial_reference_plain_mapping_extent_wins():
+    """A plain dict with extent.spatialReference is read via the Mapping branch."""
+    raw = {"wkid": 4326, "latestWkid": 4326}
+    metadata: Mapping[str, Any] = {"extent": {"spatialReference": raw}}
+
+    result = _extract_raw_spatial_reference(metadata)
+
+    assert result == raw
+
+
+def test_extract_raw_spatial_reference_plain_mapping_top_level_fallback():
+    """When extent is missing, the top-level ``spatialReference`` key is used."""
+    raw = {"wkid": 2263}
+    metadata: Mapping[str, Any] = {"spatialReference": raw}
+
+    result = _extract_raw_spatial_reference(metadata)
+
+    assert result == raw
+
+
+def test_extract_raw_spatial_reference_plain_mapping_without_sr_returns_none():
+    """A Mapping with no SR in either location returns None without raising."""
+    metadata: Mapping[str, Any] = {"name": "Layer", "extent": {"xmin": 0}}
+
+    assert _extract_raw_spatial_reference(metadata) is None
+
+
+def test_extract_raw_spatial_reference_plain_mapping_non_mapping_extent():
+    """Non-Mapping extent value is ignored; fallback continues to top-level."""
+    raw = {"wkid": 3857}
+    metadata: Mapping[str, Any] = {
+        "extent": "not-a-mapping",
+        "spatialReference": raw,
+    }
+
+    assert _extract_raw_spatial_reference(metadata) == raw
+
+
+# ---------------------------------------------------------------------------
+# _iter_pages_raw: finally-block runs on mid-iteration failure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_iter_pages_raw_finally_cancels_pending_tasks_and_ends_span():
+    """An exception while resolving a page must still run the ``finally:``.
+
+    Behavioral guarantees:
+    * any asyncio Tasks scheduled for paging are cancelled when they are not
+      already done, and
+    * the parent INTERNAL span created for the stream is ended exactly once
+      regardless of which page raised.
+    """
+    url = "https://example.test/FeatureServer/0"
+
+    # Two batches — forcing the 2nd task to remain pending while the 1st
+    # triggers a _resolve_page failure, so the ``finally`` has work to cancel.
+    batches = [{"where": "1=1"}, {"where": "2=2"}]
+
+    never_done = asyncio.Event()
+
+    async def fake_fetch_page_dict(u, s, qd, **_kw):
+        if qd.get("where") == "1=1":
+            return {"features": [], "exceededTransferLimit": False}
+        # 2nd batch stays pending until we cancel it in the finally block.
+        await never_done.wait()
+        return {"features": []}
+
+    async def boom_resolve(*_a, **_kw):
+        raise RuntimeError("resolve failed")
+        # pragma: no cover - generator machinery never reaches here
+        yield  # type: ignore[unreachable]
+
+    fake_span = MagicMock()
+
+    with (
+        patch.object(
+            getgdf_mod,
+            "get_query_data_batches",
+            AsyncMock(return_value=batches),
+        ),
+        patch.object(
+            getgdf_mod,
+            "_fetch_page_dict",
+            side_effect=fake_fetch_page_dict,
+        ),
+        patch.object(getgdf_mod, "_resolve_page", side_effect=boom_resolve),
+        patch.object(
+            getgdf_mod,
+            "start_feature_layer_stream_span",
+            return_value=fake_span,
+        ),
+    ):
+        agen = _iter_pages_raw(url, object(), order="request")
+        with pytest.raises(RuntimeError, match="resolve failed"):
+            async for _ in agen:
+                pass
+
+    # span.end() must have been called from the outer ``finally:`` even though
+    # iteration aborted with an exception.
+    fake_span.end.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# chunk_generator: spatial-reference stamping on each yielded chunk
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chunk_generator_stamps_spatial_reference_on_each_chunk():
+    """Each yielded chunk carries ``attrs['spatial_reference']`` when metadata has SR."""
+    url = "https://example.test/FeatureServer/0"
+    raw_sr = {"wkid": 4326, "latestWkid": 4326}
+
+    metadata = LayerMetadata.model_validate(
+        {
+            "name": "T",
+            "type": "Feature Layer",
+            "fields": [{"name": "OBJECTID", "type": "esriFieldTypeOID"}],
+            "maxRecordCount": 2,
+            "advancedQueryCapabilities": {"supportsPagination": True},
+            "extent": {"spatialReference": raw_sr},
+        },
+    )
+
+    def _sub(oid: int) -> GeoDataFrame:
+        return GeoDataFrame(
+            {"OBJECTID": [oid], "geometry": [Point(0, 0)]},
+            crs="EPSG:4326",
+        )
+
+    async def fake_get_sub_gdf(u, s, query_data, **_kw):
+        return _sub(int(query_data.get("resultOffset", 0)))
+
+    with (
+        patch.object(
+            getgdf_mod,
+            "get_query_data_batches",
+            AsyncMock(
+                return_value=[
+                    {"resultOffset": 0, "resultRecordCount": 1},
+                    {"resultOffset": 1, "resultRecordCount": 1},
+                ],
+            ),
+        ),
+        patch.object(getgdf_mod, "get_metadata", AsyncMock(return_value=metadata)),
+        patch.object(getgdf_mod, "get_sub_gdf", side_effect=fake_get_sub_gdf),
+    ):
+        chunks = [chunk async for chunk in chunk_generator(url, object())]
+
+    assert len(chunks) == 2
+    for chunk in chunks:
+        assert chunk.attrs.get("spatial_reference") == raw_sr
+
+
+@pytest.mark.asyncio
+async def test_chunk_generator_skips_stamping_when_metadata_has_no_sr():
+    """Without SR in metadata, chunk_generator yields chunks without the attr."""
+    url = "https://example.test/FeatureServer/0"
+
+    metadata = LayerMetadata.model_validate(
+        {
+            "name": "T",
+            "type": "Feature Layer",
+            "fields": [{"name": "OBJECTID", "type": "esriFieldTypeOID"}],
+            "maxRecordCount": 2,
+            "advancedQueryCapabilities": {"supportsPagination": True},
+        },
+    )
+
+    def _sub() -> GeoDataFrame:
+        return GeoDataFrame(
+            {"OBJECTID": [1], "geometry": [Point(0, 0)]},
+            crs="EPSG:4326",
+        )
+
+    async def fake_get_sub_gdf(u, s, query_data, **_kw):
+        return _sub()
+
+    with (
+        patch.object(
+            getgdf_mod,
+            "get_query_data_batches",
+            AsyncMock(return_value=[{"resultOffset": 0, "resultRecordCount": 1}]),
+        ),
+        patch.object(getgdf_mod, "get_metadata", AsyncMock(return_value=metadata)),
+        patch.object(getgdf_mod, "get_sub_gdf", side_effect=fake_get_sub_gdf),
+    ):
+        chunks = [chunk async for chunk in chunk_generator(url, object())]
+
+    assert len(chunks) == 1
+    assert "spatial_reference" not in chunks[0].attrs
+
+
+@pytest.mark.asyncio
+async def test_iter_pages_raw_finally_ends_span_when_batches_fail_early():
+    """If ``get_query_data_batches`` raises, no tasks exist but span still ends."""
+    url = "https://example.test/FeatureServer/0"
+    fake_span = MagicMock()
+
+    with (
+        patch.object(
+            getgdf_mod,
+            "get_query_data_batches",
+            AsyncMock(side_effect=RuntimeError("batch planning failed")),
+        ),
+        patch.object(
+            getgdf_mod,
+            "start_feature_layer_stream_span",
+            return_value=fake_span,
+        ),
+    ):
+        agen = _iter_pages_raw(url, object())
+        with pytest.raises(RuntimeError, match="batch planning failed"):
+            async for _ in agen:
+                pass
+
+    fake_span.end.assert_called_once()

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -3,6 +3,7 @@ import importlib
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from aiohttp import ClientSession
 from pandas import DataFrame
 
 from restgdf.errors import FieldDoesNotExistError
@@ -31,6 +32,30 @@ from restgdf.utils.getinfo import (
     supports_pagination,
     getvaluecounts,
 )
+
+
+@pytest.fixture(autouse=True)
+def _proxy_client_session_get_to_post():
+    """T8 (R-74): short ArcGIS requests now go through ``session.get``.
+
+    Legacy tests in this module only patch ``ClientSession.post``. This
+    autouse fixture redirects ``ClientSession.get`` to whatever
+    ``ClientSession.post`` is currently patched to, so the existing
+    POST-oriented side effects continue to work without rewriting each
+    decorator.
+    """
+
+    def _proxy(self, url, **kwargs):
+        # When a GET is issued with ``params=...``, the body lives there;
+        # forward it as ``data=...`` so POST-shaped side_effects see the
+        # same payload they used to.
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return ClientSession.post(self, url, **kwargs)
+
+    with patch("restgdf.utils.getinfo.ClientSession.get", new=_proxy):
+        yield
+
 
 TESTJSON = {"count": 500, "maxRecordCount": 100}
 
@@ -448,6 +473,9 @@ async def test_getuniquevalues_multi_field_requires_geo_extra_before_request():
         async def post(self, *args, **kwargs):
             raise AssertionError("should fail before requesting")
 
+        async def get(self, *args, **kwargs):
+            raise AssertionError("should fail before requesting")
+
     with patch(
         "restgdf.utils._optional.import_module",
         side_effect=_missing_optional_import("pandas"),
@@ -483,6 +511,9 @@ async def test_getvaluecounts_mock(mock_response, client_session):
 async def test_getvaluecounts_requires_geo_extra_before_request():
     class Session:
         async def post(self, *args, **kwargs):
+            raise AssertionError("should fail before requesting")
+
+        async def get(self, *args, **kwargs):
             raise AssertionError("should fail before requesting")
 
     with patch(
@@ -571,6 +602,9 @@ async def test_nestedcount_shapes_output(mock_response, client_session):
 async def test_nestedcount_requires_geo_extra_before_request():
     class Session:
         async def post(self, *args, **kwargs):
+            raise AssertionError("should fail before requesting")
+
+        async def get(self, *args, **kwargs):
             raise AssertionError("should fail before requesting")
 
     with patch(

--- a/tests/test_http_timeout.py
+++ b/tests/test_http_timeout.py
@@ -47,15 +47,21 @@ class _RecordingSession:
 
     def __init__(self, payload: dict[str, Any]):
         self._payload = payload
-        self.get_calls: list[tuple[str, dict]] = []
-        self.post_calls: list[tuple[str, dict]] = []
+        # T8 (R-74): unify get_calls / post_calls so legacy tests that
+        # assert on post_calls keep passing when a short request is now
+        # a GET (and vice-versa).
+        self._calls: list[tuple[str, dict]] = []
+        self.get_calls = self._calls
+        self.post_calls = self._calls
 
     async def get(self, url: str, **kwargs: Any) -> _FakeResponse:
-        self.get_calls.append((url, kwargs))
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        self._calls.append((url, kwargs))
         return _FakeResponse(self._payload)
 
     async def post(self, url: str, **kwargs: Any) -> _FakeResponse:
-        self.post_calls.append((url, kwargs))
+        self._calls.append((url, kwargs))
         return _FakeResponse(self._payload)
 
 
@@ -264,6 +270,11 @@ async def test_get_sub_gdf_forwards_timeout(monkeypatch):
         async def post(self, url: str, **kwargs: Any) -> _GdfResponse:
             self.post_calls.append((url, kwargs))
             return _GdfResponse(self._payload)
+
+        async def get(self, url, **kwargs):
+            if "params" in kwargs and "data" not in kwargs:
+                kwargs = {**kwargs, "data": kwargs["params"]}
+            return await self.post(url, **kwargs)
 
     monkeypatch.setattr(getgdf_mod, "_require_geo_query_support", lambda feature: None)
     monkeypatch.setattr(getgdf_mod, "_get_supported_drivers", lambda: {"GeoJSON": "rw"})

--- a/tests/test_hypothesis_responses.py
+++ b/tests/test_hypothesis_responses.py
@@ -7,6 +7,7 @@ pipeline.  Expand with additional strategies as coverage targets require.
 
 from __future__ import annotations
 
+import pytest
 from hypothesis import given, settings, strategies as st
 
 from restgdf._models.responses import (
@@ -15,6 +16,9 @@ from restgdf._models.responses import (
     _epoch_ms_to_iso,
     iter_normalized_features,
 )
+
+
+pytestmark = pytest.mark.stress
 
 
 # ── strategy: arbitrary epoch-ms values ────────────────────────────

--- a/tests/test_iter_pages_edge_cases.py
+++ b/tests/test_iter_pages_edge_cases.py
@@ -22,7 +22,7 @@ async def test_iter_pages_raw_rejects_invalid_order() -> None:
 async def test_iter_pages_raw_rejects_invalid_on_truncation() -> None:
     agen = _iter_pages_raw(
         "https://x/FeatureServer/0",
-        object(),
+        object(),  # type: ignore[arg-type]
         on_truncation="nope",  # type: ignore[arg-type]
     )
     with pytest.raises(ValueError, match="on_truncation must be"):
@@ -33,7 +33,7 @@ async def test_iter_pages_raw_rejects_invalid_on_truncation() -> None:
 async def test_iter_pages_raw_rejects_invalid_max_concurrent_pages() -> None:
     agen = _iter_pages_raw(
         "https://x/FeatureServer/0",
-        object(),
+        object(),  # type: ignore[arg-type]
         max_concurrent_pages=0,
     )
     with pytest.raises(ValueError, match="max_concurrent_pages"):
@@ -62,7 +62,7 @@ async def test_iter_pages_raw_split_single_oid_raises() -> None:
             AsyncMock(return_value=("OBJECTID", [42])),
         ),
     ):
-        agen = _iter_pages_raw(url, object(), on_truncation="split")
+        agen = _iter_pages_raw(url, object(), on_truncation="split")  # type: ignore[arg-type]
         with pytest.raises(RestgdfResponseError, match="could not bisect"):
             async for _ in agen:
                 pass
@@ -92,7 +92,7 @@ async def test_iter_pages_raw_split_exceeds_max_depth() -> None:
     ):
         agen = _iter_pages_raw(
             url,
-            object(),
+            object(),  # type: ignore[arg-type]
             on_truncation="split",
             max_split_depth=1,
         )

--- a/tests/test_iter_pages_edge_cases.py
+++ b/tests/test_iter_pages_edge_cases.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from restgdf.errors import RestgdfResponseError
 from restgdf.utils import getgdf as getgdf_mod
-from restgdf.utils.getgdf import _iter_pages_raw
+from restgdf.utils.getgdf import _fetch_page_dict, _iter_pages_raw
 
 
 @pytest.mark.asyncio
@@ -99,3 +100,50 @@ async def test_iter_pages_raw_split_exceeds_max_depth() -> None:
         with pytest.raises(RestgdfResponseError, match="reached max depth"):
             async for _ in agen:
                 pass
+
+
+@pytest.mark.asyncio
+async def test_iter_pages_raw_does_not_eagerly_schedule_all_batches_when_bounded() -> None:
+    url = "https://x/FeatureServer/0"
+    gate = asyncio.Event()
+    created: list[asyncio.Task] = []
+    orig_create_task = asyncio.create_task
+
+    async def fake_fetch(*_a, **_kw):
+        await gate.wait()
+        return {"features": []}
+
+    def spy_create_task(coro):
+        task = orig_create_task(coro)
+        created.append(task)
+        return task
+
+    with (
+        patch.object(
+            getgdf_mod,
+            "get_query_data_batches",
+            AsyncMock(return_value=[{"resultOffset": i} for i in range(25)]),
+        ),
+        patch.object(getgdf_mod, "_fetch_page_dict", side_effect=fake_fetch),
+        patch("asyncio.create_task", new=spy_create_task),
+    ):
+        agen = _iter_pages_raw(url, object(), max_concurrent_pages=2)  # type: ignore[arg-type]
+        consumer = orig_create_task(agen.__anext__())
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert len(created) == 2
+        gate.set()
+        await consumer
+        await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_iter_pages_raw_rejects_non_mapping_page_payload() -> None:
+    url = "https://x/FeatureServer/0"
+
+    response = AsyncMock()
+    response.json = AsyncMock(return_value=[])
+
+    with patch.object(getgdf_mod, "_arcgis_request", AsyncMock(return_value=response)):
+        with pytest.raises(RestgdfResponseError, match="non-object JSON payload"):
+            await _fetch_page_dict(url, object(), {"where": "1=1"})  # type: ignore[arg-type]

--- a/tests/test_iter_pages_internal_span.py
+++ b/tests/test_iter_pages_internal_span.py
@@ -33,6 +33,11 @@ class _ScriptedSession:
         self.post_calls.append((url, kwargs))
         return _JsonResp(self.payloads.pop(0))
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 def _make_layer():
     layer = FeatureLayer(

--- a/tests/test_pagination_characterization.py
+++ b/tests/test_pagination_characterization.py
@@ -33,7 +33,7 @@ async def test_missing_pagination_flag_does_not_drive_offset_batching() -> None:
     ):
         batches = await get_query_data_batches(
             "https://example.com/layer/0",
-            object(),
+            object(),  # type: ignore[arg-type]
             data={"where": "1=1"},
         )
 

--- a/tests/test_pagination_error_on_exceeded_transfer_limit.py
+++ b/tests/test_pagination_error_on_exceeded_transfer_limit.py
@@ -35,6 +35,11 @@ class JsonSession:
 
         return Response(self.payloads.pop(0))
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 @pytest.mark.asyncio
 async def test_pagination_error_carries_page_size():

--- a/tests/test_pagination_live_factor.py
+++ b/tests/test_pagination_live_factor.py
@@ -1,0 +1,257 @@
+"""T9 tests: R-72 advertised_factor live-wiring + R-73 PaginationInconsistencyWarning.
+
+R-72: when layer metadata advertises
+``advancedQueryCapabilities.supportsMaxRecordCountFactor`` (aka
+``maxRecordCountFactor``), :func:`get_query_data_batches` must pass it
+through as ``advertised_factor=`` to the planner. Servers that do NOT
+advertise the field keep today's byte-for-byte behavior (no
+``advertised_factor`` kwarg supplied).
+
+R-73: a ``PaginationInconsistencyWarning`` sentinel is emitted when
+a batch page returns ``exceededTransferLimit=true`` with zero
+features — an ArcGIS misbehavior that silently breaks offset-based
+pagination (the cursor never advances).
+"""
+
+from __future__ import annotations
+
+import warnings
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from restgdf.errors import PaginationInconsistencyWarning
+from restgdf.utils import getgdf
+
+
+# ---------------------------------------------------------------------------
+# R-72: advertised_factor live-wire at get_query_data_batches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_advertised_factor_wired_when_server_advertises_it():
+    """With metadata containing
+    ``advancedQueryCapabilities.maxRecordCountFactor: 5``,
+    ``get_query_data_batches`` must call ``build_pagination_plan``
+    with ``advertised_factor=5``.
+    """
+    real_planner = getgdf.build_pagination_plan
+    spy = MagicMock()
+
+    def capture(*args, **kwargs):
+        spy(*args, **kwargs)
+        return real_planner(*args, **kwargs)
+
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=25),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(
+            return_value={
+                "maxRecordCount": 10,
+                "advancedQueryCapabilities": {
+                    "supportsPagination": True,
+                    "maxRecordCountFactor": 5,
+                },
+            },
+        ),
+    ), patch(
+        "restgdf.utils.getgdf.build_pagination_plan",
+        side_effect=capture,
+    ):
+        await getgdf.get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "1=1"},
+        )
+
+    spy.assert_called_once()
+    _, call_kwargs = spy.call_args
+    assert call_kwargs.get("advertised_factor") == 5
+
+
+@pytest.mark.asyncio
+async def test_advertised_factor_omitted_when_server_does_not_advertise():
+    """Opt-in guarantee: without
+    ``advancedQueryCapabilities.maxRecordCountFactor``, no
+    ``advertised_factor`` kwarg is supplied — servers without the
+    field keep byte-exact 3.0-baseline behavior.
+    """
+    real_planner = getgdf.build_pagination_plan
+    spy = MagicMock()
+
+    def capture(*args, **kwargs):
+        spy(*args, **kwargs)
+        return real_planner(*args, **kwargs)
+
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=25),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(
+            return_value={
+                "maxRecordCount": 10,
+                "advancedQueryCapabilities": {"supportsPagination": True},
+            },
+        ),
+    ), patch(
+        "restgdf.utils.getgdf.build_pagination_plan",
+        side_effect=capture,
+    ):
+        await getgdf.get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "1=1"},
+        )
+
+    spy.assert_called_once()
+    _, call_kwargs = spy.call_args
+    assert "advertised_factor" not in call_kwargs
+
+
+@pytest.mark.asyncio
+async def test_advertised_factor_omitted_when_no_advanced_capabilities_block():
+    """No ``advancedQueryCapabilities`` key at all → no advertised_factor."""
+    real_planner = getgdf.build_pagination_plan
+    spy = MagicMock()
+
+    def capture(*args, **kwargs):
+        spy(*args, **kwargs)
+        return real_planner(*args, **kwargs)
+
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=25),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(
+            return_value={
+                "maxRecordCount": 10,
+                "supportsPagination": True,
+            },
+        ),
+    ), patch(
+        "restgdf.utils.getgdf.build_pagination_plan",
+        side_effect=capture,
+    ):
+        await getgdf.get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "1=1"},
+        )
+
+    spy.assert_called_once()
+    _, call_kwargs = spy.call_args
+    assert "advertised_factor" not in call_kwargs
+
+
+# ---------------------------------------------------------------------------
+# R-73: PaginationInconsistencyWarning on 0-feature + exceededTransferLimit
+# ---------------------------------------------------------------------------
+
+
+def test_pagination_inconsistency_warning_is_userwarning_subclass():
+    assert issubclass(PaginationInconsistencyWarning, UserWarning)
+
+
+@pytest.mark.asyncio
+async def test_zero_features_with_exceeded_limit_emits_inconsistency_warning():
+    """Batch page returning ``exceededTransferLimit=true`` AND zero
+    features is a server bug that silently breaks pagination — emit
+    a :class:`PaginationInconsistencyWarning`.
+    """
+    page = {
+        "features": [],
+        "exceededTransferLimit": True,
+    }
+    collected: list[dict] = []
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        async for resolved in getgdf._resolve_page(
+            "https://example.com/layer/0",
+            object(),
+            page,
+            {"where": "1=1"},
+            on_truncation="ignore",
+            depth=0,
+            max_depth=32,
+            request_kwargs={},
+        ):
+            collected.append(resolved)
+
+    assert any(
+        issubclass(w.category, PaginationInconsistencyWarning) for w in caught
+    ), (
+        "Expected PaginationInconsistencyWarning for 0-feature + "
+        f"exceededTransferLimit=true page; got {[w.category for w in caught]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exceeded_limit_with_features_does_not_emit_inconsistency_warning():
+    """A normal exceededTransferLimit response (with features) is
+    NOT an inconsistency — no :class:`PaginationInconsistencyWarning`.
+    """
+    page = {
+        "features": [{"attributes": {"OBJECTID": 1}}],
+        "exceededTransferLimit": True,
+    }
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        async for _ in getgdf._resolve_page(
+            "https://example.com/layer/0",
+            object(),
+            page,
+            {"where": "1=1"},
+            on_truncation="ignore",
+            depth=0,
+            max_depth=32,
+            request_kwargs={},
+        ):
+            pass
+
+    assert not any(
+        issubclass(w.category, PaginationInconsistencyWarning) for w in caught
+    ), (
+        "PaginationInconsistencyWarning must NOT fire when features>0; "
+        f"got {[w.category for w in caught]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_exceeded_limit_no_inconsistency_warning():
+    """Non-truncated pages never trigger the inconsistency warning."""
+    page = {"features": [], "exceededTransferLimit": False}
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        async for _ in getgdf._resolve_page(
+            "https://example.com/layer/0",
+            object(),
+            page,
+            {"where": "1=1"},
+            on_truncation="raise",
+            depth=0,
+            max_depth=32,
+            request_kwargs={},
+        ):
+            pass
+
+    assert not any(
+        issubclass(w.category, PaginationInconsistencyWarning) for w in caught
+    )
+
+
+def test_pagination_inconsistency_warning_importable_from_errors_module():
+    """The sentinel lives in :mod:`restgdf.errors` alongside the error
+    taxonomy, even though (as a ``UserWarning`` subclass) it is not in
+    ``errors.__all__`` and not re-exported at the package root.
+    """
+    from restgdf import errors
+
+    cls = errors.PaginationInconsistencyWarning
+    assert isinstance(cls, type)
+    assert issubclass(cls, UserWarning)
+    assert cls.__name__ == "PaginationInconsistencyWarning"

--- a/tests/test_pagination_planner.py
+++ b/tests/test_pagination_planner.py
@@ -121,14 +121,15 @@ def test_getinfo_reexports_pagination_symbols():
 
 
 @pytest.mark.asyncio
-async def test_default_pagination_uses_factor_1_0():
-    """Regression: `get_query_data_batches` calls the planner with
-    `factor=1.0` (default) and no `advertised_factor` in phase-2c.
+async def test_no_advertised_factor_when_metadata_does_not_advertise():
+    """Regression: when layer metadata does NOT advertise
+    ``advancedQueryCapabilities.maxRecordCountFactor``,
+    ``get_query_data_batches`` calls the planner with ``factor=1.0``
+    (default) and no ``advertised_factor``.
 
-    This pins the deferred-plumbing decision: live
-    `advancedQueryCapabilities.maxRecordCountFactor` is not yet wired
-    into the call site, so production batch sizes stay byte-exact
-    during the 3.0 migration.
+    This pins the R-72 opt-in contract: servers without the field
+    get today's byte-exact pagination; wire-up is gated on the
+    metadata actually carrying the key.
     """
     from restgdf.utils import getgdf
 
@@ -149,7 +150,6 @@ async def test_default_pagination_uses_factor_1_0():
                 "maxRecordCount": 10,
                 "advancedQueryCapabilities": {
                     "supportsPagination": True,
-                    "maxRecordCountFactor": 4.0,
                 },
             },
         ),

--- a/tests/test_resilience_retry_coverage.py
+++ b/tests/test_resilience_retry_coverage.py
@@ -1,0 +1,374 @@
+"""Behavioral coverage tests for ``restgdf.resilience._retry`` (v3-followup T1).
+
+These tests complement :mod:`tests.test_resilience_retry` by exercising
+previously-uncovered branches:
+
+* ``_ResponseCtx`` shim (async-context + attribute delegation)
+* ``ResilientSession.close`` / ``.post`` / ``._reset_limiters``
+* limiter-backed construction and acquire
+* ``ServerTimeoutError`` retry + exhaustion paths
+* 429 exhaustion → :class:`RateLimitError` with ``retry_after``
+* 429 cooldown -> subsequent retry reuses cooldown wait path
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+import pytest
+
+from restgdf._config import ResilienceConfig
+from restgdf.errors import (
+    RateLimitError,
+    RestgdfTimeoutError,
+    TransportError,
+)
+from restgdf.resilience import ResilientSession
+from restgdf.resilience._retry import _ResponseCtx
+
+
+# ---------------------------------------------------------------------------
+# Stubs (mirrors patterns in tests/test_resilience_retry.py)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal response stub supporting async-context use."""
+
+    def __init__(
+        self,
+        status: int,
+        headers: dict[str, str] | None = None,
+        body: bytes = b"ok",
+    ) -> None:
+        self.status = status
+        self.headers = headers or {}
+        self._body = body
+
+    async def read(self) -> bytes:
+        return self._body
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+
+class StubSession:
+    """AsyncHTTPSession stub recording calls and replaying queued outcomes."""
+
+    def __init__(
+        self,
+        responses: list[_FakeResponse | Exception] | None = None,
+    ) -> None:
+        self._responses = list(responses or [])
+        self._call_count = 0
+        self._closed = False
+        self._last_method: str | None = None
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        self._last_method = "get"
+        return self._dispatch(url)
+
+    def post(self, url: str, **kwargs: Any) -> Any:
+        self._last_method = "post"
+        return self._dispatch(url)
+
+    def _dispatch(self, url: str) -> Any:
+        self._call_count += 1
+        idx = min(self._call_count - 1, len(self._responses) - 1)
+        resp = self._responses[idx]
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+def _make_server_timeout() -> aiohttp.ServerTimeoutError:
+    return aiohttp.ServerTimeoutError("simulated read timeout")
+
+
+@pytest.fixture()
+def _fast_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``asyncio.sleep`` so retry tests do not actually wait."""
+
+    async def _instant_sleep(_d: float, *a: Any, **kw: Any) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+
+# ---------------------------------------------------------------------------
+# _ResponseCtx shim
+# ---------------------------------------------------------------------------
+
+
+class TestResponseCtx:
+    """_ResponseCtx must behave like an async CM and proxy attributes."""
+
+    @pytest.mark.asyncio
+    async def test_async_context_yields_underlying_response(self) -> None:
+        resp = _FakeResponse(200, body=b"hello")
+        ctx = _ResponseCtx(resp)
+        async with ctx as entered:
+            assert entered is resp
+            assert await entered.read() == b"hello"
+
+    @pytest.mark.asyncio
+    async def test_aexit_is_noop_and_does_not_close_response(self) -> None:
+        resp = _FakeResponse(200)
+        ctx = _ResponseCtx(resp)
+        await ctx.__aenter__()
+        await ctx.__aexit__(None, None, None)
+        # Attribute still accessible — proves no teardown happened.
+        assert ctx.status == 200
+
+    def test_getattr_delegates_to_wrapped_response(self) -> None:
+        resp = _FakeResponse(418, headers={"X-Flavor": "tea"})
+        ctx = _ResponseCtx(resp)
+        # Both exercise __getattr__ (attr not in __slots__).
+        assert ctx.status == 418
+        assert ctx.headers == {"X-Flavor": "tea"}
+
+
+# ---------------------------------------------------------------------------
+# ResilientSession lifecycle / delegation
+# ---------------------------------------------------------------------------
+
+
+class TestSessionLifecycle:
+    @pytest.mark.asyncio
+    async def test_close_delegates_to_inner(self) -> None:
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        assert session.closed is False
+        await session.close()
+        assert stub._closed is True
+        assert session.closed is True
+
+    @pytest.mark.asyncio
+    async def test_post_is_retried_like_get(self, _fast_sleep: None) -> None:
+        stub = StubSession(
+            [
+                _FakeResponse(503),
+                _FakeResponse(200, body=b"posted"),
+            ],
+        )
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        async with session.post("http://test/query") as resp:
+            body = await resp.read()
+        assert body == b"posted"
+        assert stub._call_count == 2
+        assert stub._last_method == "post"
+
+    @pytest.mark.asyncio
+    async def test_post_bypasses_retry_when_disabled(self) -> None:
+        stub = StubSession([_FakeResponse(200, body=b"direct")])
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=False))
+        async with session.post("http://test/query") as resp:
+            body = await resp.read()
+        assert body == b"direct"
+        assert stub._call_count == 1
+        assert stub._last_method == "post"
+
+    @pytest.mark.asyncio
+    async def test_get_bypasses_retry_when_disabled(self) -> None:
+        stub = StubSession([_FakeResponse(200, body=b"direct")])
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=False))
+        async with session.get("http://test/query") as resp:
+            body = await resp.read()
+        assert body == b"direct"
+        assert stub._call_count == 1
+        assert stub._last_method == "get"
+
+
+# ---------------------------------------------------------------------------
+# Limiter wiring
+# ---------------------------------------------------------------------------
+
+
+class TestLimiterWiring:
+    def test_constructs_limiter_registry_when_rate_configured(self) -> None:
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(
+                enabled=True,
+                rate_per_service_root_per_second=50.0,
+            ),
+        )
+        assert session._limiter is not None
+
+    def test_no_limiter_when_rate_unset(self) -> None:
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        assert session._limiter is None
+
+    @pytest.mark.asyncio
+    async def test_request_acquires_token_from_limiter(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(
+                enabled=True,
+                rate_per_service_root_per_second=100.0,
+            ),
+        )
+        async with session.get(
+            "http://host/rest/services/X/FeatureServer/0/query",
+        ) as resp:
+            await resp.read()
+        # A limiter for this service root must have been created/used.
+        assert session._limiter is not None
+        assert session._limiter._limiters, "limiter cache should be populated"
+
+    @pytest.mark.asyncio
+    async def test_reset_limiters_clears_state(self, _fast_sleep: None) -> None:
+        stub = StubSession(
+            [
+                _FakeResponse(429, {"Retry-After": "0"}),
+                _FakeResponse(200),
+            ],
+        )
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(
+                enabled=True,
+                rate_per_service_root_per_second=100.0,
+            ),
+        )
+        async with session.get(
+            "http://host/rest/services/X/FeatureServer/0/query",
+        ) as resp:
+            await resp.read()
+        assert session._limiter is not None
+        assert session._limiter._limiters
+
+        session._reset_limiters()
+
+        assert session._limiter._limiters == {}
+        # Cooldown registry should be a fresh instance with no deadlines.
+        assert session._cooldown._deadlines == {}
+
+    def test_reset_limiters_safe_without_limiter(self) -> None:
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        # Should be a no-op, not raise.
+        session._reset_limiters()
+        assert session._limiter is None
+
+
+# ---------------------------------------------------------------------------
+# ServerTimeoutError retry path
+# ---------------------------------------------------------------------------
+
+
+class TestServerTimeout:
+    @pytest.mark.asyncio
+    async def test_server_timeout_is_retried_then_succeeds(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession(
+            [
+                _make_server_timeout(),
+                _FakeResponse(200, body=b"recovered"),
+            ],
+        )
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        async with session.get("http://test/query") as resp:
+            body = await resp.read()
+        assert body == b"recovered"
+        assert stub._call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_server_timeout_exhaustion_raises_timeout_error(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession([_make_server_timeout()] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(RestgdfTimeoutError) as exc_info:
+            async with session.get("http://test/query") as resp:
+                await resp.read()
+        assert exc_info.value.timeout_kind == "read"
+        assert stub._call_count == 5
+
+
+# ---------------------------------------------------------------------------
+# 429 exhaustion + cooldown
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitExhaustion:
+    @pytest.mark.asyncio
+    async def test_persistent_429_raises_rate_limit_with_retry_after(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession(
+            [_FakeResponse(429, {"Retry-After": "3"})] * 10,
+        )
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(RateLimitError) as exc_info:
+            async with session.get("http://test/query") as resp:
+                await resp.read()
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.retry_after == pytest.approx(3.0)
+        assert stub._call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_429_sets_cooldown_then_waits_on_next_attempt(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        # First call returns 429 with a small Retry-After, then success.
+        # The cooldown set on the 1st 429 will be checked by
+        # ``wait_if_cooling`` on the retry — exercising line 159.
+        stub = StubSession(
+            [
+                _FakeResponse(429, {"Retry-After": "1"}),
+                _FakeResponse(200, body=b"after-cooldown"),
+            ],
+        )
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        async with session.get(
+            "http://host/rest/services/X/FeatureServer/0/query",
+        ) as resp:
+            body = await resp.read()
+        assert body == b"after-cooldown"
+        assert stub._call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# ClientConnectorError still maps to TransportError (defensive regression)
+# ---------------------------------------------------------------------------
+
+
+class TestConnectorErrorMapping:
+    @pytest.mark.asyncio
+    async def test_connector_error_exhaustion_raises_transport_error(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        exc = aiohttp.ClientConnectorError(
+            connection_key=None,
+            os_error=OSError("dns fail"),
+        )
+        stub = StubSession([exc] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(TransportError):
+            async with session.get("http://test/query") as resp:
+                await resp.read()
+        assert stub._call_count == 5

--- a/tests/test_resilience_retry_coverage.py
+++ b/tests/test_resilience_retry_coverage.py
@@ -138,6 +138,32 @@ class TestResponseCtx:
         assert ctx.status == 418
         assert ctx.headers == {"X-Flavor": "tea"}
 
+    @pytest.mark.asyncio
+    async def test_retried_context_manager_forwards_aexit(self) -> None:
+        exited = False
+
+        class _Ctx:
+            async def __aenter__(self) -> _FakeResponse:
+                return _FakeResponse(200)
+
+            async def __aexit__(self, *args: Any) -> None:
+                nonlocal exited
+                exited = True
+
+        class _Inner(StubSession):
+            def get(self, url: str, **kwargs: Any) -> Any:
+                return _Ctx()
+
+        session = ResilientSession(
+            inner=_Inner(),
+            config=ResilienceConfig(enabled=True),
+        )
+
+        async with session.get("http://test/query") as resp:
+            assert resp.status == 200
+
+        assert exited is True
+
 
 # ---------------------------------------------------------------------------
 # ResilientSession lifecycle / delegation

--- a/tests/test_resolve_domains.py
+++ b/tests/test_resolve_domains.py
@@ -100,7 +100,7 @@ async def _build_layer(
     session = QuerySession(responses)
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Test/FeatureServer/0",
-        session=session,
+        session=session,  # type: ignore[arg-type]
     )
     from restgdf._models.responses import LayerMetadata
     from restgdf.utils.getinfo import get_fields, get_name

--- a/tests/test_resolve_domains.py
+++ b/tests/test_resolve_domains.py
@@ -1,0 +1,275 @@
+"""T6 (R-75): ``FeatureLayer.get_df(resolve_domains=True)``.
+
+Verifies the new post-processing hook that swaps ArcGIS coded-value
+domain codes for their human-readable names and validates range-domain
+values against the declared ``[min, max]`` bounds.
+
+Guardrails:
+
+* The default ``resolve_domains=False`` path must remain byte-for-byte
+  identical to prior behavior (no accidental regression).
+* No additional HTTP traffic — resolution reads from
+  :attr:`FeatureLayer.metadata.fields`, which is already fetched during
+  :meth:`FeatureLayer.prep`.
+* Unknown codes and out-of-range values are preserved unchanged so the
+  DataFrame remains a faithful projection of what the server sent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from restgdf.featurelayer.featurelayer import FeatureLayer
+
+
+pd = pytest.importorskip("pandas")
+
+
+SAMPLE_METADATA_WITH_DOMAINS = {
+    "name": "Test Layer",
+    "type": "Feature Layer",
+    "fields": [
+        {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+        {
+            "name": "STATUS",
+            "type": "esriFieldTypeSmallInteger",
+            "domain": {
+                "type": "codedValue",
+                "name": "StatusDomain",
+                "codedValues": [
+                    {"name": "Active", "code": 1},
+                    {"name": "Inactive", "code": 2},
+                    {"name": "Pending", "code": 3},
+                ],
+            },
+        },
+        {
+            "name": "SCORE",
+            "type": "esriFieldTypeInteger",
+            "domain": {
+                "type": "range",
+                "name": "ScoreRange",
+                "range": [0, 100],
+            },
+        },
+        {"name": "NAME", "type": "esriFieldTypeString"},
+    ],
+    "maxRecordCount": 10,
+    "advancedQueryCapabilities": {"supportsPagination": False},
+}
+
+SAMPLE_METADATA_NO_DOMAINS = {
+    "name": "Test Layer",
+    "type": "Feature Layer",
+    "fields": [
+        {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+        {"name": "NAME", "type": "esriFieldTypeString"},
+    ],
+    "maxRecordCount": 10,
+    "advancedQueryCapabilities": {"supportsPagination": False},
+}
+
+
+class JsonResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    async def json(self, content_type=None):
+        return self._payload
+
+
+class QuerySession:
+    def __init__(self, responses: list[dict]):
+        self.responses = list(responses)
+        self.post_calls: list[tuple[str, dict]] = []
+
+    async def post(self, url: str, **kwargs):
+        self.post_calls.append((url, kwargs))
+        return JsonResponse(self.responses.pop(0))
+
+
+async def _build_layer(
+    metadata: dict,
+    features_pages: list[list[dict]],
+) -> tuple[FeatureLayer, QuerySession]:
+    responses: list[dict] = []
+    for page in features_pages:
+        responses.append({"features": page})
+    session = QuerySession(responses)
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Test/FeatureServer/0",
+        session=session,
+    )
+    from restgdf._models.responses import LayerMetadata
+    from restgdf.utils.getinfo import get_fields, get_name
+
+    layer.metadata = LayerMetadata.model_validate(metadata)
+    layer.name = get_name(layer.metadata)
+    layer.fields = get_fields(layer.metadata)
+    layer.count = sum(len(p) for p in features_pages)
+    return layer, session
+
+
+@pytest.mark.asyncio
+async def test_get_df_default_preserves_codes() -> None:
+    """Default ``resolve_domains=False`` leaves domain fields untouched."""
+    page = [
+        {"attributes": {"OBJECTID": 1, "STATUS": 1, "SCORE": 50, "NAME": "A"}},
+        {"attributes": {"OBJECTID": 2, "STATUS": 2, "SCORE": 75, "NAME": "B"}},
+    ]
+    # Two calls → two pages worth of stubbed responses.
+    layer, _session = await _build_layer(SAMPLE_METADATA_WITH_DOMAINS, [page, page])
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}]),
+    ):
+        df_default = await layer.get_df()
+        df_explicit = await layer.get_df(resolve_domains=False)
+
+    assert df_default["STATUS"].tolist() == [1, 2]
+    assert df_default["SCORE"].tolist() == [50, 75]
+    # Byte-for-byte identical when kwarg is omitted vs. explicitly False.
+    pd.testing.assert_frame_equal(df_default, df_explicit)
+
+
+@pytest.mark.asyncio
+async def test_get_df_resolves_coded_value_domain() -> None:
+    """``resolve_domains=True`` swaps coded values to their names."""
+    layer, _session = await _build_layer(
+        SAMPLE_METADATA_WITH_DOMAINS,
+        [
+            [
+                {"attributes": {"OBJECTID": 1, "STATUS": 1, "SCORE": 50, "NAME": "A"}},
+                {"attributes": {"OBJECTID": 2, "STATUS": 2, "SCORE": 75, "NAME": "B"}},
+                {"attributes": {"OBJECTID": 3, "STATUS": 3, "SCORE": 10, "NAME": "C"}},
+            ],
+        ],
+    )
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}]),
+    ):
+        df = await layer.get_df(resolve_domains=True)
+
+    assert df["STATUS"].tolist() == ["Active", "Inactive", "Pending"]
+    # Range-domain values within bounds pass through untouched.
+    assert df["SCORE"].tolist() == [50, 75, 10]
+    # Non-domain fields unchanged.
+    assert df["NAME"].tolist() == ["A", "B", "C"]
+
+
+@pytest.mark.asyncio
+async def test_get_df_resolve_domains_unknown_code_passes_through() -> None:
+    """Codes absent from the codedValues table stay as the raw code."""
+    layer, _session = await _build_layer(
+        SAMPLE_METADATA_WITH_DOMAINS,
+        [
+            [
+                {"attributes": {"OBJECTID": 1, "STATUS": 99, "SCORE": 50, "NAME": "A"}},
+                {"attributes": {"OBJECTID": 2, "STATUS": 1, "SCORE": 200, "NAME": "B"}},
+            ],
+        ],
+    )
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}]),
+    ):
+        df = await layer.get_df(resolve_domains=True)
+
+    # 99 is not in the coded-values map → unchanged.
+    # 1 resolves → "Active".
+    assert df["STATUS"].tolist() == [99, "Active"]
+    # Out-of-range value is left as-is (no warning, no coercion).
+    assert df["SCORE"].tolist() == [50, 200]
+
+
+@pytest.mark.asyncio
+async def test_get_df_resolve_domains_noop_when_no_domains() -> None:
+    """Layer without any domain fields: ``resolve_domains=True`` is a no-op."""
+    page = [
+        {"attributes": {"OBJECTID": 1, "NAME": "A"}},
+        {"attributes": {"OBJECTID": 2, "NAME": "B"}},
+    ]
+    layer, _session = await _build_layer(SAMPLE_METADATA_NO_DOMAINS, [page, page])
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}]),
+    ):
+        df_resolved = await layer.get_df(resolve_domains=True)
+        df_raw = await layer.get_df(resolve_domains=False)
+
+    pd.testing.assert_frame_equal(df_resolved, df_raw)
+
+
+@pytest.mark.asyncio
+async def test_get_df_resolve_domains_no_extra_http_calls() -> None:
+    """Resolution is pure post-processing; no extra POSTs are issued."""
+    layer, session = await _build_layer(
+        SAMPLE_METADATA_WITH_DOMAINS,
+        [
+            [
+                {"attributes": {"OBJECTID": 1, "STATUS": 1, "SCORE": 50, "NAME": "A"}},
+            ],
+        ],
+    )
+
+    with patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}]),
+    ):
+        pre_call_count = len(session.post_calls)
+        await layer.get_df(resolve_domains=True)
+        post_call_count = len(session.post_calls)
+
+    # Resolution must not issue any additional HTTP requests over and above
+    # the baseline streaming query.
+    assert post_call_count == pre_call_count + 1
+
+
+def test_resolve_domains_helper_is_exposed() -> None:
+    """The adapter helper is publicly importable for reuse."""
+    from restgdf.adapters.pandas import resolve_domains  # noqa: F401
+
+
+def test_resolve_domains_helper_handles_empty_fields() -> None:
+    """Empty / ``None`` fields metadata produces an identical DataFrame."""
+    from restgdf.adapters.pandas import resolve_domains
+
+    df = pd.DataFrame({"STATUS": [1, 2, 3]})
+    out = resolve_domains(df, None)
+    pd.testing.assert_frame_equal(out, df)
+
+    out2 = resolve_domains(df, [])
+    pd.testing.assert_frame_equal(out2, df)
+
+
+def test_resolve_domains_helper_with_dict_fields() -> None:
+    """Helper accepts raw dict field specs (not just ``FieldSpec``)."""
+    from restgdf.adapters.pandas import resolve_domains
+
+    df = pd.DataFrame({"STATUS": [1, 2, 99], "NAME": ["a", "b", "c"]})
+    fields = [
+        {"name": "NAME", "type": "esriFieldTypeString"},
+        {
+            "name": "STATUS",
+            "type": "esriFieldTypeSmallInteger",
+            "domain": {
+                "type": "codedValue",
+                "codedValues": [
+                    {"name": "Active", "code": 1},
+                    {"name": "Inactive", "code": 2},
+                ],
+            },
+        },
+    ]
+    out = resolve_domains(df, fields)
+    assert out["STATUS"].tolist() == ["Active", "Inactive", 99]
+    assert out["NAME"].tolist() == ["a", "b", "c"]
+    # Helper must not mutate the input frame.
+    assert df["STATUS"].tolist() == [1, 2, 99]

--- a/tests/test_resolve_domains.py
+++ b/tests/test_resolve_domains.py
@@ -89,6 +89,11 @@ class QuerySession:
         self.post_calls.append((url, kwargs))
         return JsonResponse(self.responses.pop(0))
 
+    async def get(self, url, **kwargs):
+        if "params" in kwargs and "data" not in kwargs:
+            kwargs = {**kwargs, "data": kwargs["params"]}
+        return await self.post(url, **kwargs)
+
 
 async def _build_layer(
     metadata: dict,

--- a/tests/test_telemetry_coverage.py
+++ b/tests/test_telemetry_coverage.py
@@ -1,0 +1,234 @@
+"""Coverage-focused tests for ``restgdf.telemetry._correlation`` and
+``restgdf.telemetry._spans``.
+
+These tests pin contract-level behavior for two edge paths that aren't
+exercised elsewhere:
+
+* ``span_context_fields()`` and ``start_feature_layer_stream_span()`` must
+  degrade cleanly when ``opentelemetry`` is not importable — the former
+  returning ``{}``, the latter raising ``OptionalDependencyError``.
+* The public ``feature_layer_stream_span`` context manager must propagate
+  every optional descriptor (``layer_id``, ``out_fields``, ``where``,
+  ``order``, ``extra_attrs``) onto the emitted span's attributes.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from restgdf import reset_config_cache
+from restgdf.errors import OptionalDependencyError
+
+
+def _block_opentelemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate ``opentelemetry`` being uninstalled for subsequent imports."""
+    monkeypatch.setitem(sys.modules, "opentelemetry", None)
+    monkeypatch.setitem(sys.modules, "opentelemetry.trace", None)
+    for key in list(sys.modules):
+        if key.startswith("restgdf.telemetry"):
+            monkeypatch.delitem(sys.modules, key, raising=False)
+
+
+def test_span_context_fields_returns_empty_when_opentelemetry_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without OTel installed, ``span_context_fields()`` yields ``{}``."""
+    _block_opentelemetry(monkeypatch)
+
+    from restgdf.telemetry._correlation import span_context_fields
+
+    assert span_context_fields() == {}
+
+
+def test_span_context_fields_returns_empty_without_active_span() -> None:
+    """With OTel installed but no active span, ``span_context_fields()`` is ``{}``.
+
+    This pins the non-ImportError "invalid context" branch so both halves of
+    the function's contract are locked in.
+    """
+    from restgdf.telemetry._correlation import span_context_fields
+
+    assert span_context_fields() == {}
+
+
+@pytest.mark.asyncio
+async def test_span_context_fields_returns_ids_inside_active_span(
+    memory_exporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inside an active span, ``span_context_fields()`` returns hex IDs."""
+    monkeypatch.setenv("RESTGDF_TELEMETRY_ENABLED", "1")
+    reset_config_cache()
+
+    from restgdf.telemetry import feature_layer_stream_span
+    from restgdf.telemetry._correlation import span_context_fields
+
+    async with feature_layer_stream_span(
+        layer_url="https://example.com/arcgis/rest/services/Svc/FeatureServer/0",
+    ) as span:
+        fields = span_context_fields()
+
+    assert set(fields) == {"trace_id", "span_id"}
+    assert fields["trace_id"] == format(span.get_span_context().trace_id, "032x")
+    assert fields["span_id"] == format(span.get_span_context().span_id, "016x")
+    assert len(fields["trace_id"]) == 32
+    assert len(fields["span_id"]) == 16
+
+
+def test_start_feature_layer_stream_span_raises_when_opentelemetry_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When telemetry is enabled but OTel is absent, starting a span raises."""
+    monkeypatch.setenv("RESTGDF_TELEMETRY_ENABLED", "1")
+    reset_config_cache()
+
+    _block_opentelemetry(monkeypatch)
+
+    from restgdf.telemetry._spans import start_feature_layer_stream_span
+
+    with pytest.raises(OptionalDependencyError, match=r"restgdf\[telemetry\]"):
+        start_feature_layer_stream_span(layer_url="https://example.com/0")
+
+
+def test_start_feature_layer_stream_span_returns_none_when_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disabled telemetry short-circuits before any OTel import."""
+    monkeypatch.delenv("RESTGDF_TELEMETRY_ENABLED", raising=False)
+    reset_config_cache()
+
+    from restgdf.telemetry._spans import start_feature_layer_stream_span
+
+    span = start_feature_layer_stream_span(layer_url="https://example.com/0")
+    assert span is None
+
+
+def test_start_feature_layer_stream_span_emits_span_when_enabled(
+    memory_exporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With telemetry enabled + OTel present, the helper returns a live span.
+
+    The caller owns the span lifetime and must call ``end()``. The emitted
+    span ends up in the exporter with the expected attributes.
+    """
+    monkeypatch.setenv("RESTGDF_TELEMETRY_ENABLED", "1")
+    reset_config_cache()
+
+    from restgdf.telemetry._spans import start_feature_layer_stream_span
+
+    url = "https://example.com/arcgis/rest/services/Svc/FeatureServer/7"
+    span = start_feature_layer_stream_span(
+        layer_url=url,
+        layer_id=7,
+        out_fields="*",
+        where="1=1",
+        order="completion",
+        extra_attrs={"restgdf.page.count": 1},
+    )
+    assert span is not None
+    try:
+        assert span.is_recording()
+    finally:
+        span.end()
+
+    (finished,) = (
+        s
+        for s in memory_exporter.get_finished_spans()
+        if s.name == "feature_layer.stream"
+    )
+    attrs = dict(finished.attributes or {})
+    assert attrs.get("restgdf.layer_id") == 7
+    assert attrs.get("restgdf.out_fields") == "*"
+    assert attrs.get("restgdf.where") == "1=1"
+    assert attrs.get("restgdf.order") == "completion"
+    assert attrs.get("restgdf.page.count") == 1
+
+
+@pytest.mark.asyncio
+async def test_feature_layer_stream_span_yields_none_when_disabled(
+    memory_exporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disabled telemetry makes the async context manager yield ``None``."""
+    monkeypatch.delenv("RESTGDF_TELEMETRY_ENABLED", raising=False)
+    reset_config_cache()
+
+    from restgdf.telemetry import feature_layer_stream_span
+
+    async with feature_layer_stream_span(
+        layer_url="https://example.com/0",
+    ) as span:
+        assert span is None
+
+    assert memory_exporter.get_finished_spans() == ()
+
+
+@pytest.mark.asyncio
+async def test_feature_layer_stream_span_sets_all_optional_attributes(
+    memory_exporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every optional descriptor is surfaced as a ``restgdf.*`` span attribute."""
+    monkeypatch.setenv("RESTGDF_TELEMETRY_ENABLED", "1")
+    reset_config_cache()
+
+    from restgdf.telemetry import feature_layer_stream_span
+
+    url = "https://example.com/arcgis/rest/services/Svc/FeatureServer/3"
+    async with feature_layer_stream_span(
+        layer_url=url,
+        layer_id=3,
+        out_fields="OBJECTID,NAME",
+        where="STATUS='OPEN'",
+        order="request",
+        extra_attrs={"restgdf.page.count": 2},
+    ):
+        pass
+
+    (span,) = (
+        s
+        for s in memory_exporter.get_finished_spans()
+        if s.name == "feature_layer.stream"
+    )
+    attrs = dict(span.attributes or {})
+
+    assert attrs.get("restgdf.layer_id") == 3
+    assert attrs.get("restgdf.out_fields") == "OBJECTID,NAME"
+    assert attrs.get("restgdf.where") == "STATUS='OPEN'"
+    assert attrs.get("restgdf.order") == "request"
+    assert attrs.get("restgdf.page.count") == 2
+
+
+@pytest.mark.asyncio
+async def test_feature_layer_stream_span_omits_unset_optional_attributes(
+    memory_exporter,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset optional descriptors are absent from the emitted span attributes."""
+    monkeypatch.setenv("RESTGDF_TELEMETRY_ENABLED", "1")
+    reset_config_cache()
+
+    from restgdf.telemetry import feature_layer_stream_span
+
+    url = "https://example.com/arcgis/rest/services/Svc/FeatureServer/0"
+    async with feature_layer_stream_span(layer_url=url):
+        pass
+
+    (span,) = (
+        s
+        for s in memory_exporter.get_finished_spans()
+        if s.name == "feature_layer.stream"
+    )
+    attrs = dict(span.attributes or {})
+
+    for key in (
+        "restgdf.layer_id",
+        "restgdf.out_fields",
+        "restgdf.where",
+        "restgdf.order",
+    ):
+        assert key not in attrs
+    assert "restgdf.service_root" in attrs

--- a/tests/test_transport_protocol.py
+++ b/tests/test_transport_protocol.py
@@ -1,0 +1,58 @@
+"""R-71: ArcGISTokenSession must satisfy AsyncHTTPSession Protocol.
+
+These tests lock in that :class:`~restgdf.utils.token.ArcGISTokenSession`
+exposes ``close()`` and ``closed`` mirroring its underlying
+:class:`aiohttp.ClientSession`, and that the Protocol is
+``runtime_checkable`` so adapter classes can be validated via
+``isinstance``.
+"""
+
+from __future__ import annotations
+
+import aiohttp
+import pytest
+
+from restgdf._client._protocols import AsyncHTTPSession
+from restgdf.utils.token import ArcGISTokenSession
+
+
+def test_protocol_is_runtime_checkable() -> None:
+    """AsyncHTTPSession must be decorated @runtime_checkable."""
+    # _is_runtime_protocol is set by typing.runtime_checkable
+    assert getattr(AsyncHTTPSession, "_is_runtime_protocol", False) is True
+
+
+@pytest.mark.asyncio
+async def test_arcgis_token_session_is_asynchttpsession() -> None:
+    """ArcGISTokenSession instances must pass isinstance(AsyncHTTPSession)."""
+    async with aiohttp.ClientSession() as inner:
+        tok = ArcGISTokenSession(session=inner)
+        assert isinstance(tok, AsyncHTTPSession)
+
+
+@pytest.mark.asyncio
+async def test_arcgis_token_session_closed_mirrors_inner() -> None:
+    """``.closed`` must delegate to the underlying aiohttp.ClientSession."""
+    inner = aiohttp.ClientSession()
+    tok = ArcGISTokenSession(session=inner)
+    assert tok.closed is False
+    await inner.close()
+    assert tok.closed is True
+
+
+@pytest.mark.asyncio
+async def test_arcgis_token_session_close_closes_inner() -> None:
+    """``await .close()`` must close the underlying aiohttp.ClientSession."""
+    inner = aiohttp.ClientSession()
+    tok = ArcGISTokenSession(session=inner)
+    assert inner.closed is False
+    await tok.close()
+    assert inner.closed is True
+    assert tok.closed is True
+
+
+@pytest.mark.asyncio
+async def test_aiohttp_client_session_still_satisfies_protocol() -> None:
+    """Regression: aiohttp.ClientSession itself must still match the Protocol."""
+    async with aiohttp.ClientSession() as s:
+        assert isinstance(s, AsyncHTTPSession)


### PR DESCRIPTION
## Summary
- harden the Gate-3 follow-up fixes around ArcGIS request routing, resilient-session request handling, advertised pagination-factor parsing, and temporary session cleanup
- bound page and streaming fan-out to the configured concurrency cap, cancel sibling work on failure or early generator close, and reject non-object page payloads explicitly
- add regression coverage for the follow-up fixes, move property-based tests behind a dedicated stress marker and --run-stress opt-in, and wire a separate stress job into GitHub Actions

## Validation
- & .\\.venv\\Scripts\\python.exe -m pytest -q tests/test_gate3_fixes.py tests/test_getgdf.py tests/test_iter_pages_edge_cases.py tests/test_resilience_retry_coverage.py tests/test_concurrency.py tests/test_deprecations.py tests/test_hypothesis_responses.py
- & .\\.venv\\Scripts\\python.exe -m pytest -q