### PR TITLE
fix: fail bumpver on an empty CHANGELOG Unreleased section (W1-8)

### DIFF
--- a/scripts/bumpver_stamp_date.py
+++ b/scripts/bumpver_stamp_date.py
@@ -12,13 +12,23 @@ field bumpver can't touch via file_patterns alone.
 Behaviour
 ---------
 This hook runs between bumpver's file-pattern substitution step and its
-commit step. It rewrites the ``date-released:`` line in ``CITATION.cff``
-with today's UTC date (ISO 8601, ``YYYY-MM-DD``) and ``git add``s the
-file so bumpver's subsequent commit picks up the change.
+commit step. It performs two independent checks/actions, in order:
 
-Exits non-zero if ``CITATION.cff`` does not contain exactly one
-``date-released:`` line, which would indicate the file has drifted from
-the shape ``tests/test_citation_cff_version.py`` expects.
+1. **CHANGELOG fail-fast (CICD-02 / W1-8, fail-fast-only per maintainer
+   decision):** read ``CHANGELOG.md`` and exit non-zero if the
+   ``## [Unreleased]`` section has no non-blank body. This is a hard
+   assertion only — it does NOT rename ``## [Unreleased]`` or otherwise
+   consolidate the changelog (that would be the heavier option the
+   maintainer decision explicitly declined). Runs first, before touching
+   ``CITATION.cff``, so a rejected release leaves no partial file writes.
+2. Rewrites the ``date-released:`` line in ``CITATION.cff`` with today's
+   UTC date (ISO 8601, ``YYYY-MM-DD``) and ``git add``s the file so
+   bumpver's subsequent commit picks up the change.
+
+Exits non-zero if ``CHANGELOG.md`` has no populated ``## [Unreleased]``
+section, or if ``CITATION.cff`` does not contain exactly one
+``date-released:`` line (which would indicate the file has drifted from
+the shape ``tests/test_citation_cff_version.py`` expects).
 """
 
 from __future__ import annotations
@@ -32,17 +42,75 @@ import sys
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _CITATION_CFF = _REPO_ROOT / "CITATION.cff"
+_CHANGELOG_MD = _REPO_ROOT / "CHANGELOG.md"
 _DATE_RELEASED_RE = re.compile(
     r'^(?P<prefix>date-released:\s*)"\d{4}-\d{2}-\d{2}"\s*$',
     re.MULTILINE,
 )
+_UNRELEASED_HEADER_RE = re.compile(r"^## \[Unreleased\]\s*$", re.MULTILINE)
+_NEXT_VERSION_HEADER_RE = re.compile(r"^## \[", re.MULTILINE)
 
 
 def _today_utc_iso() -> str:
     return _dt.datetime.now(tz=_dt.timezone.utc).date().isoformat()
 
 
+def _unreleased_section_body(text: str) -> str | None:
+    """Return the raw text between ``## [Unreleased]`` and the next
+    ``## [`` header (exclusive of both), or ``None`` if no
+    ``## [Unreleased]`` header is present in ``text``.
+    """
+    header_match = _UNRELEASED_HEADER_RE.search(text)
+    if header_match is None:
+        return None
+    start = header_match.end()
+    next_match = _NEXT_VERSION_HEADER_RE.search(text, pos=start)
+    end = next_match.start() if next_match is not None else len(text)
+    return text[start:end]
+
+
+def _check_changelog_unreleased_populated() -> int:
+    """Fail fast (non-zero) when ``CHANGELOG.md``'s ``## [Unreleased]``
+    section has no non-blank body.
+
+    Mirrors the ``date-released`` guard's fail-fast discipline (clear
+    stderr message, non-zero exit on any unexpected shape) rather than
+    silently letting an empty-Unreleased release ship. This is a hard
+    assertion ONLY: it never rewrites ``CHANGELOG.md`` (no auto-rename,
+    no consolidation) per the recorded maintainer decision for W1-8.
+    """
+    if not _CHANGELOG_MD.is_file():
+        print(f"[bumpver_stamp_date] {_CHANGELOG_MD} not found", file=sys.stderr)
+        return 5
+
+    text = _CHANGELOG_MD.read_text(encoding="utf-8")
+    body = _unreleased_section_body(text)
+
+    if body is None:
+        print(
+            '[bumpver_stamp_date] expected a "## [Unreleased]" header in '
+            f"{_CHANGELOG_MD}; found none.",
+            file=sys.stderr,
+        )
+        return 6
+
+    if not body.strip():
+        print(
+            '[bumpver_stamp_date] the "## [Unreleased]" section in '
+            f"{_CHANGELOG_MD} has no body. Add a changelog entry before "
+            "bumping the version (see CONTRIBUTING.md).",
+            file=sys.stderr,
+        )
+        return 7
+
+    return 0
+
+
 def main() -> int:
+    changelog_status = _check_changelog_unreleased_populated()
+    if changelog_status != 0:
+        return changelog_status
+
     if not _CITATION_CFF.is_file():
         print(f"[bumpver_stamp_date] {_CITATION_CFF} not found", file=sys.stderr)
         return 1

--- a/tests/test_bumpver_stamp_date.py
+++ b/tests/test_bumpver_stamp_date.py
@@ -1,0 +1,269 @@
+"""W1-8 (CICD-02): red-first tests for the bumpver CHANGELOG fail-fast guard.
+
+``scripts/bumpver_stamp_date.py`` runs as bumpver's ``pre_commit_hook``
+between file-pattern substitution and the release commit. Per the
+recorded maintainer decision (fail-fast-ONLY — no ``## [Unreleased]``
+consolidation/rename), it now also fails the hook when ``CHANGELOG.md``'s
+``## [Unreleased]`` section has no non-blank body, so an empty-Unreleased
+release can no longer ship silently.
+
+The script is loaded fresh per-test by file path (``scripts/`` has no
+``__init__.py`` and is not an importable package) and its module-level
+path constants are monkeypatched to an isolated ``tmp_path`` "repo root"
+so no test ever reads or writes the real ``CHANGELOG.md``/``CITATION.cff``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess  # nosec B404 - test-only, used to init a throwaway tmp_path repo
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "bumpver_stamp_date.py"
+
+
+def _load_module() -> ModuleType:
+    """Load a fresh copy of the script module for each test."""
+    spec = importlib.util.spec_from_file_location(
+        "bumpver_stamp_date_under_test",
+        _SCRIPT_PATH,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def script(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """A freshly loaded script module pointed at an isolated tmp_path "repo root"."""
+    module = _load_module()
+    monkeypatch.setattr(module, "_REPO_ROOT", tmp_path)
+    monkeypatch.setattr(module, "_CITATION_CFF", tmp_path / "CITATION.cff")
+    monkeypatch.setattr(module, "_CHANGELOG_MD", tmp_path / "CHANGELOG.md")
+    return module
+
+
+def _write_changelog(tmp_path: Path, unreleased_body: str) -> Path:
+    text = (
+        "# Changelog\n\n"
+        "## [Unreleased]\n"
+        f"{unreleased_body}"
+        "## [1.0.0] - 2026-01-01\n"
+        "- Initial release.\n"
+    )
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _write_citation_cff(tmp_path: Path, *, date: str = "2020-01-01") -> Path:
+    path = tmp_path / "CITATION.cff"
+    path.write_text(
+        f'cff-version: 1.2.0\ndate-released: "{date}"\nversion: 1.0.0\n',
+        encoding="utf-8",
+    )
+    return path
+
+
+def _init_git_repo(path: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)  # nosec B603 B607
+    subprocess.run(  # nosec B603 B607
+        ["git", "config", "user.email", "test@example.invalid"],
+        cwd=path,
+        check=True,
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)  # nosec B603 B607
+
+
+class TestUnreleasedSectionBody:
+    """Pure-parsing coverage for ``_unreleased_section_body`` — no file I/O."""
+
+    def test_populated_section_returns_full_body(self, script: ModuleType) -> None:
+        text = "## [Unreleased]\n### Fixed\n\n- A real fix.\n\n## [1.0.0]\n- x\n"
+
+        body = script._unreleased_section_body(text)
+
+        assert body is not None
+        assert "A real fix" in body
+        assert "## [1.0.0]" not in body
+
+    def test_empty_section_returns_blank_body(self, script: ModuleType) -> None:
+        text = "## [Unreleased]\n## [1.0.0]\n- x\n"
+
+        body = script._unreleased_section_body(text)
+
+        assert body is not None
+        assert body.strip() == ""
+
+    def test_whitespace_only_section_returns_blank_body(self, script: ModuleType) -> None:
+        text = "## [Unreleased]\n\n   \n\n## [1.0.0]\n- x\n"
+
+        body = script._unreleased_section_body(text)
+
+        assert body is not None
+        assert body.strip() == ""
+
+    def test_missing_header_returns_none(self, script: ModuleType) -> None:
+        text = "## [1.0.0]\n- x\n"
+
+        assert script._unreleased_section_body(text) is None
+
+    def test_unreleased_at_end_of_file_returns_full_remainder(
+        self, script: ModuleType,
+    ) -> None:
+        text = "## [Unreleased]\n### Added\n\n- Only entry, no version header after.\n"
+
+        body = script._unreleased_section_body(text)
+
+        assert body is not None
+        assert "Only entry" in body
+
+    def test_does_not_mis_parse_a_triple_hash_subsection_as_a_version_header(
+        self, script: ModuleType,
+    ) -> None:
+        """A populated section containing ``### Added``/``### Fixed`` subsections
+        must not be truncated early by the next-header search (guards against the
+        risk named in plan/01 W1-8: 'an awk pattern that mis-parses a legitimately
+        populated section blocks a real release')."""
+        text = (
+            "## [Unreleased]\n"
+            "### Added\n\n- Item one.\n\n"
+            "### Fixed\n\n- Item two.\n\n"
+            "## [1.0.0]\n- old\n"
+        )
+
+        body = script._unreleased_section_body(text)
+
+        assert body is not None
+        assert "Item one" in body
+        assert "Item two" in body
+        assert "old" not in body
+
+
+class TestCheckChangelogUnreleasedPopulated:
+    """File-reading wrapper: ``_check_changelog_unreleased_populated``."""
+
+    def test_empty_unreleased_section_fails(
+        self,
+        script: ModuleType,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        _write_changelog(tmp_path, unreleased_body="")
+
+        status = script._check_changelog_unreleased_populated()
+
+        assert status != 0
+        err = capsys.readouterr().err
+        assert "Unreleased" in err
+
+    def test_whitespace_only_unreleased_section_fails(
+        self, script: ModuleType, tmp_path: Path,
+    ) -> None:
+        _write_changelog(tmp_path, unreleased_body="\n   \n\n")
+
+        status = script._check_changelog_unreleased_populated()
+
+        assert status != 0
+
+    def test_populated_unreleased_section_passes(
+        self, script: ModuleType, tmp_path: Path,
+    ) -> None:
+        _write_changelog(
+            tmp_path,
+            unreleased_body="### Fixed\n\n- Something real got fixed.\n\n",
+        )
+
+        status = script._check_changelog_unreleased_populated()
+
+        assert status == 0
+
+    def test_missing_unreleased_header_fails(
+        self, script: ModuleType, tmp_path: Path,
+    ) -> None:
+        path = tmp_path / "CHANGELOG.md"
+        path.write_text(
+            "# Changelog\n\n## [1.0.0] - 2026-01-01\n- Initial release.\n",
+            encoding="utf-8",
+        )
+
+        status = script._check_changelog_unreleased_populated()
+
+        assert status != 0
+
+    def test_missing_changelog_file_fails(self, script: ModuleType) -> None:
+        status = script._check_changelog_unreleased_populated()
+
+        assert status != 0
+
+
+class TestMainOrdering:
+    """``main()`` runs the CHANGELOG guard first and short-circuits on failure."""
+
+    def test_main_fails_fast_and_never_touches_citation_cff(
+        self, script: ModuleType, tmp_path: Path,
+    ) -> None:
+        _write_changelog(tmp_path, unreleased_body="")
+        # Deliberately no CITATION.cff at all: if the guard did not run
+        # first, main() would instead fail with the (different) "CITATION.cff
+        # not found" error -- proving the ordering, not just "some" failure.
+        assert not (tmp_path / "CITATION.cff").exists()
+
+        exit_code = script.main()
+
+        assert exit_code != 0
+        assert not (tmp_path / "CITATION.cff").exists()
+
+    def test_main_fails_fast_even_when_citation_cff_would_otherwise_succeed(
+        self, script: ModuleType, tmp_path: Path,
+    ) -> None:
+        _write_changelog(tmp_path, unreleased_body="")
+        citation = _write_citation_cff(tmp_path)
+        before = citation.read_text(encoding="utf-8")
+
+        exit_code = script.main()
+
+        assert exit_code != 0
+        # CITATION.cff must be untouched -- the changelog guard ran before
+        # any write.
+        assert citation.read_text(encoding="utf-8") == before
+
+
+class TestCitationCffStampUnaffected:
+    """Existing CITATION.cff date-stamp behavior is unchanged by the new guard."""
+
+    def test_main_stamps_date_when_changelog_is_populated(
+        self, script: ModuleType, tmp_path: Path,
+    ) -> None:
+        _init_git_repo(tmp_path)
+        _write_changelog(
+            tmp_path,
+            unreleased_body="### Fixed\n\n- A real fix.\n\n",
+        )
+        citation = _write_citation_cff(tmp_path, date="2020-01-01")
+
+        exit_code = script.main()
+
+        assert exit_code == 0
+        rewritten = citation.read_text(encoding="utf-8")
+        assert '"2020-01-01"' not in rewritten
+        assert "date-released:" in rewritten
+
+    def test_main_still_fails_on_malformed_citation_cff_when_changelog_is_populated(
+        self, script: ModuleType, tmp_path: Path,
+    ) -> None:
+        _write_changelog(
+            tmp_path,
+            unreleased_body="### Fixed\n\n- A real fix.\n\n",
+        )
+        citation = tmp_path / "CITATION.cff"
+        citation.write_text("cff-version: 1.2.0\nversion: 1.0.0\n", encoding="utf-8")
+
+        exit_code = script.main()
+
+        assert exit_code == 2

--- a/tests/test_bumpver_stamp_date.py
+++ b/tests/test_bumpver_stamp_date.py
@@ -77,7 +77,11 @@ def _init_git_repo(path: Path) -> None:
         cwd=path,
         check=True,
     )
-    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)  # nosec B603 B607
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=path,
+        check=True,
+    )  # nosec B603 B607
 
 
 class TestUnreleasedSectionBody:
@@ -100,7 +104,10 @@ class TestUnreleasedSectionBody:
         assert body is not None
         assert body.strip() == ""
 
-    def test_whitespace_only_section_returns_blank_body(self, script: ModuleType) -> None:
+    def test_whitespace_only_section_returns_blank_body(
+        self,
+        script: ModuleType,
+    ) -> None:
         text = "## [Unreleased]\n\n   \n\n## [1.0.0]\n- x\n"
 
         body = script._unreleased_section_body(text)
@@ -114,7 +121,8 @@ class TestUnreleasedSectionBody:
         assert script._unreleased_section_body(text) is None
 
     def test_unreleased_at_end_of_file_returns_full_remainder(
-        self, script: ModuleType,
+        self,
+        script: ModuleType,
     ) -> None:
         text = "## [Unreleased]\n### Added\n\n- Only entry, no version header after.\n"
 
@@ -124,7 +132,8 @@ class TestUnreleasedSectionBody:
         assert "Only entry" in body
 
     def test_does_not_mis_parse_a_triple_hash_subsection_as_a_version_header(
-        self, script: ModuleType,
+        self,
+        script: ModuleType,
     ) -> None:
         """A populated section containing ``### Added``/``### Fixed`` subsections
         must not be truncated early by the next-header search (guards against the
@@ -163,7 +172,9 @@ class TestCheckChangelogUnreleasedPopulated:
         assert "Unreleased" in err
 
     def test_whitespace_only_unreleased_section_fails(
-        self, script: ModuleType, tmp_path: Path,
+        self,
+        script: ModuleType,
+        tmp_path: Path,
     ) -> None:
         _write_changelog(tmp_path, unreleased_body="\n   \n\n")
 
@@ -172,7 +183,9 @@ class TestCheckChangelogUnreleasedPopulated:
         assert status != 0
 
     def test_populated_unreleased_section_passes(
-        self, script: ModuleType, tmp_path: Path,
+        self,
+        script: ModuleType,
+        tmp_path: Path,
     ) -> None:
         _write_changelog(
             tmp_path,
@@ -184,7 +197,9 @@ class TestCheckChangelogUnreleasedPopulated:
         assert status == 0
 
     def test_missing_unreleased_header_fails(
-        self, script: ModuleType, tmp_path: Path,
+        self,
+        script: ModuleType,
+        tmp_path: Path,
     ) -> None:
         path = tmp_path / "CHANGELOG.md"
         path.write_text(
@@ -206,7 +221,9 @@ class TestMainOrdering:
     """``main()`` runs the CHANGELOG guard first and short-circuits on failure."""
 
     def test_main_fails_fast_and_never_touches_citation_cff(
-        self, script: ModuleType, tmp_path: Path,
+        self,
+        script: ModuleType,
+        tmp_path: Path,
     ) -> None:
         _write_changelog(tmp_path, unreleased_body="")
         # Deliberately no CITATION.cff at all: if the guard did not run
@@ -220,7 +237,9 @@ class TestMainOrdering:
         assert not (tmp_path / "CITATION.cff").exists()
 
     def test_main_fails_fast_even_when_citation_cff_would_otherwise_succeed(
-        self, script: ModuleType, tmp_path: Path,
+        self,
+        script: ModuleType,
+        tmp_path: Path,
     ) -> None:
         _write_changelog(tmp_path, unreleased_body="")
         citation = _write_citation_cff(tmp_path)
@@ -238,7 +257,9 @@ class TestCitationCffStampUnaffected:
     """Existing CITATION.cff date-stamp behavior is unchanged by the new guard."""
 
     def test_main_stamps_date_when_changelog_is_populated(
-        self, script: ModuleType, tmp_path: Path,
+        self,
+        script: ModuleType,
+        tmp_path: Path,
     ) -> None:
         _init_git_repo(tmp_path)
         _write_changelog(
@@ -255,7 +276,9 @@ class TestCitationCffStampUnaffected:
         assert "date-released:" in rewritten
 
     def test_main_still_fails_on_malformed_citation_cff_when_changelog_is_populated(
-        self, script: ModuleType, tmp_path: Path,
+        self,
+        script: ModuleType,
+        tmp_path: Path,
     ) -> None:
         _write_changelog(
             tmp_path,


### PR DESCRIPTION
## Summary
CICD-03, fail-fast-only per the recorded maintainer decision: `scripts/bumpver_stamp_date.py` (the single bumpver `pre_commit_hook`) now fails with distinct exit codes when `## [Unreleased]` is missing (6), the file is missing (5), or the section body is empty/whitespace-only (7) — closing the gap that let 3.0.0 ship with an empty section from the bump path. No consolidation, no second hook, no trigger changes; CITATION.cff stamping byte-identical.

Red-first: the failing test landed before the implementation (15 new tests in `tests/test_bumpver_stamp_date.py` — the script previously had no dedicated tests).

## Evidence
Suite 1196/4/4 (baseline +15) · pre-commit green. **Adversarial verify (Opus, default-refute): CONFIRMED, 0 mustFix** — probed 6 legitimate section shapes (subheading-first, CRLF, unicode, BOM, EOF-section, trailing-space header: all read POPULATED — no false red) and the empty variants (all fail closed). One pipeline-wide note for the maintainer: an HTML-comment-only body reads as populated in BOTH this guard and the merged W1-4 gate (consistent definitions; flagged, not a defect).

Squash-merge (red+green PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk