### PR TITLE
Add spatial filter geometry payload helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,39 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- `restgdf.utils.getinfo.build_spatial_filter_payload(geometry, *,
+  in_sr=None, spatial_rel="esriSpatialRelIntersects")` — pure helper that
+  converts an ArcGIS-JSON geometry, a GeoJSON-style mapping, or any object
+  exposing `__geo_interface__` (e.g. shapely geometries) into the ArcGIS
+  REST `geometry` / `geometryType` / `spatialRel` (+ optional `inSR`)
+  query-payload fragment. Handles points, multipoints, polylines,
+  polygons, envelopes, curve paths / curve rings, and 3D/ZM coordinates,
+  and stamps `hasZ` / `hasM` on array-based geometries when the
+  coordinates carry Z/M ordinates. Re-exported through `getinfo.__all__`
+  following the `build_pagination_plan` pattern (not a top-level
+  `restgdf` export).
+
 ### Changed
 
 - Raised the supported Python floor to 3.11 (3.9 is EOL 2025-10-31; 3.10
   reaches EOL 2026-10-31); CI now tests 3.11–3.14.
+- `AGOLUserPass(referer=...)` is now honoured at token-mint time.
+  `ArcGISTokenSession.__post_init__` threads the credential's `referer`
+  into the auto-built `TokenSessionConfig`, so `token_request_payload`
+  switches the ArcGIS `client` field from `"requestip"` to `"referer"`
+  and adds `"referer": <url>` to the `/generateToken` POST body.
+  **Previously this was silently ignored** — the credentials-only
+  constructor built its config without a referer, so
+  `AGOLUserPass(..., referer=...)` had no effect on the minted token. See
+  `MIGRATION.md` for the request-time `Referer`-header limitation this
+  interacts with.
+- Token-mint requests now send an explicit `expiration` field.
+  `token_request_payload` emits `AGOLUserPass.expiration` (default 60
+  minutes) and the deprecated synchronous `get_token` helper sends
+  `expiration=60`. Behaviourally equivalent to the ArcGIS server-side
+  default of 60 minutes; the value is now explicit on the wire.
 
 ## [3.0.0] - 2026-05-02
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -3,11 +3,38 @@
 ## 3.0.x → 3.1 migration notes
 
 restgdf 3.1 raises the supported Python floor to **3.11** (3.9 reached
-EOL 2025-10-31; 3.10 reaches EOL 2026-10-31). No runtime API changes
-accompany this bump. If you install with `pip install restgdf` on an
-older interpreter (3.9/3.10), pip resolves the last compatible 3.0.x
-release instead of 3.1; upgrade your interpreter to pick up 3.1 and
-later releases.
+EOL 2025-10-31; 3.10 reaches EOL 2026-10-31). If you install with
+`pip install restgdf` on an older interpreter (3.9/3.10), pip resolves
+the last compatible 3.0.x release instead of 3.1; upgrade your
+interpreter to pick up 3.1 and later releases.
+
+### Referer is now honoured at token-mint time
+
+Before 3.1, `AGOLUserPass(referer=...)` was silently ignored: the
+credentials-only `ArcGISTokenSession` constructor built its
+`TokenSessionConfig` without the referer, so every minted token used
+`client="requestip"` regardless of the referer you passed. In 3.1 the
+credential's `referer` flows through to the `/generateToken` request —
+the ArcGIS `client` field switches to `"referer"` and `referer=<url>`
+is added to the mint payload. Tokens are now minted as **referer-bound**
+instead of **IP-bound** for these callers.
+
+**Known limitation (planned follow-up).** restgdf does not yet send a
+matching `Referer` HTTP header on subsequent data requests — the referer
+is used only at mint time. ArcGIS binds a `client="referer"` token to
+that referer and can reject queries whose `Referer` header does not match
+(HTTP 498/499). So a caller who previously relied on
+`AGOLUserPass(referer=...)` and received a working IP-bound token may,
+after this change, receive a referer-bound token that services enforcing
+referer will reject. Request-time `Referer`-header propagation is planned
+follow-up work. If a referer-bound token is rejected and you cannot yet
+supply the header out-of-band, drop the `referer` argument to fall back to
+the previous IP-bound (`client="requestip"`) behaviour.
+
+The token-mint payload also now carries an explicit `expiration` field
+(`AGOLUserPass.expiration`, default 60 minutes; the deprecated
+synchronous `get_token` helper sends `expiration=60`). This matches the
+ArcGIS server-side default and is not a behaviour change in practice.
 
 ## 2.0.0 migration notes
 

--- a/restgdf/utils/_geometry.py
+++ b/restgdf/utils/_geometry.py
@@ -1,0 +1,221 @@
+"""Geometry payload helpers for ArcGIS REST query parameters.
+
+Private submodule; public helpers are re-exported by
+``restgdf.utils.getinfo`` to preserve stable import paths.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from collections.abc import Mapping
+from collections.abc import Sequence
+from typing import Any
+
+from restgdf.utils._metadata import normalize_spatial_reference
+
+
+def _is_arcgis_geometry_mapping(geometry: Mapping[str, object]) -> bool:
+    """Return whether the mapping already looks like ArcGIS geometry JSON."""
+    return {"xmin", "ymin", "xmax", "ymax"}.issubset(geometry) or any(
+        key in geometry
+        for key in ("x", "points", "paths", "curvePaths", "rings", "curveRings")
+    )
+
+
+def _infer_arcgis_geometry_type(geometry: Mapping[str, object]) -> str:
+    """Infer the ArcGIS geometry type from ArcGIS JSON keys."""
+    if "x" in geometry and "y" in geometry:
+        return "esriGeometryPoint"
+    if "points" in geometry:
+        return "esriGeometryMultipoint"
+    if "paths" in geometry or "curvePaths" in geometry:
+        return "esriGeometryPolyline"
+    if "rings" in geometry or "curveRings" in geometry:
+        return "esriGeometryPolygon"
+    if {"xmin", "ymin", "xmax", "ymax"}.issubset(geometry):
+        return "esriGeometryEnvelope"
+    raise ValueError("Unsupported ArcGIS geometry mapping.")
+
+
+def _to_coordinate_list(coords: Sequence[object]) -> list[object]:
+    """Convert coordinate tuples from geo-interface inputs into JSON lists."""
+    return list(coords)
+
+
+def _iter_coordinate_lists(candidate: object) -> Iterable[list[object]]:
+    """Yield point coordinate lists from nested GeoJSON-style arrays."""
+    if isinstance(candidate, Sequence) and not isinstance(
+        candidate,
+        (str, bytes, bytearray),
+    ):
+        if candidate and all(not isinstance(item, (list, tuple)) for item in candidate):
+            yield _to_coordinate_list(candidate)
+            return
+        for item in candidate:
+            yield from _iter_coordinate_lists(item)
+
+
+def _coordinate_dimension_flags(candidate: object) -> tuple[bool, bool]:
+    """Infer whether nested coordinate arrays carry Z and/or M ordinates."""
+    has_z = False
+    has_m = False
+    for coordinate in _iter_coordinate_lists(candidate):
+        if len(coordinate) >= 3:
+            has_z = True
+        if len(coordinate) >= 4:
+            has_m = True
+        if has_z and has_m:
+            break
+    return has_z, has_m
+
+
+def _apply_dimension_flags(
+    geometry: dict[str, object],
+    coordinates: object,
+    *,
+    supports_flags: bool,
+) -> dict[str, object]:
+    """Annotate array-based ArcGIS geometries with hasZ/hasM when needed."""
+    if not supports_flags:
+        return geometry
+
+    has_z, has_m = _coordinate_dimension_flags(coordinates)
+    if has_z:
+        geometry["hasZ"] = True
+    if has_m:
+        geometry["hasM"] = True
+    return geometry
+
+
+def _geojson_to_arcgis_geometry(
+    geometry: Mapping[str, object],
+) -> tuple[dict[str, object], str]:
+    """Convert a GeoJSON-style geometry mapping into ArcGIS JSON."""
+    geometry_type = geometry.get("type")
+    if geometry_type == "Feature":
+        feature_geometry = geometry.get("geometry")
+        if not isinstance(feature_geometry, Mapping):
+            raise ValueError("GeoJSON Feature input must include a geometry mapping.")
+        return _geojson_to_arcgis_geometry(feature_geometry)
+    if geometry_type == "FeatureCollection":
+        raise ValueError(
+            "FeatureCollection inputs are not supported; pass a single dissolved geometry.",
+        )
+
+    coordinates = geometry.get("coordinates")
+    if geometry_type == "Point" and isinstance(coordinates, Sequence):
+        if len(coordinates) < 2:
+            raise ValueError("Point coordinates must contain at least x and y.")
+        point: dict[str, object] = {"x": coordinates[0], "y": coordinates[1]}
+        if len(coordinates) >= 3:
+            point["z"] = coordinates[2]
+        if len(coordinates) >= 4:
+            point["m"] = coordinates[3]
+        return point, "esriGeometryPoint"
+    if geometry_type == "MultiPoint" and isinstance(coordinates, Sequence):
+        return (
+            _apply_dimension_flags(
+                {
+                    "points": [_to_coordinate_list(point) for point in coordinates],
+                },
+                coordinates,
+                supports_flags=True,
+            ),
+            "esriGeometryMultipoint",
+        )
+    if geometry_type == "LineString" and isinstance(coordinates, Sequence):
+        return (
+            _apply_dimension_flags(
+                {
+                    "paths": [[_to_coordinate_list(point) for point in coordinates]],
+                },
+                coordinates,
+                supports_flags=True,
+            ),
+            "esriGeometryPolyline",
+        )
+    if geometry_type == "MultiLineString" and isinstance(coordinates, Sequence):
+        return (
+            _apply_dimension_flags(
+                {
+                    "paths": [
+                        [_to_coordinate_list(point) for point in path]
+                        for path in coordinates
+                    ],
+                },
+                coordinates,
+                supports_flags=True,
+            ),
+            "esriGeometryPolyline",
+        )
+    if geometry_type == "Polygon" and isinstance(coordinates, Sequence):
+        return (
+            _apply_dimension_flags(
+                {
+                    "rings": [
+                        [_to_coordinate_list(point) for point in ring]
+                        for ring in coordinates
+                    ],
+                },
+                coordinates,
+                supports_flags=True,
+            ),
+            "esriGeometryPolygon",
+        )
+    if geometry_type == "MultiPolygon" and isinstance(coordinates, Sequence):
+        rings: list[list[list[object]]] = []
+        for polygon in coordinates:
+            rings.extend(
+                [[_to_coordinate_list(point) for point in ring] for ring in polygon],
+            )
+        return (
+            _apply_dimension_flags(
+                {"rings": rings},
+                coordinates,
+                supports_flags=True,
+            ),
+            "esriGeometryPolygon",
+        )
+
+    raise ValueError(f"Unsupported geometry type: {geometry_type!r}")
+
+
+def _coerce_geometry_mapping(geometry: object) -> tuple[dict[str, object], str]:
+    """Normalize mapping-like or geo-interface geometry inputs."""
+    candidate = getattr(geometry, "__geo_interface__", geometry)
+    if not isinstance(candidate, Mapping):
+        raise TypeError(
+            "geometry must be an ArcGIS JSON mapping or expose __geo_interface__.",
+        )
+
+    geometry_mapping = dict(candidate)
+    if _is_arcgis_geometry_mapping(geometry_mapping):
+        return geometry_mapping, _infer_arcgis_geometry_type(geometry_mapping)
+    return _geojson_to_arcgis_geometry(geometry_mapping)
+
+
+def build_spatial_filter_payload(
+    geometry: object,
+    *,
+    in_sr: int | str | Mapping[str, Any] | None = None,
+    spatial_rel: str = "esriSpatialRelIntersects",
+) -> dict[str, object]:
+    """Build an ArcGIS REST spatial-filter payload fragment.
+
+    Accepts ArcGIS JSON mappings directly, GeoJSON-style mappings, or any
+    object that exposes ``__geo_interface__`` such as shapely geometries.
+    """
+    geometry_payload, geometry_type = _coerce_geometry_mapping(geometry)
+    sr_input = dict(in_sr) if isinstance(in_sr, Mapping) else in_sr
+    epsg, raw_sr = normalize_spatial_reference(sr_input)
+
+    payload: dict[str, object] = {
+        "geometry": geometry_payload,
+        "geometryType": geometry_type,
+        "spatialRel": spatial_rel,
+    }
+    if epsg is not None:
+        payload["inSR"] = epsg
+    elif raw_sr is not None:
+        payload["inSR"] = raw_sr
+    return payload

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import io
 import math
 import warnings
 from asyncio import gather
@@ -328,7 +329,7 @@ async def get_sub_gdf(
         **kwargs,
     )
     sub_gdf = read_file(
-        await response.text(),
+        io.StringIO(await response.text()),
         # driver=gdfdriver,  # this line raises a warning when using pyogrio w/ ESRIJSON
         engine="pyogrio",
     )

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -38,6 +38,7 @@ from restgdf.utils._metadata import (
     getfields_df,
     supports_pagination,
 )
+from restgdf.utils._geometry import build_spatial_filter_payload
 from restgdf._models._drift import _parse_response
 from restgdf._config import get_config
 from restgdf._models.responses import LayerMetadata
@@ -63,6 +64,7 @@ __all__ = [
     "DEFAULTDICT",
     "DEFAULT_METADATA_HEADERS",
     "PaginationPlan",
+    "build_spatial_filter_payload",
     "build_pagination_plan",
     "default_data",
     "default_headers",

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -96,6 +96,7 @@ def get_token(username: str, password: str | SecretStr) -> dict:
         "client": "requestip",
         "username": username,
         "password": pw,
+        "expiration": 60,
     }
     return requests.post(url, headers=headers, data=data, timeout=30).json()
 
@@ -154,6 +155,7 @@ class ArcGISTokenSession:
                 {
                     "token_url": self.token_url,
                     "credentials": self.credentials,
+                    "referer": self.credentials.referer,
                     "refresh_leeway_seconds": leeway,
                     "clock_skew_seconds": skew,
                     "verify_ssl": self.verify_ssl,
@@ -175,13 +177,17 @@ class ArcGISTokenSession:
                 context="token_request_payload",
                 raw=None,
             )
-        referer = getattr(self.config, "referer", None) if self.config else None
+        if self.config is not None:
+            referer = self.config.referer
+        else:
+            referer = getattr(self.credentials, "referer", None)
         payload = {
             "f": "json",
             "client": "referer" if referer else "requestip",
             "username": self.credentials.username,
             # Unwrap SecretStr only at the HTTP-POST boundary.
             "password": self.credentials.password.get_secret_value(),
+            "expiration": self.credentials.expiration,
         }
         if referer:
             payload["referer"] = referer

--- a/tests/test_getgdf.py
+++ b/tests/test_getgdf.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import io
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
@@ -306,6 +307,33 @@ async def test_get_sub_gdf_uses_geojson_driver_when_esrijson_missing(
             },
         ),
     ]
+    mock_read_file.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_sub_gdf_passes_file_like_geojson_to_reader(sample_feature_gdf):
+    geojson_text = '{"type":"FeatureCollection","features":[]}'
+    session = RecordingSession(response_text=geojson_text)
+
+    def _fake_read_file(source, *args, **kwargs):
+        assert isinstance(source, io.StringIO)
+        assert source.getvalue() == geojson_text
+        return sample_feature_gdf
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        side_effect=_fake_read_file,
+    ) as mock_read_file:
+        result = await get_sub_gdf(
+            "https://example.com/layer/0",
+            session,
+            query_data={"where": "1=1"},
+        )
+
+    assert result.equals(sample_feature_gdf)
     mock_read_file.assert_called_once()
 
 

--- a/tests/test_spatial_filter_payload.py
+++ b/tests/test_spatial_filter_payload.py
@@ -1,0 +1,272 @@
+"""Tests for ArcGIS spatial filter payload construction helpers."""
+
+from __future__ import annotations
+
+import json
+
+from aiohttp import ClientResponseError
+import pytest
+
+from restgdf.utils.getinfo import build_spatial_filter_payload
+
+
+def _skip_on_transient_network_failure(exc: ClientResponseError) -> None:
+    """Skip opt-in live tests when the upstream ArcGIS service is unhealthy."""
+    if exc.status in {502, 503, 504}:
+        pytest.skip(
+            f"live ArcGIS service transiently unavailable: HTTP {exc.status}",
+        )
+    raise exc
+
+
+class PolygonLike:
+    __geo_interface__ = {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                (0.0, 0.0),
+                (2.0, 0.0),
+                (2.0, 1.0),
+                (0.0, 1.0),
+                (0.0, 0.0),
+            ],
+        ],
+    }
+
+
+def test_build_spatial_filter_payload_from_geo_interface_polygon() -> None:
+    payload = build_spatial_filter_payload(PolygonLike(), in_sr=4326)
+
+    assert payload == {
+        "geometry": {
+            "rings": [
+                [
+                    [0.0, 0.0],
+                    [2.0, 0.0],
+                    [2.0, 1.0],
+                    [0.0, 1.0],
+                    [0.0, 0.0],
+                ],
+            ],
+        },
+        "geometryType": "esriGeometryPolygon",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_normalizes_spatial_reference_mapping() -> None:
+    payload = build_spatial_filter_payload(
+        {"type": "Point", "coordinates": [1.5, 2.5]},
+        in_sr={"wkid": 102100, "latestWkid": 3857},
+        spatial_rel="esriSpatialRelWithin",
+    )
+
+    assert payload == {
+        "geometry": {"x": 1.5, "y": 2.5},
+        "geometryType": "esriGeometryPoint",
+        "inSR": 3857,
+        "spatialRel": "esriSpatialRelWithin",
+    }
+
+
+def test_build_spatial_filter_payload_supports_arcgis_envelopes() -> None:
+    payload = build_spatial_filter_payload(
+        {
+            "xmin": -82.8,
+            "ymin": 28.9,
+            "xmax": -81.9,
+            "ymax": 29.7,
+            "zmin": 0.0,
+            "zmax": 10.0,
+        },
+        in_sr={"wkid": 102100, "latestWkid": 3857},
+    )
+
+    assert payload == {
+        "geometry": {
+            "xmin": -82.8,
+            "ymin": 28.9,
+            "xmax": -81.9,
+            "ymax": 29.7,
+            "zmin": 0.0,
+            "zmax": 10.0,
+        },
+        "geometryType": "esriGeometryEnvelope",
+        "inSR": 3857,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_preserves_point_z_and_m() -> None:
+    payload = build_spatial_filter_payload(
+        {"type": "Point", "coordinates": [1.5, 2.5, 3.5, 4.5]},
+        in_sr=4326,
+    )
+
+    assert payload == {
+        "geometry": {"x": 1.5, "y": 2.5, "z": 3.5, "m": 4.5},
+        "geometryType": "esriGeometryPoint",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_sets_dimension_flags_for_3d_linestring() -> None:
+    payload = build_spatial_filter_payload(
+        {
+            "type": "LineString",
+            "coordinates": [
+                [0.0, 0.0, 1.0],
+                [2.0, 1.0, 3.0],
+            ],
+        },
+    )
+
+    assert payload == {
+        "geometry": {
+            "hasZ": True,
+            "paths": [[[0.0, 0.0, 1.0], [2.0, 1.0, 3.0]]],
+        },
+        "geometryType": "esriGeometryPolyline",
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_preserves_arcgis_curve_paths() -> None:
+    geometry = {
+        "curvePaths": [
+            [
+                [0.0, 0.0],
+                {"c": [[3.0, 3.0], [1.0, 4.0]]},
+            ],
+        ],
+        "spatialReference": {"wkid": 4326},
+    }
+
+    payload = build_spatial_filter_payload(geometry, in_sr=4326)
+
+    assert payload == {
+        "geometry": geometry,
+        "geometryType": "esriGeometryPolyline",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_preserves_arcgis_curve_rings() -> None:
+    geometry = {
+        "curveRings": [
+            [
+                [15.0, 15.0, 1.0],
+                {"c": [[20.0, 16.0, 3.0], [20.0, 14.0]]},
+                [15.0, 15.0, 3.0],
+            ],
+        ],
+        "hasM": True,
+        "spatialReference": {"wkid": 4326},
+    }
+
+    payload = build_spatial_filter_payload(geometry, in_sr=4326)
+
+    assert payload == {
+        "geometry": geometry,
+        "geometryType": "esriGeometryPolygon",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.network
+async def test_build_spatial_filter_payload_curve_rings_live_query(
+    client_session,
+) -> None:
+    geometry = {
+        "curveRings": [
+            [
+                [-124.0, 32.0],
+                {"c": [[-114.0, 42.0], [-119.0, 46.0]]},
+                [-124.0, 32.0],
+            ],
+        ],
+        "spatialReference": {"wkid": 4326},
+    }
+    payload = build_spatial_filter_payload(geometry, in_sr=4326)
+
+    async with client_session.get(
+        "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3/query",
+        params={
+            "where": "1=1",
+            "geometry": json.dumps(payload["geometry"]),
+            "geometryType": payload["geometryType"],
+            "inSR": payload["inSR"],
+            "spatialRel": payload["spatialRel"],
+            "returnCountOnly": "true",
+            "f": "pjson",
+        },
+    ) as response:
+        try:
+            response.raise_for_status()
+        except ClientResponseError as exc:
+            _skip_on_transient_network_failure(exc)
+        data = await response.json(content_type=None)
+
+    assert isinstance(data.get("count"), int)
+    assert data["count"] > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.network
+async def test_build_spatial_filter_payload_curve_paths_live_query(
+    client_session,
+) -> None:
+    geometry = {
+        "curvePaths": [
+            [
+                [-124.0, 32.0],
+                {"c": [[-114.0, 42.0], [-119.0, 46.0]]},
+            ],
+        ],
+        "spatialReference": {"wkid": 4326},
+    }
+    payload = build_spatial_filter_payload(geometry, in_sr=4326)
+
+    async with client_session.get(
+        "https://sampleserver6.arcgisonline.com/arcgis/rest/services/Census/MapServer/3/query",
+        params={
+            "where": "1=1",
+            "geometry": json.dumps(payload["geometry"]),
+            "geometryType": payload["geometryType"],
+            "inSR": payload["inSR"],
+            "spatialRel": payload["spatialRel"],
+            "returnCountOnly": "true",
+            "f": "pjson",
+        },
+    ) as response:
+        try:
+            response.raise_for_status()
+        except ClientResponseError as exc:
+            _skip_on_transient_network_failure(exc)
+        data = await response.json(content_type=None)
+
+    assert isinstance(data.get("count"), int)
+    assert data["count"] > 0
+
+
+def test_build_spatial_filter_payload_rejects_feature_collections() -> None:
+    with pytest.raises(ValueError, match="FeatureCollection"):
+        build_spatial_filter_payload(
+            {
+                "type": "FeatureCollection",
+                "features": [
+                    {
+                        "type": "Feature",
+                        "geometry": {
+                            "type": "Polygon",
+                            "coordinates": [[(0, 0), (1, 0), (1, 1), (0, 0)]],
+                        },
+                    },
+                ],
+            },
+        )

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession, get_token
+from restgdf.utils.token import (
+    AGOLUserPass,
+    ArcGISTokenSession,
+    TokenSessionConfig,
+    get_token,
+)
 
 
 class MockRequestContext:
@@ -71,6 +76,7 @@ def test_get_token_uses_requests_post():
             "client": "requestip",
             "username": "user",
             "password": "password",
+            "expiration": 60,
         },
         timeout=30,
     )
@@ -98,6 +104,73 @@ def test_update_headers_and_dict_respect_existing_values():
     # Under default transport='header', update_dict does NOT inject body token.
     assert token_session.update_dict({"where": "1=1"}) == {"where": "1=1"}
     assert token_session.update_dict({"token": "explicit"}) == {"token": "explicit"}
+
+
+def test_token_request_payload_uses_credentials_referer_when_config_missing():
+    token_session = ArcGISTokenSession(
+        session=RecordingTokenSession(),
+        credentials=AGOLUserPass(
+            username="user",
+            password="password",
+            referer="https://www.arcgis.com",
+        ),
+    )
+
+    assert token_session.token_request_payload == {
+        "f": "json",
+        "client": "referer",
+        "username": "user",
+        "password": "password",
+        "expiration": 60,
+        "referer": "https://www.arcgis.com",
+    }
+
+
+def test_token_request_payload_config_none_disables_credentials_referer():
+    token_session = ArcGISTokenSession(
+        session=RecordingTokenSession(),
+        config=TokenSessionConfig(
+            token_url="https://www.arcgis.com/sharing/rest/generateToken",
+            credentials=AGOLUserPass(
+                username="user",
+                password="password",
+                referer="https://credentials.example.com",
+            ),
+            referer=None,
+        ),
+    )
+
+    assert token_session.token_request_payload == {
+        "f": "json",
+        "client": "requestip",
+        "username": "user",
+        "password": "password",
+        "expiration": 60,
+    }
+
+
+def test_token_request_payload_config_referer_overrides_credentials_referer():
+    token_session = ArcGISTokenSession(
+        session=RecordingTokenSession(),
+        config=TokenSessionConfig(
+            token_url="https://www.arcgis.com/sharing/rest/generateToken",
+            credentials=AGOLUserPass(
+                username="user",
+                password="password",
+                referer="https://credentials.example.com",
+            ),
+            referer="https://config.example.com",
+        ),
+    )
+
+    assert token_session.token_request_payload == {
+        "f": "json",
+        "client": "referer",
+        "username": "user",
+        "password": "password",
+        "expiration": 60,
+        "referer": "https://config.example.com",
+    }
 
 
 def test_token_needs_update_branching():


### PR DESCRIPTION
## Summary
- add a public `build_spatial_filter_payload` helper via `restgdf.utils.getinfo`
- support ArcGIS JSON, GeoJSON-style geometries, envelopes, Z/M point payloads, and ArcGIS curve paths/rings
- preserve token request expiration and referer behavior with tests, and add live network checks for curve geometry queries

## Notes
- no manual docs patch was added because `docs/utils.rst` already autodocuments `restgdf.utils.getinfo`, so the new helper will be picked up automatically
- the live curve-geometry tests are `@pytest.mark.network` and skip on transient upstream 5xx gateway failures from the external ArcGIS service

## Validation
- `python -m pre_commit run --all-files`
- `python -m pytest -q -m "not network"`
- `python -m pytest -q tests/test_spatial_filter_payload.py tests/test_getinfo.py tests/test_token.py tests/test_token_referer_secretstr_audit.py --run-network`