### PR TITLE
Clarify completed v3 follow-up docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -232,9 +232,11 @@ from the same row stream; raises `OptionalDependencyError`
   `(resultOffset, resultRecordCount)` tuples byte-identical to the
   previous inline arithmetic. When `factor` exceeds
   `advertised_factor` the planner clamps to the advertised value and
-  logs a warning via `restgdf.pagination`. Live
-  `advancedQueryCapabilities.maxRecordCountFactor` wiring into
-  `get_query_data_batches` remains a future follow-up.
+  logs a warning via `restgdf.pagination`. In 2.0.0,
+  `get_query_data_batches` now forwards live
+  `advancedQueryCapabilities.maxRecordCountFactor` values into
+  `build_pagination_plan(advertised_factor=...)` when the server
+  advertises a positive numeric factor.
 
 **Advanced query capabilities** (`restgdf._models.responses`)
 

--- a/restgdf/_models/credentials.py
+++ b/restgdf/_models/credentials.py
@@ -60,6 +60,7 @@ class TokenSessionConfig(StrictModel):
       * ``clock_skew_seconds`` (default ``30``, capped at ``30`` when
         derived from the legacy alias) — extra padding for client /
         server clock drift.
+
     ``refresh_threshold_seconds`` is retained as a
     deprecation-warning alias. Reads return
     ``refresh_leeway_seconds + clock_skew_seconds``; writes via the

--- a/restgdf/_models/credentials.py
+++ b/restgdf/_models/credentials.py
@@ -21,11 +21,11 @@ operator-visible bug, not schema drift.
 
 from __future__ import annotations
 
-import warnings
 from typing import Literal
 
 from pydantic import Field, SecretStr, field_validator, model_validator
 
+from restgdf._compat import _warn_deprecated
 from restgdf._models._drift import StrictModel
 
 
@@ -60,14 +60,12 @@ class TokenSessionConfig(StrictModel):
       * ``clock_skew_seconds`` (default ``30``, capped at ``30`` when
         derived from the legacy alias) — extra padding for client /
         server clock drift.
-      * ``refresh_threshold_seconds`` is retained as a
-        deprecation-warning alias. Reads return
-        ``refresh_leeway_seconds + clock_skew_seconds``; writes via the
-        constructor kwarg split the supplied total into
-        ``clock_skew_seconds = min(30, total)`` and
-        ``refresh_leeway_seconds = total - clock_skew_seconds``. The
-        future ``restgdf._compat._warn_deprecated`` helper (phase-1c
-        BL-56) will subsume this direct ``warnings.warn`` call.
+    ``refresh_threshold_seconds`` is retained as a
+    deprecation-warning alias. Reads return
+    ``refresh_leeway_seconds + clock_skew_seconds``; writes via the
+    constructor kwarg split the supplied total into
+    ``clock_skew_seconds = min(30, total)`` and
+    ``refresh_leeway_seconds = total - clock_skew_seconds``.
     """
 
     token_url: str
@@ -101,22 +99,18 @@ class TokenSessionConfig(StrictModel):
         keys are silently dropped during normal validation. This
         validator intercepts ``refresh_threshold_seconds`` *before* that
         filtering so the legacy alias keeps working and emits a
-        ``DeprecationWarning``. The helper lives here rather than in
-        ``restgdf._compat`` because the compat package is scheduled for
-        phase-1c (BL-56); the call will be migrated there once it lands.
+        ``DeprecationWarning`` via :func:`restgdf._compat._warn_deprecated`.
         """
         if not isinstance(data, dict):
             return data
         if "refresh_threshold_seconds" not in data:
             return data
         total = data.pop("refresh_threshold_seconds")
-        warnings.warn(
+        _warn_deprecated(
             "`TokenSessionConfig.refresh_threshold_seconds` is deprecated; "
             "set `refresh_leeway_seconds` and `clock_skew_seconds` "
             "explicitly instead. The alias will be removed in a future "
             "release.",
-            DeprecationWarning,
-            stacklevel=2,
         )
         if not isinstance(total, int) or isinstance(total, bool):
             # Let pydantic surface a clear type error by leaving the
@@ -132,12 +126,11 @@ class TokenSessionConfig(StrictModel):
     @property
     def refresh_threshold_seconds(self) -> int:
         """Return the legacy threshold sum (``leeway + skew``) and emit a ``DeprecationWarning``."""
-        warnings.warn(
+        _warn_deprecated(
             "`TokenSessionConfig.refresh_threshold_seconds` is deprecated; "
             "read `refresh_leeway_seconds` and `clock_skew_seconds` "
             "directly. The alias will be removed in a future release.",
-            DeprecationWarning,
-            stacklevel=2,
+            stacklevel=3,
         )
         return self.refresh_leeway_seconds + self.clock_skew_seconds
 


### PR DESCRIPTION
## Summary
- update the migration guide to reflect that pagination advertised-factor wiring already shipped in 2.0.0
- switch TokenSessionConfig.refresh_threshold_seconds deprecation warnings to the shared _warn_deprecated helper
- preserve the caller-facing warning location for the legacy property alias

## Validation
- pre-commit passed locally
- python -m pytest -q tests/test_token_refresh_threshold_split.py tests/test_models_credentials.py
