### PR TITLE
Tighten release-readiness checks

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -28,13 +28,13 @@ jobs:
     name: pre-commit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   test:
     name: pytest (py${{ matrix.python-version }})
@@ -44,9 +44,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -80,8 +80,8 @@ jobs:
           - label: dev
             extras: "[dev]"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: pip
@@ -99,8 +99,8 @@ jobs:
     name: pytest-base-install
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: pip
@@ -123,8 +123,8 @@ jobs:
     name: pytest-network
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: pip
@@ -140,8 +140,8 @@ jobs:
     name: pytest-stress
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: pip
@@ -157,8 +157,8 @@ jobs:
     name: docs (strict)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
           cache: pip
@@ -171,7 +171,7 @@ jobs:
         run: python -m sphinx -n -W --keep-going -b html docs docs/_build/html
       - name: Upload built docs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: docs-html
           path: docs/_build/html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,7 @@
 All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
-
+## [2.0.0] - 2026-05-02
 ### Changed
 
 - **Gate-3 hardening follow-up (post-T6-T11).** Three review-driven

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,7 +13,7 @@ repository-code: "https://github.com/joshuasundance-swca/restgdf"
 url: "https://restgdf.readthedocs.io/"
 license: MIT
 version: 2.0.0
-date-released: "2026-04-20"
+date-released: "2026-05-02"
 keywords:
   - geopandas
   - esri

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,12 +1,11 @@
 # restgdf migration guide
 
-## Unreleased migration notes
+## 2.0.0 migration notes
 
-The 3.0 release reshapes install surface, error taxonomy, configuration,
+restgdf 2.0.0 reshapes install surface, error taxonomy, configuration,
 authentication, observability, and streaming on top of the typed
-pydantic models that landed in 2.0. Everything below is consolidated
-across the phase-1 through phase-4 work tracks — the preserved 1.x → 2.0
-guide follows at the bottom unchanged.
+pydantic models that now ship in the release. The preserved 1.x → 2.0
+guide follows below.
 
 ### Summary
 
@@ -50,10 +49,6 @@ guide follows at the bottom unchanged.
   `PaginationPlan` / `build_pagination_plan`, pure-helper
   `normalize_spatial_reference` and `normalize_date_fields`, and
   `ResilientSession` / `RestgdfInstrumentor`.
-- **Version strings are frozen at `2.0.0`** until the 3.0 cut so the
-  taxonomy/contract tests (`tests/test_compat.py`) stay green through
-  the rewrite.
-
 ### Breaking changes
 
 **Install**
@@ -239,7 +234,7 @@ from the same row stream; raises `OptionalDependencyError`
   `advertised_factor` the planner clamps to the advertised value and
   logs a warning via `restgdf.pagination`. Live
   `advancedQueryCapabilities.maxRecordCountFactor` wiring into
-  `get_query_data_batches` is a deliberate post-3.0 follow-up.
+  `get_query_data_batches` remains a future follow-up.
 
 **Advanced query capabilities** (`restgdf._models.responses`)
 
@@ -345,8 +340,8 @@ from the same row stream; raises `OptionalDependencyError`
   span when telemetry is enabled.
 
 All deprecations are shim-backed — existing code keeps working and
-emits `DeprecationWarning`. Removal of any deprecated surface will not
-happen before the 3.0 final release.
+emits `DeprecationWarning`. Removal of any deprecated surface will only
+happen in a future major release.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ lightweight async Esri REST client with optional GeoPandas extras
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 
-## What's new in 3.0 (in progress)
+## Release highlights
 
-The `integration/3.0-rewrite` branch is the active development line for
-restgdf 3.0. Everything below ships alongside the 2.0 surface on the
-same `main` until the version number is rolled.
+restgdf 2.0.0 includes the following major additions alongside the core
+typed-model migration described below.
 
 - **Streaming APIs.** `FeatureLayer.stream_features`,
   `stream_feature_batches`, and `stream_rows` expose ArcGIS
@@ -67,9 +66,9 @@ same `main` until the version number is rolled.
 
 See [`CHANGELOG.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/CHANGELOG.md)
 and [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md)
-for the complete list.
+for the full release notes and upgrade guidance.
 
-## What's new in 2.0
+## 2.0 migration changes
 
 restgdf 2.0 is a **major release** built on [pydantic 2.13](https://docs.pydantic.dev/).
 See [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md) for the full breaking-changes table and
@@ -94,7 +93,7 @@ code-rewrite recipes.
   upgrade window.
 - **Deprecated shim.** `restgdf._types.*` still imports the legacy
   `TypedDict` names, but they now re-export the pydantic classes and
-  emit `DeprecationWarning`. The shim will be removed in 3.x.
+  emit `DeprecationWarning`. The shim will be removed in a future major release.
 - **Dependency bump.** `pydantic>=2.13.3,<3` is a new required
   dependency.
 
@@ -153,11 +152,10 @@ pip install "restgdf[geo]"
 - pandas-backed helpers like `get_value_counts()` and `get_nested_count()`
 - low-level `restgdf.utils.getgdf` helpers
 
-Planning a 2.x → 3.x rollout? Treat the split above as the stable dependency
-boundary: geo-enabled environments should depend on `restgdf[geo]`
-explicitly. [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md)
-now starts with the upcoming optional-dependency notes and keeps the full
-1.x → 2.0 rewrite table below.
+Treat the split above as the stable dependency boundary: geo-enabled
+environments should depend on `restgdf[geo]` explicitly. See
+[`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md)
+for the full 1.x → 2.0 rewrite table and upgrade recipes.
 
 ## Light-core usage
 
@@ -414,7 +412,7 @@ contents.
   taxonomy, logger hierarchy, config precedence, session ownership,
   streaming shapes, extras matrix.
 - [CHANGELOG.md](CHANGELOG.md) — every user-visible change.
-- [MIGRATION.md](MIGRATION.md) — upgrading from 2.x to 3.x.
+- [MIGRATION.md](MIGRATION.md) — upgrading from 1.x to 2.0.
 
 # Uses
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,10 @@ description = "lightweight async Esri REST client with optional GeoPandas extras
 authors = [{ name = "Joshua Sundance Bailey" }]
 readme = "README.md"
 dependencies = [
-    "aiohttp",
+    "aiohttp>=3.9",
     "pydantic>=2.13.3,<3",
     "eval_type_backport; python_version < '3.10'",
-    "requests",
+    "requests>=2.31",
 ]
 license = "MIT"
 license-files = ["LICENSE"]
@@ -69,9 +69,9 @@ Changelog = "https://github.com/joshuasundance-swca/restgdf/blob/main/CHANGELOG.
 
 [project.optional-dependencies]
 geo = [
-    "geopandas",
-    "pandas",
-    "pyogrio",
+    "geopandas>=0.14",
+    "pandas>=2.1",
+    "pyogrio>=0.7",
 ]
 
 resilience = [
@@ -183,6 +183,10 @@ pythonpath = "."
 testpaths = "tests"
 addopts = "--strict-markers"
 asyncio_mode = "strict"
+filterwarnings = [
+    "error::DeprecationWarning:restgdf(\\.|$)",
+    "error::PendingDeprecationWarning:restgdf(\\.|$)",
+]
 markers = [
     "network: tests that hit live external ArcGIS services",
     "stress: resource-intensive or property-based tests excluded by default; pass --run-stress to include them",

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.14"
+    python: "3.12"
 
 sphinx:
   configuration: docs/conf.py

--- a/restgdf/__init__.py
+++ b/restgdf/__init__.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
         TokenResponse,
         TokenSessionConfig,
         get_settings,
+        reset_settings_cache,
     )
     from .directory.directory import Directory
     from .errors import (
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
         InvalidCredentialsError,
         OptionalDependencyError,
         OutputConversionError,
+        PaginationInconsistencyWarning,
         PaginationError,
         RateLimitError,
         RestgdfError,
@@ -90,6 +92,7 @@ __all__ = [
     "ObjectIdsResponse",
     "OptionalDependencyError",
     "OutputConversionError",
+    "PaginationInconsistencyWarning",
     "PaginationError",
     "RateLimitError",
     "ResilienceConfig",
@@ -114,6 +117,7 @@ __all__ = [
     "get_config",
     "get_settings",
     "reset_config_cache",
+    "reset_settings_cache",
     "utils",
 ]
 
@@ -157,6 +161,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str | None]] = {
             "TokenResponse",
             "TokenSessionConfig",
             "get_settings",
+            "reset_settings_cache",
         )
     },
     **{
@@ -170,6 +175,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str | None]] = {
             "InvalidCredentialsError",
             "OptionalDependencyError",
             "OutputConversionError",
+            "PaginationInconsistencyWarning",
             "PaginationError",
             "RateLimitError",
             "RestgdfError",

--- a/restgdf/errors.py
+++ b/restgdf/errors.py
@@ -425,6 +425,7 @@ __all__ = [
     "InvalidCredentialsError",
     "OptionalDependencyError",
     "OutputConversionError",
+    "PaginationInconsistencyWarning",
     "PaginationError",
     "RateLimitError",
     "RestgdfError",

--- a/restgdf/utils/_deprecations.py
+++ b/restgdf/utils/_deprecations.py
@@ -8,6 +8,7 @@ through re-exports). See Phase 6 of the TDD refactor plan and
 
 from __future__ import annotations
 
+import inspect
 import warnings
 from functools import wraps
 from typing import Any, Callable, TypeVar
@@ -48,9 +49,7 @@ def deprecated_alias(new_func: F, old_name: str, new_name: str) -> F:
 
 
 def _is_async_callable(obj: Any) -> bool:
-    import asyncio
-
-    return asyncio.iscoroutinefunction(obj)
+    return inspect.iscoroutinefunction(obj)
 
 
 __all__ = ["deprecated_alias"]

--- a/restgdf/utils/_http.py
+++ b/restgdf/utils/_http.py
@@ -6,10 +6,10 @@ Private submodule; all public names are re-exported by
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 import inspect
 from typing import Any, Literal
-from collections.abc import Mapping
-from urllib.parse import urlencode, urlsplit
+from urllib.parse import urlencode
 
 import aiohttp
 
@@ -42,14 +42,6 @@ def default_data(
     default_dict = default_dict or DEFAULTDICT
     return {**default_dict, **(data or {})}
 
-
-_POST_ENDPOINT_SUFFIXES: tuple[str, ...] = ("/query", "/queryRelatedRecords")
-_GET_PARENT_SEGMENTS: tuple[str, ...] = (
-    "MapServer",
-    "FeatureServer",
-    "ImageServer",
-    "GPServer",
-)
 
 # T8 (R-74): ArcGIS REST practical URL-length ceiling. Past this many bytes
 # (URL + encoded body), servers (and intermediaries like IIS/WAFs) routinely
@@ -91,12 +83,6 @@ def _choose_verb(
     if len(url) + separator + encoded_len <= _ARCGIS_URL_BODY_LIMIT:
         return "GET"
     return "POST"
-
-
-# Legacy endpoint-classification data kept for potential diagnostic reuse
-# (see git blame for BL-20). The active verb decision is length-based —
-# these constants are intentionally unused at runtime.
-_ = (_POST_ENDPOINT_SUFFIXES, _GET_PARENT_SEGMENTS, urlsplit)
 
 
 async def _arcgis_request(

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
     from geopandas import GeoDataFrame
 
 supported_drivers: dict[str, str] | None = None
+_METADATA_LOG = get_logger("transport")
 
 
 def _require_geo_query_support(feature: str) -> None:
@@ -389,7 +390,12 @@ async def chunk_generator(
     raw_sr: dict[str, Any] | None
     try:
         metadata = await get_metadata(url, session, token=token)
-    except Exception:  # pragma: no cover - metadata errors surface elsewhere
+    except Exception as exc:  # pragma: no cover - metadata errors surface elsewhere
+        _METADATA_LOG.debug(
+            "spatial_reference.metadata_lookup_failed url=%s operation=chunk_generator",
+            url,
+            exc_info=exc,
+        )
         raw_sr = None
     else:
         raw_sr = _extract_raw_spatial_reference(metadata)
@@ -573,7 +579,12 @@ async def _apply_spatial_reference_attr(
     token = request_data.get("token") if isinstance(request_data, Mapping) else None
     try:
         metadata = await get_metadata(url, session, token=token)
-    except Exception:  # pragma: no cover - metadata errors surface elsewhere
+    except Exception as exc:  # pragma: no cover - metadata errors surface elsewhere
+        _METADATA_LOG.debug(
+            "spatial_reference.metadata_lookup_failed url=%s operation=apply_attr",
+            url,
+            exc_info=exc,
+        )
         return
     raw_sr = _extract_raw_spatial_reference(metadata)
     if raw_sr is not None:

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import importlib
 import logging
 from dataclasses import dataclass, field
 
 import aiohttp
-import requests
 
 from restgdf._models._drift import _parse_response
 from restgdf._models.credentials import AGOLUserPass, TokenSessionConfig
@@ -41,6 +41,25 @@ _MAX_TOKEN_RETRIES: int = 3  # Max /generateToken POST attempts
 _BASE_BACKOFF_S: float = 0.5  # Initial retry sleep; doubles each attempt
 
 _RETRYABLE_ERRORS = (OSError, asyncio.TimeoutError, ConnectionError)
+
+
+class _LazyRequestsModule:
+    """Load ``requests`` only when the deprecated sync helper is touched."""
+
+    def _module(self):
+        return importlib.import_module("requests")
+
+    def __getattr__(self, name: str):
+        return getattr(self._module(), name)
+
+    def __setattr__(self, name: str, value) -> None:
+        setattr(self._module(), name, value)
+
+    def __delattr__(self, name: str) -> None:
+        delattr(self._module(), name)
+
+
+requests = _LazyRequestsModule()
 
 
 def _utc_now() -> datetime.datetime:

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -738,14 +738,13 @@ async def test_featurelayer(client_session):
         session=client_session,
         where="City <> 'fgsfds'",
     )
-    beaches_gdf = await beaches.getgdf()
-    assert len(await beaches.samplegdf(2)) == 2
-    assert len(await beaches.headgdf(2)) == 2
+    beaches_gdf = await beaches.get_gdf()
+    assert len(await beaches.sample_gdf(2)) == 2
+    assert len(await beaches.head_gdf(2)) == 2
     assert len(beaches_gdf) > 0
 
-    row_gen = beaches.row_dict_generator()
     beaches_row_gen_count = 0
-    async for row in row_gen:
+    async for row in beaches.stream_rows():
         assert isinstance(row, dict)
         beaches_row_gen_count += 1
     assert beaches_row_gen_count == len(beaches_gdf)

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -425,6 +425,9 @@ async def test_featurelayer_get_gdf_requires_geo_extra_before_query():
 
 
 @pytest.mark.asyncio
+@pytest.mark.filterwarnings(
+    r"ignore:FeatureLayer\.row_dict_generator is deprecated:DeprecationWarning",
+)
 async def test_row_dict_generator_merges_data_kwargs():
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",

--- a/tests/test_base_install.py
+++ b/tests/test_base_install.py
@@ -300,6 +300,9 @@ async def test_row_dict_generator_uses_query_batch_data_without_duplicate_kwargs
 
 
 @pytest.mark.asyncio
+@pytest.mark.filterwarnings(
+    r"ignore:FeatureLayer\.row_dict_generator is deprecated:DeprecationWarning",
+)
 async def test_featurelayer_row_dict_generator_merges_data_kwargs():
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -182,7 +182,7 @@ async def test_bounded_semaphore_caps_concurrency_at_fanout_sites(monkeypatch):
         raising=False,
     )
 
-    monkeypatch.setenv("RESTGDF_MAX_CONCURRENT_REQUESTS", "4")
+    monkeypatch.setenv("RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS", "4")
     reset_settings_cache()
     try:
         from restgdf.utils.getinfo import service_metadata

--- a/tests/test_concurrency_nesting.py
+++ b/tests/test_concurrency_nesting.py
@@ -86,7 +86,7 @@ async def test_fetch_all_data_shares_semaphore_across_nested_fanout(monkeypatch)
     nested ``service_metadata`` call. With cap=2 and 3 services × 3 layers
     each, the observed peak must be ≤ 2 — not ≤ 4 (2*2) as the pre-fix
     nested-unshared semaphore would allow."""
-    monkeypatch.setenv("RESTGDF_MAX_CONCURRENT_REQUESTS", "2")
+    monkeypatch.setenv("RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS", "2")
     reset_settings_cache()
     try:
         peak_of = _install_counting_metadata_fakes(monkeypatch)
@@ -114,7 +114,7 @@ async def test_fetch_all_data_shares_semaphore_across_nested_fanout(monkeypatch)
 async def test_safe_crawl_shares_semaphore_across_nested_fanout(monkeypatch):
     """``safe_crawl`` must share ONE ``BoundedSemaphore`` with every nested
     ``service_metadata`` call (same contract as ``fetch_all_data``)."""
-    monkeypatch.setenv("RESTGDF_MAX_CONCURRENT_REQUESTS", "2")
+    monkeypatch.setenv("RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS", "2")
     reset_settings_cache()
     try:
         peak_of = _install_counting_metadata_fakes(monkeypatch)

--- a/tests/test_error_mro.py
+++ b/tests/test_error_mro.py
@@ -244,6 +244,7 @@ def test_module_lists_full_public_api() -> None:
         "InvalidCredentialsError",
         "OptionalDependencyError",
         "OutputConversionError",
+        "PaginationInconsistencyWarning",
         "PaginationError",
         "RateLimitError",
         "RestgdfError",

--- a/tests/test_gate3_fixes.py
+++ b/tests/test_gate3_fixes.py
@@ -27,6 +27,7 @@ Covers three follow-up-on-follow-up fixes on top of T6–T11:
 from __future__ import annotations
 
 import math
+from urllib.parse import urlencode
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -261,6 +262,59 @@ def test_coerce_params_for_get_normalizes_bool_none_and_preserves_other_values()
         "resultRecordCount": 1000,
         "objectIds": [1, 2, 3],
     }
+
+
+def test_encoded_body_length_matches_urlencode_doseq_behavior():
+    """The length helper must mirror ``urlencode(..., doseq=True)`` exactly."""
+    from restgdf.utils._http import _encoded_body_length
+
+    body = {
+        "where": "NAME IN ('A', 'B')",
+        "objectIds": [1, 2, 3],
+        "returnGeometry": True,
+    }
+
+    assert _encoded_body_length(None) == 0
+    assert _encoded_body_length({}) == 0
+    assert _encoded_body_length(body) == len(urlencode(body, doseq=True))
+
+
+def test_safe_static_attr_value_handles_descriptor_and_attributeerror():
+    """Static attr reads must resolve properties without fabricating values."""
+    from restgdf.utils._http import _safe_static_attr_value
+
+    class _PropertyBacked:
+        @property
+        def _transport(self) -> str:
+            return "query"
+
+    class _MissingAtRuntime:
+        @property
+        def _transport(self) -> str:
+            raise AttributeError("not set")
+
+    assert _safe_static_attr_value(_PropertyBacked(), "_transport") == "query"
+    assert _safe_static_attr_value(_MissingAtRuntime(), "_transport") is None
+
+
+def test_session_requires_body_transport_walks_property_backed_inner_chain():
+    """Property-backed wrapper chains should still surface a query/body transport."""
+    from restgdf.utils._http import _session_requires_body_transport
+
+    class _TokenInner:
+        @property
+        def _transport(self) -> str:
+            return "query"
+
+    class _Wrapper:
+        def __init__(self, inner) -> None:
+            self._wrapped = inner
+
+        @property
+        def _inner(self):
+            return self._wrapped
+
+    assert _session_requires_body_transport(_Wrapper(_TokenInner())) is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_getgdf_coverage.py
+++ b/tests/test_getgdf_coverage.py
@@ -249,6 +249,49 @@ async def test_chunk_generator_skips_stamping_when_metadata_has_no_sr():
 
 
 @pytest.mark.asyncio
+async def test_apply_spatial_reference_attr_passes_token_and_stamps_raw_sr():
+    url = "https://example.test/FeatureServer/0"
+    raw_sr = {"wkid": 4326, "latestWkid": 4326}
+    session = object()
+    gdf = GeoDataFrame({"OBJECTID": [1], "geometry": [Point(0, 0)]}, crs="EPSG:4326")
+
+    with patch.object(
+        getgdf_mod,
+        "get_metadata",
+        AsyncMock(return_value={"extent": {"spatialReference": raw_sr}}),
+    ) as get_metadata:
+        await getgdf_mod._apply_spatial_reference_attr(
+            gdf,
+            url,
+            session,
+            data={"token": "secret", "where": "1=1"},
+        )
+
+    get_metadata.assert_awaited_once_with(url, session, token="secret")
+    assert gdf.attrs["spatial_reference"] == raw_sr
+
+
+@pytest.mark.asyncio
+async def test_apply_spatial_reference_attr_ignores_metadata_errors():
+    url = "https://example.test/FeatureServer/0"
+    gdf = GeoDataFrame({"OBJECTID": [1], "geometry": [Point(0, 0)]}, crs="EPSG:4326")
+
+    with patch.object(
+        getgdf_mod,
+        "get_metadata",
+        AsyncMock(side_effect=RuntimeError("metadata unavailable")),
+    ):
+        await getgdf_mod._apply_spatial_reference_attr(
+            gdf,
+            url,
+            object(),
+            data={"token": "secret"},
+        )
+
+    assert "spatial_reference" not in gdf.attrs
+
+
+@pytest.mark.asyncio
 async def test_iter_pages_raw_finally_ends_span_when_batches_fail_early():
     """If ``get_query_data_batches`` raises, no tasks exist but span still ends."""
     url = "https://example.test/FeatureServer/0"

--- a/tests/test_http_timeout.py
+++ b/tests/test_http_timeout.py
@@ -91,7 +91,7 @@ def test_default_timeout_uses_explicit_settings_timeout_seconds():
 def test_default_timeout_default_resolves_to_settings_30_float(monkeypatch):
     from restgdf.utils._http import default_timeout
 
-    monkeypatch.delenv("RESTGDF_TIMEOUT_SECONDS", raising=False)
+    monkeypatch.delenv("RESTGDF_TIMEOUT_TOTAL_S", raising=False)
     reset_settings_cache()
     try:
         result = default_timeout()
@@ -104,7 +104,7 @@ def test_default_timeout_default_resolves_to_settings_30_float(monkeypatch):
 def test_default_timeout_reads_env_as_float(monkeypatch):
     from restgdf.utils._http import default_timeout
 
-    monkeypatch.setenv("RESTGDF_TIMEOUT_SECONDS", "7.25")
+    monkeypatch.setenv("RESTGDF_TIMEOUT_TOTAL_S", "7.25")
     reset_settings_cache()
     try:
         result = default_timeout()
@@ -183,7 +183,7 @@ async def test_update_token_forwards_timeout(monkeypatch):
                 {"token": "t", "expires": 32503680000000},
             )
 
-    monkeypatch.setenv("RESTGDF_TIMEOUT_SECONDS", "12.5")
+    monkeypatch.setenv("RESTGDF_TIMEOUT_TOTAL_S", "12.5")
     reset_settings_cache()
     try:
         token_session = ArcGISTokenSession(

--- a/tests/test_pagination_live_factor.py
+++ b/tests/test_pagination_live_factor.py
@@ -246,8 +246,7 @@ async def test_no_exceeded_limit_no_inconsistency_warning():
 
 def test_pagination_inconsistency_warning_importable_from_errors_module():
     """The sentinel lives in :mod:`restgdf.errors` alongside the error
-    taxonomy, even though (as a ``UserWarning`` subclass) it is not in
-    ``errors.__all__`` and not re-exported at the package root.
+    taxonomy and is re-exported through the package root for consistency.
     """
     from restgdf import errors
 
@@ -255,3 +254,10 @@ def test_pagination_inconsistency_warning_importable_from_errors_module():
     assert isinstance(cls, type)
     assert issubclass(cls, UserWarning)
     assert cls.__name__ == "PaginationInconsistencyWarning"
+
+
+def test_pagination_inconsistency_warning_importable_from_package_root():
+    from restgdf import PaginationInconsistencyWarning
+
+    assert isinstance(PaginationInconsistencyWarning, type)
+    assert issubclass(PaginationInconsistencyWarning, UserWarning)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -41,6 +41,7 @@ _EXPECTED_CLASSES = {
     "ObjectIdsResponse",
     "OptionalDependencyError",
     "OutputConversionError",
+    "PaginationInconsistencyWarning",
     "PaginationError",
     "RateLimitError",
     "ResilienceConfig",
@@ -66,6 +67,7 @@ _EXPECTED_CALLABLES = {
     "get_config",
     "get_settings",
     "reset_config_cache",
+    "reset_settings_cache",
 }
 
 _EXPECTED_MODULES = {
@@ -129,6 +131,7 @@ def test_flat_import_forms_work() -> None:
         TokenSessionConfig,
         compat,
         get_settings,
+        reset_settings_cache,
         utils,
     )
 

--- a/tests/test_resilience_retry_coverage.py
+++ b/tests/test_resilience_retry_coverage.py
@@ -25,7 +25,8 @@ from restgdf.errors import (
     TransportError,
 )
 from restgdf.resilience import ResilientSession
-from restgdf.resilience._retry import _ResponseCtx
+from restgdf.resilience._limiter import CooldownRegistry
+from restgdf.resilience._retry import _ResponseCtx, _do_retried_request, _enter_request
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +164,36 @@ class TestResponseCtx:
             assert resp.status == 200
 
         assert exited is True
+
+
+class TestEnterRequest:
+    @pytest.mark.asyncio
+    async def test_awaitable_response_is_wrapped_in_response_ctx(self) -> None:
+        class _AwaitableResponse(_FakeResponse):
+            def __await__(self):
+                async def _resolve() -> _AwaitableResponse:
+                    return self
+
+                return _resolve().__await__()
+
+        resp = _AwaitableResponse(200, body=b"awaited")
+
+        ctx, entered = await _enter_request(resp)
+
+        assert isinstance(ctx, _ResponseCtx)
+        assert entered is resp
+
+    @pytest.mark.asyncio
+    async def test_plain_response_is_wrapped_in_response_ctx(self) -> None:
+        class _PlainResponse:
+            status = 204
+
+        plain = _PlainResponse()
+
+        ctx, entered = await _enter_request(plain)
+
+        assert isinstance(ctx, _ResponseCtx)
+        assert entered is plain
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +406,86 @@ class TestRateLimitExhaustion:
             body = await resp.read()
         assert body == b"after-cooldown"
         assert stub._call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_retry_after_invalid_header_uses_fallback_cooldown(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        class _CooldownSpy(CooldownRegistry):
+            def __init__(self) -> None:
+                super().__init__()
+                self.wait_keys: list[str] = []
+                self.set_calls: list[tuple[str, float]] = []
+
+            async def wait_if_cooling(self, key: str) -> None:
+                self.wait_keys.append(key)
+
+            def set_cooldown(self, key: str, seconds: float) -> None:
+                self.set_calls.append((key, seconds))
+
+        stub = StubSession(
+            [
+                _FakeResponse(429, {"Retry-After": "not-a-number"}),
+                _FakeResponse(200, body=b"ok"),
+            ],
+        )
+        cooldown = _CooldownSpy()
+
+        ctx, resp = await _do_retried_request(
+            stub,
+            ResilienceConfig(enabled=True, fallback_retry_after_seconds=7.5),
+            "get",
+            "http://host/rest/services/X/FeatureServer/0/query",
+            {},
+            cooldown=cooldown,
+        )
+
+        assert resp.status == 200
+        assert cooldown.wait_keys == ["http://host/rest/services/X/FeatureServer"] * 2
+        assert cooldown.set_calls == [
+            ("http://host/rest/services/X/FeatureServer", 7.5),
+        ]
+        await ctx.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_retry_after_is_capped_before_setting_cooldown(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        class _CooldownSpy(CooldownRegistry):
+            def __init__(self) -> None:
+                super().__init__()
+                self.set_calls: list[tuple[str, float]] = []
+
+            async def wait_if_cooling(self, key: str) -> None:
+                return None
+
+            def set_cooldown(self, key: str, seconds: float) -> None:
+                self.set_calls.append((key, seconds))
+
+        stub = StubSession(
+            [
+                _FakeResponse(429, {"Retry-After": "120"}),
+                _FakeResponse(200, body=b"ok"),
+            ],
+        )
+        cooldown = _CooldownSpy()
+
+        ctx, resp = await _do_retried_request(
+            stub,
+            ResilienceConfig(enabled=True, respect_retry_after_max_s=4.0),
+            "get",
+            "http://host/rest/services/X/FeatureServer/0/query",
+            {},
+            cooldown=cooldown,
+        )
+
+        assert resp.status == 200
+        assert cooldown.set_calls == [
+            ("http://host/rest/services/X/FeatureServer", 4.0),
+        ]
+        await ctx.__aexit__(None, None, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_safe_crawl_semaphore_bound.py
+++ b/tests/test_safe_crawl_semaphore_bound.py
@@ -83,7 +83,7 @@ async def test_feature_count_fanout_bounded_by_max_concurrent_requests(monkeypat
     3 services × 20 layers = 60 ``get_feature_count`` calls. With
     ``max_concurrent_requests=4``, observed peak must be ≤ 4.
     """
-    monkeypatch.setenv("RESTGDF_MAX_CONCURRENT_REQUESTS", "4")
+    monkeypatch.setenv("RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS", "4")
     reset_settings_cache()
     try:
         peak_of = _install_counting_fakes(monkeypatch, layer_count=20)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -214,6 +214,7 @@ def test_reset_settings_cache_forces_new_instance(monkeypatch):
 
 
 def test_get_settings_reads_current_env_on_first_call(monkeypatch):
-    monkeypatch.setenv("RESTGDF_USER_AGENT", "probe/9.9")
-    s = get_settings()
+    monkeypatch.setenv("RESTGDF_TRANSPORT_USER_AGENT", "probe/9.9")
+    with pytest.warns(DeprecationWarning, match=r"get_settings\(\)"):
+        s = get_settings()
     assert s.user_agent == "probe/9.9"

--- a/tests/test_taxonomy_contract.py
+++ b/tests/test_taxonomy_contract.py
@@ -15,7 +15,7 @@ import pytest
 
 from restgdf import errors as errors_module
 from restgdf._logging import LOGGER_SUFFIXES, get_logger
-from restgdf.errors import PaginationError, RestgdfError
+from restgdf.errors import PaginationError, PaginationInconsistencyWarning, RestgdfError
 
 
 def test_every_public_exception_inherits_restgdf_error() -> None:
@@ -25,7 +25,13 @@ def test_every_public_exception_inherits_restgdf_error() -> None:
     for name in errors_module.__all__:
         cls = getattr(errors_module, name)
         assert isinstance(cls, type), f"{name} is not a class"
+        if issubclass(cls, Warning):
+            continue
         assert issubclass(cls, RestgdfError), f"{name} must inherit RestgdfError"
+
+
+def test_public_warning_exports_remain_warnings() -> None:
+    assert issubclass(PaginationInconsistencyWarning, UserWarning)
 
 
 def test_exception_taxonomy_is_catchable_as_restgdf_error() -> None:

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -52,6 +52,9 @@ class RecordingTokenSession:
         return MockRequestContext({"ok": True})
 
 
+@pytest.mark.filterwarnings(
+    r"ignore:get_token\(\) is deprecated:DeprecationWarning",
+)
 def test_get_token_uses_requests_post():
     response = Mock()
     response.json.return_value = {"token": "sync-token"}


### PR DESCRIPTION
## Summary
- align release-facing docs and packaging metadata for the 2.0.0 release without bumping versions
- expose the pagination inconsistency warning and settings-cache reset more consistently in the public API, and trim dead import-time code paths
- add focused regression tests for HTTP routing, retry cooldown handling, spatial-reference stamping, and deprecation-aware legacy surfaces

## Validation
- python -m pre_commit run --all-files
- python -m coverage run -m pytest -q
- python -m coverage report
- python -m sphinx -n -W --keep-going -b html docs docs/_build/html
- python -m build
- python -m twine check --strict dist/*

## Notes
- no version bump included in this PR
