### PR TITLE
chore: M1 zero-risk quick wins (W1-5, W1-6, W3-7, W5-7, W6-1)

### DIFF
--- a/.github/workflows/bumpver.yml
+++ b/.github/workflows/bumpver.yml
@@ -20,12 +20,12 @@ jobs:
       contents: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.14"
         cache: pip

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -19,12 +19,12 @@ jobs:
       pull-requests: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.14"
         cache: pip
@@ -45,4 +45,4 @@ jobs:
     - name: Commit changes
       with:
         COMMIT_MESSAGE: "Update coverage"
-      uses: stefanzweifel/git-auto-commit-action@v7
+      uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0

--- a/.github/workflows/readthedocs.yml
+++ b/.github/workflows/readthedocs.yml
@@ -20,12 +20,12 @@ jobs:
       pull-requests: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v7
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         token: ${{ secrets.WORKFLOW_GIT_ACCESS_TOKEN }}
         fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v7
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.14"
         cache: pip
@@ -40,4 +40,4 @@ jobs:
     - name: Commit changes
       with:
         COMMIT_MESSAGE: "Update doc files"
-      uses: stefanzweifel/git-auto-commit-action@v7
+      uses: stefanzweifel/git-auto-commit-action@4a55954c782fc1ea30b9056cd3e7a2b40ca8887d # v7.2.0

--- a/.github/workflows/verify_attestation.yml
+++ b/.github/workflows/verify_attestation.yml
@@ -43,7 +43,7 @@ jobs:
           ref: ${{ github.event.workflow_run.head_sha || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to restgdf are documented here. This project follows
   following the `build_pagination_plan` pattern (not a top-level
   `restgdf` export).
 
+### Fixed
+
+- Static type-checkers can now resolve `restgdf.FieldDoesNotExistError`.
+  It was already exported at runtime (`__all__` and the lazy-export
+  table), but missing from the `TYPE_CHECKING` import block that backs
+  static analysis, so `mypy`/`pyright` reported an unresolved attribute
+  even though the name worked fine at runtime.
+
 ### Changed
 
 - Raised the supported Python floor to 3.11 (3.9 is EOL 2025-10-31; 3.10

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,11 +2,12 @@
 
 ## Supported Versions
 
-Only the latest minor release line of `restgdf` receives security updates.
+The current major release line (currently 3.x) receives security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.x     | :white_check_mark: |
+| 3.x     | :white_check_mark: |
+| 2.x     | :x:                |
 | 1.x     | :x:                |
 | < 1.0   | :x:                |
 

--- a/restgdf/__init__.py
+++ b/restgdf/__init__.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
         AuthNotAttachedError,
         AuthenticationError,
         ConfigurationError,
+        FieldDoesNotExistError,
         InvalidCredentialsError,
         OptionalDependencyError,
         OutputConversionError,

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -1,9 +1,10 @@
 """Layered runtime configuration for restgdf (phase-2a BL-18).
 
-Seven frozen pydantic 2.x sub-configs mirror the plan-obs §3 taxonomy:
+Eight frozen pydantic 2.x sub-configs mirror the plan-obs §3 taxonomy:
 :class:`TransportConfig`, :class:`TimeoutConfig`, :class:`RetryConfig`,
 :class:`LimiterConfig`, :class:`ConcurrencyConfig`, :class:`AuthConfig`,
-:class:`TelemetryConfig`. The aggregate :class:`Config` is resolved lazily via
+:class:`TelemetryConfig`, :class:`ResilienceConfig`. The aggregate
+:class:`Config` is resolved lazily via
 :func:`get_config` (LRU-cached size-1; reset with :func:`reset_config_cache`).
 
 Env-var naming


### PR DESCRIPTION
## Summary
Five S-effort audit items, one commit each, all zero-runtime-risk (M1 wave 1 of the remediation program):
- **W1-5** `ci:` SHA-pin the write-token workflows (bumpver/coverage/readthedocs) — checkout `v7.0.1`, setup-python `v7.0.0` (SHAs already proven in pytest.yml post-#189), git-auto-commit-action `v7.2.0` resolved+verified via the GitHub API.
- **W1-6** `ci:` fix the stale setup-python pin comment in verify_attestation.yml (tree had `# v6.0.0` on the v7.0.0 SHA — both the audit's and plan's expected values were stale; re-verified live).
- **W3-7** `docs:` `_config.py` docstring: Seven → eight sub-configs (count verified).
- **W5-7** `fix:` add `FieldDoesNotExistError` to the `TYPE_CHECKING` block (3-way surface sync verified; CHANGELOG bullet).
- **W6-1** `docs:` SECURITY.md → rot-proof "current major (3.x)" support policy per maintainer decision.

## Evidence
Offline suite identical before/after (1181/4/4, py3.12 fresh env); `pre-commit run --all-files` green incl. actionlint; per-item before/after in `scratch/m1/reports/QW-report.md` (local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk