### PR TITLE
build: raise Python floor to 3.11 and repair fresh-dependency CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -191,3 +191,17 @@ jobs:
             exit 1
           fi
           echo "All required jobs succeeded."
+
+  ci-offline:
+    name: ci-offline
+    if: always()
+    needs: [lint, test, install_combinations, base_install, docs]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate offline job results
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} docs=${{ needs.docs.result }}"
+            exit 1
+          fi
+          echo "All required jobs succeeded."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py311-plus]
 
   - repo: https://github.com/dannysepler/rm_unneeded_f_str
     rev: v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+### Changed
+
+- Raised the supported Python floor to 3.11 (3.9 is EOL 2025-10-31; 3.10
+  reaches EOL 2026-10-31); CI now tests 3.11–3.14.
+
 ## [3.0.0] - 2026-05-02
 
 ## [2.0.0] - 2026-05-02

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,14 @@
 # restgdf migration guide
 
+## 3.0.x → 3.1 migration notes
+
+restgdf 3.1 raises the supported Python floor to **3.11** (3.9 reached
+EOL 2025-10-31; 3.10 reaches EOL 2026-10-31). No runtime API changes
+accompany this bump. If you install with `pip install restgdf` on an
+older interpreter (3.9/3.10), pip resolves the last compatible 3.0.x
+release instead of 3.1; upgrade your interpreter to pick up 3.1 and
+later releases.
+
 ## 2.0.0 migration notes
 
 restgdf 2.0.0 reshapes install surface, error taxonomy, configuration,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ lightweight async Esri REST client with optional GeoPandas extras
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 
-> **Python ≥ 3.9** | async-first | zero mandatory geo dependencies | pydantic-validated responses
+> **Python ≥ 3.11** | async-first | zero mandatory geo dependencies | pydantic-validated responses
 
 ```python
 import asyncio
@@ -147,7 +147,8 @@ GeoPandas extra.
 
 # Installation
 
-**Requires Python ≥ 3.9.**
+**Requires Python ≥ 3.11** (3.9 reached EOL 2025-10-31; 3.10 reaches EOL
+2026-10-31).
 
 Install the lightweight core package when you want typed metadata, query
 helpers, crawl/auth utilities, or raw feature rows without pulling in

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,7 @@
 # Quickstart
 
-**Requires Python ≥ 3.9.**
+**Requires Python ≥ 3.11** (3.9 reached EOL 2025-10-31; 3.10 reaches EOL
+2026-10-31).
 
 Choose the install that matches the workflow you want:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ readme = "README.md"
 dependencies = [
     "aiohttp>=3.9",
     "pydantic>=2.13.3,<3",
-    "eval_type_backport; python_version < '3.10'",
     "requests>=2.31",
 ]
 license = "MIT"
@@ -33,8 +32,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -55,7 +52,7 @@ keywords = [
     "featureserver",
     "mapserver",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 [project.urls]
 Homepage = "https://github.com/joshuasundance-swca/restgdf"
 Documentation = "https://restgdf.readthedocs.io/"
@@ -207,7 +204,7 @@ no_implicit_optional = true
 strict_equality = true
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.lint]
 ignore = ["E501"]

--- a/restgdf/_compat.py
+++ b/restgdf/_compat.py
@@ -21,31 +21,11 @@ from __future__ import annotations
 import functools
 import inspect
 import warnings
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
+from collections.abc import Callable
 from collections.abc import Awaitable
 
-try:
-    from contextlib import aclosing  # type: ignore[attr-defined]  # py310+
-except ImportError:  # pragma: no cover - exercised on py39 only
-    # Minimal backport of :class:`contextlib.aclosing` for Python 3.9.
-    # Upstream added ``aclosing`` in 3.10 (bpo-41229); restgdf still targets
-    # py39 per ``pyproject.toml`` ``requires-python = ">=3.9"`` and the
-    # streaming iterators need deterministic ``aclose()`` on early break so
-    # the R-61 INTERNAL span's ``finally`` runs without GC delay.
-    from contextlib import AbstractAsyncContextManager
-
-    class aclosing(AbstractAsyncContextManager):  # type: ignore[no-redef]
-        """Async context manager that ``aclose()``s its target on exit."""
-
-        def __init__(self, thing: Any) -> None:
-            self.thing = thing
-
-        async def __aenter__(self) -> Any:
-            return self.thing
-
-        async def __aexit__(self, *exc_info: Any) -> None:
-            await self.thing.aclose()
-
+from contextlib import aclosing
 
 __all__ = ["aclosing", "_warn_deprecated", "async_deprecated_wrapper"]
 

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -37,7 +37,8 @@ import functools
 import os
 import warnings
 from collections.abc import Mapping
-from typing import Any, Callable, Literal
+from typing import Any, Literal
+from collections.abc import Callable
 
 from pydantic import (
     BaseModel,

--- a/restgdf/_models/_settings.py
+++ b/restgdf/_models/_settings.py
@@ -33,7 +33,8 @@ import warnings
 from collections.abc import Mapping
 from importlib.metadata import PackageNotFoundError, version as package_version
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 from pydantic import (
     BaseModel,

--- a/restgdf/directory/directory.py
+++ b/restgdf/directory/directory.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._models.crawl import CrawlReport, CrawlServiceEntry
 from restgdf._models.responses import LayerMetadata
@@ -34,7 +32,7 @@ class Directory:
         self,
         url: str,
         session: AsyncHTTPSession,
-        token: Optional[str] = None,
+        token: str | None = None,
     ):
         """Initialize a Directory instance.
 
@@ -58,10 +56,10 @@ class Directory:
         self.url = url
         self.session = session
         self.token = token
-        self.services: Optional[list[CrawlServiceEntry]] = None
-        self.services_with_feature_count: Optional[list[CrawlServiceEntry]] = None
-        self.metadata: Optional[LayerMetadata] = None
-        self.report: Optional[CrawlReport] = None
+        self.services: list[CrawlServiceEntry] | None = None
+        self.services_with_feature_count: list[CrawlServiceEntry] | None = None
+        self.metadata: LayerMetadata | None = None
+        self.report: CrawlReport | None = None
 
     async def prep(self):
         """Fetch and validate directory metadata from the server.

--- a/restgdf/resilience/_bounded_retry.py
+++ b/restgdf/resilience/_bounded_retry.py
@@ -21,7 +21,8 @@ Retry contract (must match the inline fallback byte-for-byte semantically):
 from __future__ import annotations
 
 import asyncio
-from typing import Callable, TypeVar
+from typing import TypeVar
+from collections.abc import Callable
 from collections.abc import Awaitable
 
 import aiohttp

--- a/restgdf/utils/_deprecations.py
+++ b/restgdf/utils/_deprecations.py
@@ -11,7 +11,8 @@ from __future__ import annotations
 import inspect
 import warnings
 from functools import wraps
-from typing import Any, Callable, TypeVar
+from typing import Any, TypeVar
+from collections.abc import Callable
 
 F = TypeVar("F", bound=Callable[..., Any])
 

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -141,11 +141,7 @@ async def _feature_count_with_timeout(
     for attempt in range(max_attempts):
         try:
             return await get_feature_count(url, session, **kwargs)
-        except (
-            asyncio.TimeoutError,
-            TimeoutError,
-            ServerTimeoutError,
-        ) as exc:
+        except (TimeoutError, ServerTimeoutError) as exc:
             last_exc = exc
         if attempt < max_attempts - 1:
             await asyncio.sleep(0.1 * (2**attempt))

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -68,7 +68,7 @@ def _utc_now() -> datetime.datetime:
     Exposed as a module-level function so tests can monkeypatch it
     to control wall-clock time without freezing the real clock.
     """
-    return datetime.datetime.now(datetime.timezone.utc)
+    return datetime.datetime.now(datetime.UTC)
 
 
 __all__ = [
@@ -199,7 +199,7 @@ class ArcGISTokenSession:
         if self.expires is None:
             return None
         epoch = self.expires / 1000 if self.expires > 1e11 else self.expires
-        return datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc)
+        return datetime.datetime.fromtimestamp(epoch, tz=datetime.UTC)
 
     @property
     def _transport(self) -> str:

--- a/restgdf/utils/utils.py
+++ b/restgdf/utils/utils.py
@@ -2,7 +2,6 @@
 
 import re
 from collections.abc import Iterable
-from typing import Union
 
 ends_with_num_pat = re.compile(r"\d+$")
 
@@ -12,7 +11,7 @@ def ends_with_num(url: str) -> bool:
     return bool(ends_with_num_pat.search(url))
 
 
-def where_var_in_list(var: str, vals: Iterable[Union[str, int, float]]) -> str:
+def where_var_in_list(var: str, vals: Iterable[str | int | float]) -> str:
     """Return a where clause for a variable in a list of values."""
     vals_str = ", ".join(
         f"'{val}'" if isinstance(val, str) else str(val) for val in vals

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,86 @@
 from __future__ import annotations
 
+import inspect
 import json
 from typing import Any
 
+import aioresponses.core as _aioresponses_core
 import pytest
 import pytest_asyncio
+from aiohttp import ClientResponse as _AiohttpClientResponse
 from aiohttp import ClientSession
+
+# ---------------------------------------------------------------------------
+# aioresponses x aiohttp 3.14 compatibility shim (TEST DOUBLE ONLY).
+#
+# aiohttp 3.14 added a required keyword-only ``stream_writer`` argument to
+# ``ClientResponse.__init__`` (read to seed ``output_size`` when the request
+# was already sent). aioresponses 0.7.9 builds its fake responses without it
+# (``resp = response_class(method, url, **kwargs)`` in aioresponses/core.py),
+# so under aiohttp>=3.14 every mocked request raises, verbatim:
+#     TypeError: ClientResponse.__init__() missing 1 required keyword-only
+#     argument: 'stream_writer'
+#
+# This patches ONLY the aioresponses test double -- never restgdf runtime code
+# and never aiohttp itself -- injecting a no-op stream writer when (and only
+# when) the installed aiohttp actually requires the argument. aioresponses
+# always constructs the double with ``writer=None`` ("request already sent"),
+# so ``ClientResponse.__init__`` reads exactly one attribute off it,
+# ``stream_writer.output_size``; the stub below supplies that and nothing
+# else, leaving every response attribute the tests assert on (status /
+# headers / body / json payload -- reified by aioresponses afterwards)
+# untouched.
+#
+# Inertness: detection is by signature introspection, never a version string.
+# Under aiohttp<3.14 the ``stream_writer`` parameter is absent, the guard is
+# False, and NOTHING below runs -- a complete no-op on the repo's aiohttp
+# 3.13 pin.
+#
+# EXPIRY: remove this shim once aioresponses ships aiohttp-3.14 support
+# upstream -- watch https://github.com/pnuckowski/aioresponses -- at which
+# point the double stops needing the argument and the guard self-disarms.
+# ---------------------------------------------------------------------------
+
+
+def _client_response_requires_stream_writer() -> bool:
+    """Return True iff aiohttp's ``ClientResponse`` requires ``stream_writer``.
+
+    Signature introspection only -- present *and* without a default (i.e.
+    aiohttp 3.14+). Never parses a version string, so it disarms the moment
+    the argument is no longer required.
+    """
+    param = inspect.signature(_AiohttpClientResponse.__init__).parameters.get(
+        "stream_writer",
+    )
+    return param is not None and param.default is inspect.Parameter.empty
+
+
+if _client_response_requires_stream_writer():
+
+    class _NoOpStreamWriter:
+        """Minimal stand-in for aiohttp's stream writer in the aioresponses double.
+
+        aioresponses passes ``writer=None`` ("request already sent"), so
+        ``ClientResponse.__init__`` reads only ``stream_writer.output_size``.
+        Nothing else about a real writer is exercised for a pre-fed fake body.
+        """
+
+        output_size = 0
+
+    class _StreamWriterShimResponse(_aioresponses_core.ClientResponse):  # type: ignore[misc,valid-type]
+        """aioresponses response double that supplies aiohttp 3.14's ``stream_writer``.
+
+        Base class is bound to the *current* ``aioresponses.core.ClientResponse``
+        (the real aiohttp class) at definition time; the module attribute is
+        then repointed at this subclass so aioresponses' default response
+        construction picks it up via ``__getattr__`` on the module global.
+        """
+
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            kwargs.setdefault("stream_writer", _NoOpStreamWriter())
+            super().__init__(*args, **kwargs)  # type: ignore[arg-type]
+
+    _aioresponses_core.ClientResponse = _StreamWriterShimResponse
 
 
 def pytest_addoption(parser):

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -1,6 +1,5 @@
 import json
 import importlib
-from typing import Optional
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -30,7 +29,7 @@ class MockRequestContext:
     async def __aexit__(self, exc_type, exc_value, traceback):
         return None
 
-    async def json(self, content_type: Optional[str] = None):
+    async def json(self, content_type: str | None = None):
         return self.payload
 
     async def text(self):
@@ -66,7 +65,7 @@ class MockFeatureLayerSession:
         self,
         metadata: dict,
         count: int,
-        object_ids: Optional[list[int]] = None,
+        object_ids: list[int] | None = None,
     ):
         self.metadata = metadata
         self.count = count

--- a/tests/test_aioresponses_aiohttp314_compat.py
+++ b/tests/test_aioresponses_aiohttp314_compat.py
@@ -1,0 +1,94 @@
+"""Regression: aioresponses must serve mocked responses under aiohttp 3.14.
+
+aiohttp 3.14 added a required keyword-only ``stream_writer`` argument to
+``ClientResponse.__init__``. aioresponses 0.7.9 constructs its response
+double without it, so before the ``tests/conftest.py`` shim every mocked
+request raised, verbatim::
+
+    TypeError: ClientResponse.__init__() missing 1 required keyword-only
+    argument: 'stream_writer'
+
+(raised at ``aioresponses/core.py`` ``RequestMatch._build_response`` ->
+``resp = response_class(method, url, **kwargs)``), reached from restgdf's
+real consumer path ``restgdf.utils._http._arcgis_request``.
+
+These tests drive that real path -- ``aioresponses`` payload mock ->
+``_arcgis_request`` (both the GET and the POST verb it selects) -> parsed
+JSON round-trip. If the conftest shim is removed while aiohttp>=3.14 is
+installed, the aioresponses construction fails and these tests error with the
+``stream_writer`` ``TypeError`` above. Under aiohttp<3.14 the argument does
+not exist, the shim is a no-op, and these tests pass unchanged.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+from aiohttp import ClientResponse, ClientSession
+from aioresponses import aioresponses
+
+from restgdf.utils._http import _ARCGIS_URL_BODY_LIMIT, _arcgis_request, _choose_verb
+
+# Match the base query URL with or without an encoded query string, so the
+# GET path (which appends ``?f=json&...``) is matched the same as POST.
+_QUERY_URL = "https://svc.example/arcgis/rest/services/Demo/FeatureServer/0/query"
+_QUERY_URL_RE = re.compile(re.escape(_QUERY_URL) + r"(\?.*)?$")
+
+
+def _aiohttp_requires_stream_writer() -> bool:
+    param = inspect.signature(ClientResponse.__init__).parameters.get("stream_writer")
+    return param is not None and param.default is inspect.Parameter.empty
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_get_round_trips_through_aioresponses():
+    """Short body -> GET verb -> aioresponses payload round-trips intact."""
+    body = {"f": "json", "returnCountOnly": True, "where": "1=1"}
+    # Guard the premise: this body must actually route to GET so the test
+    # exercises the GET construction path (not POST).
+    assert _choose_verb(_QUERY_URL, body=body) == "GET"
+
+    async with ClientSession() as session:
+        with aioresponses() as m:
+            m.get(_QUERY_URL_RE, payload={"count": 42}, repeat=True)
+            resp = await _arcgis_request(session, _QUERY_URL, body)
+            data = await resp.json(content_type=None)
+
+    assert data == {"count": 42}
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_post_round_trips_through_aioresponses():
+    """Oversized body -> POST verb -> aioresponses payload round-trips intact."""
+    # A where clause past the URL/body ceiling forces the POST branch of
+    # ``_arcgis_request`` (the length-based router picks POST for >8k bodies).
+    body = {"f": "json", "where": "x" * (_ARCGIS_URL_BODY_LIMIT + 1)}
+    assert _choose_verb(_QUERY_URL, body=body) == "POST"
+
+    async with ClientSession() as session:
+        with aioresponses() as m:
+            m.post(_QUERY_URL, payload={"count": 7}, repeat=True)
+            resp = await _arcgis_request(session, _QUERY_URL, body)
+            data = await resp.json(content_type=None)
+
+    assert data == {"count": 7}
+
+
+def test_stream_writer_shim_is_active_exactly_when_aiohttp_requires_it():
+    """The conftest shim must be installed iff aiohttp requires ``stream_writer``.
+
+    Proves both directions of the inertness contract from a single assertion:
+    * aiohttp>=3.14 (argument required) -> aioresponses' response class is the
+      shim subclass installed by conftest;
+    * aiohttp<3.14 (argument absent) -> the class is left untouched.
+    """
+    import aioresponses.core as core
+
+    if _aiohttp_requires_stream_writer():
+        assert core.ClientResponse.__name__ == "_StreamWriterShimResponse"
+        assert issubclass(core.ClientResponse, ClientResponse)
+    else:
+        # No-op path: conftest must not have repointed the class.
+        assert core.ClientResponse is ClientResponse

--- a/tests/test_compat_helper.py
+++ b/tests/test_compat_helper.py
@@ -7,16 +7,20 @@ Asserts:
   * `async_deprecated_wrapper` emits the warning synchronously (before
     the coroutine is awaited) and still returns the correct awaited value.
   * Applying the decorator to a non-async function raises `TypeError`.
+  * `restgdf._compat.aclosing` is the stdlib `contextlib.aclosing` (the
+    floor is now >=3.11, so no py39 backport class is needed) and the
+    supported async-context-manager path still works end to end.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import warnings
 
 import pytest
 
-from restgdf._compat import _warn_deprecated, async_deprecated_wrapper
+from restgdf._compat import _warn_deprecated, aclosing, async_deprecated_wrapper
 
 
 def _call_warn(message: str) -> None:
@@ -70,3 +74,59 @@ def test_async_deprecated_wrapper_rejects_sync_function() -> None:
     decorator = async_deprecated_wrapper("nope")
     with pytest.raises(TypeError, match="async def"):
         decorator(not_async)  # type: ignore[type-var]
+
+
+def test_aclosing_is_stdlib_contextlib_aclosing() -> None:
+    """restgdf._compat.aclosing is a plain re-export of contextlib.aclosing.
+
+    The py39 backport class was removed once the floor rose to >=3.11
+    (contextlib.aclosing has shipped since 3.10); this asserts identity
+    rather than duck-typed behavior so a regression (e.g. a shadowing
+    reintroduction of a custom class) is caught immediately.
+    """
+
+    assert aclosing is contextlib.aclosing
+
+
+def test_aclosing_async_smoke_closes_on_exit() -> None:
+    class _Resource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    async def _use() -> _Resource:
+        resource = _Resource()
+        async with aclosing(resource) as r:
+            assert r is resource
+            assert not r.closed
+        return resource
+
+    resource = asyncio.run(_use())
+    assert resource.closed is True
+
+
+def test_aclosing_async_smoke_closes_on_exception() -> None:
+    class _Resource:
+        def __init__(self) -> None:
+            self.closed = False
+
+        async def aclose(self) -> None:
+            self.closed = True
+
+    class _Boom(Exception):
+        pass
+
+    resource = _Resource()
+
+    async def _use() -> None:
+        async with aclosing(resource):
+            # Deterministic aclose() must still fire on an early exit via
+            # exception (the streaming-iterator early-break case this
+            # module's docstring calls out), not just the happy path.
+            raise _Boom("early exit")
+
+    with pytest.raises(_Boom):
+        asyncio.run(_use())
+    assert resource.closed is True

--- a/tests/test_feature_count_retry_delegation.py
+++ b/tests/test_feature_count_retry_delegation.py
@@ -63,7 +63,7 @@ async def test_inline_fallback_when_resilience_absent(monkeypatch):
     async def _flaky(*args, **kwargs):
         attempts.append(1)
         if len(attempts) < 3:
-            raise asyncio.TimeoutError
+            raise TimeoutError
         return 11
 
     monkeypatch.setattr(getinfo, "_resilience_bounded_retry", None)
@@ -109,7 +109,7 @@ async def test_inline_fallback_wraps_timeout_after_exhaustion(monkeypatch):
     """Fallback path: exhausted timeouts wrap to RestgdfTimeoutError."""
 
     async def _always_timeout(*args, **kwargs):
-        raise asyncio.TimeoutError
+        raise TimeoutError
 
     monkeypatch.setattr(getinfo, "_resilience_bounded_retry", None)
     monkeypatch.setattr(getinfo, "get_feature_count", _always_timeout)
@@ -162,7 +162,7 @@ async def test_delegation_path_wraps_timeout_after_exhaustion(monkeypatch):
 
     async def _always_timeout(*args, **kwargs):
         attempts.append(1)
-        raise asyncio.TimeoutError
+        raise TimeoutError
 
     monkeypatch.setattr(getinfo, "_resilience_bounded_retry", bounded_retry_timeout)
     monkeypatch.setattr(getinfo, "get_feature_count", _always_timeout)

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -110,14 +110,14 @@ def test_token_needs_update_branching():
     )
     assert token_session.token_needs_update() is True
 
-    future = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+    future = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
         minutes=5,
     )
     token_session.token = "abc123"
     token_session.expires = future.timestamp()
     assert token_session.token_needs_update() is False
 
-    soon = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+    soon = datetime.datetime.now(datetime.UTC) + datetime.timedelta(
         seconds=30,
     )
     token_session.expires = soon.timestamp() * 1000

--- a/tests/test_token_expiry_utc.py
+++ b/tests/test_token_expiry_utc.py
@@ -34,7 +34,7 @@ class TestUTCWallClockExpiry:
             datetime.datetime,
         ), f"expires_at must be datetime, got {type(ts.expires_at)}"
         assert ts.expires_at.tzinfo is not None, "expires_at must be tz-aware"
-        assert ts.expires_at.tzinfo == datetime.timezone.utc
+        assert ts.expires_at.tzinfo == datetime.UTC
 
     def test_utc_now_shim_exists(self):
         """A _utc_now() shim must exist for test monkeypatching."""
@@ -43,7 +43,7 @@ class TestUTCWallClockExpiry:
         now = _utc_now()
         assert isinstance(now, datetime.datetime)
         assert now.tzinfo is not None
-        assert now.tzinfo == datetime.timezone.utc
+        assert now.tzinfo == datetime.UTC
 
     def test_token_needs_update_uses_expires_at(self):
         """token_needs_update should compare against expires_at, not raw epoch."""


### PR DESCRIPTION
## Summary

P0B of the audit remediation program (see PR #190). Three commits, each independently gate-green locally:

1. **`build:` Python floor → 3.11** — 3.9 is EOL (2025-10-31); 3.10 EOLs 2026-10-31, which would force a second floor bump within months. `requires-python = ">=3.11"`, classifiers/ruff/pyupgrade targets updated (+ the resulting mechanical `--py311-plus` rewrites), CI matrix 3.11–3.14, py39 `aclosing` backport removed (now a plain `contextlib` re-export with identity/behavior tests), docs floor claims + CHANGELOG/MIGRATION notes.
2. **`test:` aioresponses × aiohttp-3.14 shim** — fresh resolution (aiohttp 3.14.3 + aioresponses 0.7.9) fails 4 tests on every leg: aiohttp 3.14's required `ClientResponse.stream_writer` breaks the aioresponses double (`aioresponses/core.py` `_build_response`). Remedy: signature-introspection-gated conftest shim (byte-for-byte no-op under aiohttp <3.14; no runtime code touched; expiry comment for upstream aioresponses support) + a regression that drives the **real** consumer path (`_arcgis_request`, GET and POST). An aioresponses bump is *not* a remedy — 0.7.9 is current and already resolved in the failing runs.
3. **`ci:` `ci-offline` aggregate job** — `[lint, test, install_combinations, base_install, docs]` with the same `always()`-guarded result-check as `ci`, excluding live-network/stress. Intended required check for `main` (P0D); the existing `ci` job is unchanged.

## Evidence

- **Repro** (pristine `main`, clean envs, all of 3.11.13/3.12.13/3.13.7/3.14.6): exact 4 failures, identical `stream_writer` TypeError, via the real `_arcgis_request` path.
- **Matrix post-fix** (same envs, branch tree, aiohttp 3.14.3): **1169 passed / 4 skipped / 2 deselected per leg**, and identically on the local aiohttp-3.13.5 venv (shim inert both by evidence and by an inertness assertion).
- **Local full gate at head**: pytest ✅ · coverage 98% (floor 97) ✅ · `pre-commit run --all-files` ✅ · `sphinx -n -W` ✅ · `build` + `twine check --strict` ✅ · wheel `Requires-Python: >=3.11` asserted, and a py3.10 install of the built wheel is **rejected** by pip.
- **Adversarial verification** (3 independent default-refute reviews): floor completeness CONFIRMED (zero stale floor claims/version gates); CI wiring CONFIRMED (`ci` byte-identical, `always()`/`needs` semantics reasoned through); remedy realism CONFIRMED (negative probe without the shim reproduces the exact TypeError; the 4 repaired tests are byte-identical to `main`).

Merge criterion: `ci-offline` green (network/stress advisory). Squash-merge per program convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk