### PR TITLE
fix: force POST when the request body carries a token (AUTH-01)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,22 @@ All notable changes to restgdf are documented here. This project follows
   `expiration=60`. Behaviourally equivalent to the ArcGIS server-side
   default of 60 minutes; the value is now explicit on the wire.
 
+### Security
+
+- **AUTH-01: a caller-supplied token in the request body is no longer
+  serialized into the URL query string.** On the documented
+  `FeatureLayer(token=...)` / `data={"token": ...}` path, a short
+  token-bearing request was routed via `GET`, leaking the ArcGIS token
+  into the URL — where it lands in server / proxy / WAF access logs and
+  `Referer` headers — on a plain `aiohttp.ClientSession` or a default
+  header-mode `ArcGISTokenSession`. `_arcgis_request` now forces `POST`
+  (token in the request body) whenever the outgoing body carries a
+  `token` key, regardless of session transport. This complements the
+  existing session-transport guard; ArcGIS `/query` and metadata roots
+  already accept form-encoded `POST` bodies, so the wire contract is
+  unchanged for servers. Tokenless requests keep the length-based
+  `GET`/`POST` routing.
+
 ## [3.0.0] - 2026-05-02
 
 ## [2.0.0] - 2026-05-02

--- a/restgdf/utils/_http.py
+++ b/restgdf/utils/_http.py
@@ -113,8 +113,18 @@ async def _arcgis_request(
     and forces ``POST`` whenever any layer reports a non-``"header"``
     transport (``ResilientSession(ArcGISTokenSession(transport="body"))``
     and similar wrappers included).
+
+    **Credential safety (AUTH-01).** The session-transport guard above
+    only sees the *session's* transport mode, so a caller-supplied token
+    in the outgoing ``body`` — the documented ``FeatureLayer(token=...)``
+    / ``data={"token": ...}`` path — would still ride on ``GET`` (and
+    leak into the URL) on a plain :class:`aiohttp.ClientSession` or a
+    default header-mode session. To close that leak, this helper also
+    forces ``POST`` whenever the outgoing ``body`` carries a ``token``
+    key, regardless of session transport. This complements (does not
+    replace) the session-transport guard.
     """
-    if _session_requires_body_transport(session):
+    if _session_requires_body_transport(session) or (body and "token" in body):
         return await session.post(url, data=body, **kwargs)
     verb = _choose_verb(url, body=body)
     if verb == "GET":

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -77,9 +77,12 @@ async def test_get_feature_count_propagates_where_and_token_from_data(fake_sessi
     )
 
     _, kwargs = fake_session.post_calls[0]
+    # AUTH-01 (W2-1): token-bearing bodies are now forced onto POST, which
+    # forwards the body untouched -- the raw bool rides through instead of
+    # the GET path's coerced "true" string. Pinned post-fix behavior.
     assert kwargs["data"] == {
         "where": "STATUS = 'OPEN'",
-        "returnCountOnly": "true",
+        "returnCountOnly": True,
         "f": "json",
         "token": "abc",
     }
@@ -120,9 +123,11 @@ async def test_get_object_ids_preserves_where_and_returns_tuple(fake_session):
 
     assert (field, ids) == ("OBJECTID", [1, 2, 3])
     _, kwargs = fake_session.post_calls[0]
+    # AUTH-01 (W2-1): token-bearing bodies are now forced onto POST, which
+    # forwards the body untouched (raw bool, not the GET-coerced "true").
     assert kwargs["data"] == {
         "where": "A=1",
-        "returnIdsOnly": "true",
+        "returnIdsOnly": True,
         "f": "json",
         "token": "t",
     }

--- a/tests/test_gate3_fixes.py
+++ b/tests/test_gate3_fixes.py
@@ -27,6 +27,7 @@ Covers three follow-up-on-follow-up fixes on top of T6–T11:
 from __future__ import annotations
 
 import math
+import re
 from urllib.parse import urlencode
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -342,6 +343,119 @@ async def test_arcgis_request_get_path_uses_normalized_params():
         "outFields": "",
         "f": "json",
     }
+
+
+# ---------------------------------------------------------------------------
+# AUTH-01: a caller-supplied token in the request body must never be
+# serialized into the URL query string (token-in-URL leak to proxy/server
+# access logs). The pre-fix Gate-3 guard keyed only on session transport
+# mode, so a plain ``aiohttp.ClientSession`` or a default header-mode
+# ``ArcGISTokenSession`` still GET-serialized a short token-bearing body.
+# ---------------------------------------------------------------------------
+
+_AUTH01_TOKEN = "SUPERSECRETTOKEN-AUTH01-DEADBEEF"
+_AUTH01_LAYER_URL = "https://svc.example/arcgis/rest/services/Secured/FeatureServer/0"
+_AUTH01_METADATA_URL_RE = re.compile(
+    r"^https://svc\.example/arcgis/rest/services/Secured/FeatureServer/0(\?.*)?$",
+)
+_AUTH01_QUERY_URL_RE = re.compile(
+    r"^https://svc\.example/arcgis/rest/services/Secured/FeatureServer/0/query(\?.*)?$",
+)
+
+
+def _auth01_metadata_payload() -> dict:
+    return {
+        "name": "Secured Layer",
+        "type": "Feature Layer",
+        "fields": [
+            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+            {"name": "CITY", "type": "esriFieldTypeString"},
+        ],
+        "maxRecordCount": 2000,
+        "advancedQueryCapabilities": {"supportsPagination": True},
+    }
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_token_never_appears_in_request_url():
+    """AUTH-01 (real consumer path): ``FeatureLayer.from_url(token=...)`` on a
+    plain ``aiohttp.ClientSession`` must never emit the token in a request URL.
+
+    Before the body-aware POST fix, the short metadata (``?f=json``) and count
+    (``returnCountOnly=true``) requests ride on GET, so the token is
+    serialized into the URL query string — a credential leak into every proxy
+    / server access log. This asserts the token appears in NO requested URL.
+    """
+    from aiohttp import ClientSession
+    from aioresponses import aioresponses
+
+    from restgdf.featurelayer.featurelayer import FeatureLayer
+
+    with aioresponses() as m:
+        # Register both verbs for both endpoints so the assertion is about the
+        # URL, not the verb: pre-fix the library GETs (token leaks into URL),
+        # post-fix it POSTs (token rides in the body).
+        m.get(_AUTH01_METADATA_URL_RE, payload=_auth01_metadata_payload(), repeat=True)
+        m.post(_AUTH01_METADATA_URL_RE, payload=_auth01_metadata_payload(), repeat=True)
+        m.get(_AUTH01_QUERY_URL_RE, payload={"count": 1}, repeat=True)
+        m.post(_AUTH01_QUERY_URL_RE, payload={"count": 1}, repeat=True)
+
+        async with ClientSession() as session:
+            await FeatureLayer.from_url(
+                _AUTH01_LAYER_URL,
+                session=session,
+                token=_AUTH01_TOKEN,
+            )
+
+        leaked = [
+            str(url) for (_method, url) in m.requests if _AUTH01_TOKEN in str(url)
+        ]
+
+    assert not leaked, (
+        "AUTH-01: caller-supplied token must not appear in any request URL; "
+        f"leaked into: {leaked}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_forces_post_when_body_carries_token_plain_session():
+    """AUTH-01 (unit): a token-bearing body must route via POST even on a
+    plain duck-typed session with NO ``_transport`` attribute (the base-install
+    ``aiohttp.ClientSession`` shape). Pre-fix the short body took the GET path
+    and leaked the token into the URL query string."""
+    from restgdf.utils._http import _arcgis_request
+
+    session = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(status=200)),
+        post=AsyncMock(return_value=SimpleNamespace(status=200)),
+    )
+    body = {"f": "json", "token": "leak-me"}
+
+    await _arcgis_request(session, "https://example/query", body)
+
+    assert session.post.await_count == 1, "token-in-body must force POST"
+    assert session.get.await_count == 0
+    _, kwargs = session.post.call_args
+    assert kwargs.get("data") == body
+
+
+@pytest.mark.asyncio
+async def test_arcgis_request_forces_post_when_body_carries_token_header_session():
+    """AUTH-01 (unit): even a default header-mode ``ArcGISTokenSession`` leaks
+    when the caller also passes ``data['token']`` — the header-transport guard
+    returns False, so a short token-bearing body took the GET path pre-fix.
+    A token in the body must force POST regardless of session transport."""
+    from restgdf.utils._http import _arcgis_request
+
+    session = _FakeAuthSession(transport="header")
+    body = {"f": "json", "token": "leak-me"}
+
+    await _arcgis_request(session, "https://example/query", body)
+
+    assert session.post.await_count == 1, "token-in-body must force POST"
+    assert session.get.await_count == 0
+    _, kwargs = session.post.call_args
+    assert kwargs.get("data") == body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gate3_fixes.py
+++ b/tests/test_gate3_fixes.py
@@ -87,8 +87,14 @@ async def test_arcgis_request_forces_post_when_transport_is_query():
 
 @pytest.mark.asyncio
 async def test_arcgis_request_still_uses_get_for_header_transport():
-    """transport='header' is the safe default (token in HTTP header);
-    short requests can use GET without leaking credentials."""
+    """transport='header' is the safe default (token in HTTP header).
+
+    A short request may use GET here ONLY because this body carries no
+    ``token`` key — the request itself has no credential to leak into the
+    URL. A token-bearing body forces POST regardless of transport; that is
+    covered by ``test_arcgis_request_forces_post_when_body_carries_token_*``
+    (AUTH-01).
+    """
     from restgdf.utils._http import _arcgis_request
 
     session = _FakeAuthSession(transport="header")


### PR DESCRIPTION
## Summary
The audit's highest-priority runtime finding (AUTH-01, high): a caller-supplied token in the request body — the documented `FeatureLayer(token=...)` path — was GET-serialized **into the URL query string** on a plain `aiohttp.ClientSession` or default header-mode session whenever the encoded request fit under the URL ceiling. Tokens in URLs get logged by proxies and servers.

**Red-first**: the first commit lands 3 failing tests, including one through the real consumer path (plain session + `FeatureLayer.from_url(..., token=...)`) that captured the token leaking into both the metadata and count URLs (raw evidence retained). The second commit is the minimum fix: `_arcgis_request` forces POST whenever the outgoing body carries a `token` key, complementing the existing session-transport guard. Tokenless requests keep the length-based GET optimization untouched.

Includes the plan-anticipated W2-1 characterization re-pin (2 assertions, coordinator-adjudicated): token-bearing bodies now ride POST, which forwards the body untouched per the helper's documented invariant, so recorded values are raw bools. W1-9 (M3) still owns full verb-separation restoration; POST-path bool-coercion parity is pre-existing library-wide behavior, tracked separately.

## Evidence
- Suite: **1184 passed / 4 skipped / 4 deselected** (baseline +3 new tests, 0 failures), fresh py3.11 env.
- Both consumers verified: plain session and header-mode session force POST on token bodies; `ArcGISTokenSession` body/query and `ResilientSession`-wrapped guards regress-free; tokenless GET characterization/memoization tests untouched and green.
- CHANGELOG `### Security` bullet included.

Squash-merge (red+green PR per program convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk