### PR TITLE
ci: real deps-present mypy gate + the typing fixes it surfaces (W1-2 stack)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -206,13 +206,13 @@ jobs:
   ci:
     name: ci
     if: always()
-    needs: [lint, test, install_combinations, base_install, network, stress, docs]
+    needs: [lint, test, mypy, install_combinations, base_install, network, stress, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate job results
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.stress.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
-            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} stress=${{ needs.stress.result }} docs=${{ needs.docs.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.mypy.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.stress.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} mypy=${{ needs.mypy.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} stress=${{ needs.stress.result }} docs=${{ needs.docs.result }}"
             exit 1
           fi
           echo "All required jobs succeeded."
@@ -220,13 +220,13 @@ jobs:
   ci-offline:
     name: ci-offline
     if: always()
-    needs: [lint, test, install_combinations, base_install, docs]
+    needs: [lint, test, mypy, install_combinations, base_install, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate offline job results
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
-            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} docs=${{ needs.docs.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.mypy.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} mypy=${{ needs.mypy.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} docs=${{ needs.docs.result }}"
             exit 1
           fi
           echo "All required jobs succeeded."

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,6 +61,31 @@ jobs:
       - name: Run tests
         run: python -m pytest -q -m "not network"
 
+  mypy:
+    name: mypy (deps-present)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package with all extras + mypy
+        # Deps-present type check: real aiohttp / pydantic / geo /
+        # resilience / telemetry types, unlike the intentionally lean
+        # pre-commit mypy hook. mypy is pinned to the mirrors-mypy hook
+        # version (v1.20.1) for parity. pandas / geopandas stay untyped
+        # via the pyproject ignore_missing_imports override (their
+        # published stubs surface intended-Any DataFrame boundaries as
+        # noise — TYPING-01 anti-recommendation), so no stub packages here.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,geo,resilience,telemetry]"
+          python -m pip install "mypy==1.20.1" types-requests
+      - name: Type-check restgdf (pydantic plugin, deps present)
+        run: python -m mypy restgdf/
+
   install_combinations:
     name: install-${{ matrix.label }}
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,8 +27,15 @@ repos:
     rev: v1.20.1
     hooks:
       - id: mypy
+        # Scope to the package to match the deps-present CI mypy job
+        # (`mypy restgdf/`); the isolated hook env stays lean (pydantic is
+        # required only so the `pydantic.mypy` plugin declared in
+        # pyproject `[tool.mypy]` can load). Extras (aiohttp/geo/resilience)
+        # are intentionally absent here — the CI job is the deps-present gate.
+        files: ^restgdf/
         additional_dependencies:
           - types-requests
+          - pydantic
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ All notable changes to restgdf are documented here. This project follows
 
 ### Changed
 
+- The `mypy` type gate now runs against real dependency types. A dedicated
+  CI job installs every extra plus `mypy` and enables the `pydantic.mypy`
+  plugin (via `[tool.mypy] plugins`), so it type-checks against actual
+  `aiohttp`/`pydantic` types instead of reporting green over unresolved
+  imports; `pandas`/`geopandas` are scope-silenced with
+  `ignore_missing_imports` (their integration boundary is intentionally
+  untyped). The internal type errors the un-defanged gate surfaced were
+  fixed — drift alias-choice narrowing, the metadata field-row annotation,
+  bounded-retry exception typing, and widening `get_gdf`'s `session`
+  parameter to the `AsyncHTTPSession` transport protocol (a runtime
+  contract that `aiohttp.ClientSession` satisfies at runtime but, under
+  current aiohttp stubs, not as a static subtype).
 - Raised the supported Python floor to 3.11 (3.9 is EOL 2025-10-31; 3.10
   reaches EOL 2026-10-31); CI now tests 3.11–3.14.
 - `AGOLUserPass(referer=...)` is now honoured at token-mint time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,17 @@ markers = [
 ]
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
+
+# pandas / geopandas are optional-extra (`geo`) deps whose import boundary is
+# deliberately untyped (Any). Published stubs exist (pandas-stubs,
+# types-geopandas) but installing them surfaces intended-Any DataFrame⇄list
+# conversion boundaries as noise (the TYPING-01 / W1-2 anti-recommendation
+# against a broad strict/stub flip), so scope-silence the missing imports here
+# rather than type-hardening the extras integration.
+[[tool.mypy.overrides]]
+module = ["pandas", "pandas.*", "geopandas", "geopandas.*"]
+ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["restgdf._client.*", "restgdf._models.*", "restgdf.compat"]

--- a/restgdf/_client/_protocols.py
+++ b/restgdf/_client/_protocols.py
@@ -23,12 +23,32 @@ from typing import Any, Protocol, runtime_checkable
 class AsyncHTTPSession(Protocol):
     """Structural type for restgdf transport sessions.
 
-    Matches :class:`aiohttp.ClientSession` and
-    :class:`~restgdf.utils.token.ArcGISTokenSession`, and is the
-    forward-compatible target for resilience/telemetry adapters
-    (BL-31 / BL-32). Only method/attribute *presence* is checked at
-    ``isinstance`` time; signature details are advisory per
-    :class:`typing.Protocol`.
+    This is a **runtime presence contract**: flagged
+    :func:`typing.runtime_checkable`, ``isinstance`` verifies only that
+    ``get`` / ``post`` / ``close`` / ``closed`` are present, and both
+    :class:`aiohttp.ClientSession` and
+    :class:`~restgdf.utils.token.ArcGISTokenSession` satisfy it at
+    runtime. It is the forward-compatible target for resilience /
+    telemetry adapters (BL-31 / BL-32).
+
+    Static-typing note (TYPING-02): restgdf's own
+    :class:`~restgdf.utils.token.ArcGISTokenSession` *is* a static
+    structural subtype of this Protocol, but
+    :class:`aiohttp.ClientSession` is **not**. Current aiohttp type
+    stubs declare ``get`` / ``post`` as
+    ``def get(self, url, **kwargs: Unpack[_RequestOptions])`` — a typed
+    keyword-args unpack that only accepts the specific ``_RequestOptions``
+    keys, which no ``**kwargs: Any`` protocol can be a supertype of. The
+    ``get`` / ``post`` signatures below therefore document the call
+    surface restgdf relies on; they are *not* a claim that
+    ``ClientSession`` is statically assignable here (only method/attribute
+    *presence* is guaranteed, per :class:`typing.Protocol`). Where a
+    concrete :class:`aiohttp.ClientSession` must reach an
+    ``AsyncHTTPSession``-typed seam (e.g. the bare session built inside
+    :func:`restgdf.utils.getgdf.get_gdf`), an explicit
+    :func:`typing.cast` bridges the runtime-valid-but-statically-unprovable
+    gap rather than forcing aiohttp to conform structurally (the audit's
+    explicit anti-recommendation).
 
     .. note::
        ``get`` and ``post`` are declared as non-async ``def`` because

--- a/restgdf/_models/_drift.py
+++ b/restgdf/_models/_drift.py
@@ -24,7 +24,7 @@ import logging
 from collections.abc import Iterable, Mapping
 from typing import Any, TypeVar
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import AliasChoices, BaseModel, ConfigDict, ValidationError
 
 from restgdf._logging import get_drift_logger
 from restgdf._models._errors import RestgdfResponseError
@@ -80,13 +80,10 @@ def _known_keys(model_cls: type[BaseModel]) -> set[str]:
         if info.alias:
             names.add(info.alias)
         choices = info.validation_alias
-        if choices is not None:
-            try:
-                for choice in choices.choices:
-                    if isinstance(choice, str):
-                        names.add(choice)
-            except AttributeError:
-                pass
+        if isinstance(choices, AliasChoices):
+            for choice in choices.choices:
+                if isinstance(choice, str):
+                    names.add(choice)
     return names
 
 

--- a/restgdf/resilience/_bounded_retry.py
+++ b/restgdf/resilience/_bounded_retry.py
@@ -34,7 +34,7 @@ __all__ = ["bounded_retry_timeout"]
 
 T = TypeVar("T")
 
-_TIMEOUT_EXCS: tuple[type[BaseException], ...] = (
+_TIMEOUT_EXCS: tuple[type[Exception], ...] = (
     asyncio.TimeoutError,
     TimeoutError,
     aiohttp.ServerTimeoutError,

--- a/restgdf/utils/_metadata.py
+++ b/restgdf/utils/_metadata.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Union
 
 from pydantic import BaseModel
 
-from restgdf._models.responses import FieldSpec, LayerMetadata
+from restgdf._models.responses import LayerMetadata
 from restgdf.errors import FieldDoesNotExistError
 from restgdf.utils._deprecations import deprecated_alias
 from restgdf.utils._optional import require_pandas_dataframe
@@ -153,7 +153,7 @@ def get_fields(layer_metadata: LayerMetadataLike, types: bool = False):
 def _field_rows(layer_metadata: LayerMetadataLike) -> list[tuple[str, str]]:
     """Return ``(name, type)`` rows for the layer fields."""
     layer_metadata = _as_dict(layer_metadata)
-    fields: list[FieldSpec] = layer_metadata.get("fields") or []
+    fields: list[dict[str, Any]] = layer_metadata.get("fields") or []
     return [(f["name"], f["type"].replace("esriFieldType", "")) for f in fields]
 
 

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -9,7 +9,7 @@ import warnings
 from asyncio import gather
 from collections.abc import AsyncGenerator, Mapping
 from functools import reduce
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from aiohttp import ClientSession
 
@@ -501,14 +501,18 @@ async def gdf_by_concat(
 
 async def get_gdf(
     url: str,
-    session: ClientSession | None = None,
+    session: AsyncHTTPSession | None = None,
     where: str | None = None,
     token: str | None = None,
     **kwargs,
 ) -> GeoDataFrame:
     _require_geo_query_support("get_gdf()")
     owns_session = session is None
-    session = session or ClientSession()
+    # A bare aiohttp ClientSession satisfies AsyncHTTPSession at runtime
+    # (runtime_checkable presence check) but is not a static structural
+    # subtype under current aiohttp stubs (see _protocols.AsyncHTTPSession);
+    # cast bridges that gap rather than forcing aiohttp to conform (TYPING-04).
+    session = session or cast(AsyncHTTPSession, ClientSession())
     datadict = default_data(kwargs.pop("data", None) or {})
     if where is not None:
         datadict["where"] = where


### PR DESCRIPTION
## Summary
The M1 typing transition stack (TYPING-01..05): makes the mypy gate real, fixes what it surfaces, then wires it into both CI aggregators — sequenced so every state is green.

- **Discovery** (raw outputs retained): deps-present mypy on the unfixed tree = 16 errors → 13 with the pydantic plugin → 6 real code defects after scoped `ignore_missing_imports` for genuinely-untyped geo deps (installing pandas-stubs instead surfaced intended-`Any` boundaries — the audit's anti-recommendation, avoided).
- **Fixes**: W5-10 `_drift` union-attr (static defect; the only runtime-code change is a behavior-identical `isinstance` narrowing — verified), W5-11 `_metadata` annotation, W4-6 `get_gdf` session annotation → `AsyncHTTPSession` (+ one typed `cast` at the bare-session seam), a discovered `_bounded_retry` exception-type fix, and **W5-9 resolved via the audit's fallback**: current aiohttp stubs type `get/post` via `Unpack[_RequestOptions]`, so no Protocol variant can make `ClientSession` a static subtype (empirically tested) — documented runtime-presence scoping instead of a signature change.
- **Gate**: `[tool.mypy] plugins=["pydantic.mypy"]`; dedicated deps-present `mypy` CI job (mypy pinned to the pre-commit hook's 1.20.1); final commit adds it to `ci` **and** `ci-offline` needs + result-chains — valid because this PR's head is mypy-green (0 errors / 51 files).

## Evidence
mypy exit 0 · suite 1181/4/4 · coverage 97% · pre-commit + actionlint green. **Adversarial verify (Opus, default-refute): CONFIRMED, 0 mustFix** — independently re-ran mypy, audited every diff hunk for runtime impact (exactly one, behavior-identical), checked aggregator fail-closed semantics.

Note: commit order is fixes-first (the shared pydantic-plugin config would make pre-commit red on the unfixed tree; machinery-first was uncommittable without `--no-verify`). Squash-merge.

Known downstream (tracked for M2): caller code passing a raw `ClientSession` positionally now sees a mypy complaint under current stubs; a pre-existing test-file typing issue (`test_models_metadata.py:173`) is logged for the M2 lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk