### PR TITLE
docs: real 3.0.0 CHANGELOG narrative, header dedupe, CLAUDE.md refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ rate-limiting via `stamina`/`aiolimiter`), and `restgdf[telemetry]`
 (`RestgdfInstrumentor` OpenTelemetry instrumentation) — so a base
 install stays dependency-light. A typed streaming surface
 (`iter_pages`, `stream_features`, `stream_feature_batches`,
-`stream_rows`, `stream_gdf_chunks`) replaces the legacy synchronous
+`stream_rows`, `stream_gdf_chunks`) replaces the legacy row/feature
 helpers, with query-verb selection centralized in `_choose_verb`/
 `_arcgis_request` (`restgdf/utils/_http.py`). `restgdf.Config` adds
 layered, frozen pydantic sub-configs resolved from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,24 @@ All notable changes to restgdf are documented here. This project follows
 
 ## [3.0.0] - 2026-05-02
 
-## [2.0.0] - 2026-05-02
+restgdf 3.0.0 is a major, backwards-incompatible rewrite. The package
+splits into a light async core (`aiohttp` + `pydantic` v2) plus three
+opt-in extras — `restgdf[geo]` (GeoPandas/pandas/pyogrio),
+`restgdf[resilience]` (`ResilientSession`/`ResilienceConfig` retry and
+rate-limiting via `stamina`/`aiolimiter`), and `restgdf[telemetry]`
+(`RestgdfInstrumentor` OpenTelemetry instrumentation) — so a base
+install stays dependency-light. A typed streaming surface
+(`iter_pages`, `stream_features`, `stream_feature_batches`,
+`stream_rows`, `stream_gdf_chunks`) replaces the legacy synchronous
+helpers, with query-verb selection centralized in `_choose_verb`/
+`_arcgis_request` (`restgdf/utils/_http.py`). `restgdf.Config` adds
+layered, frozen pydantic sub-configs resolved from
+`RESTGDF_<CATEGORY>_<FIELD>` env vars, and `restgdf.errors` grows a
+wider exception taxonomy including a five-member `AuthenticationError`
+hierarchy. See `MIGRATION.md` for the full breaking-change list; the
+detailed change set below was carried forward from the pre-release
+tranche.
+
 ### Changed
 
 - **Gate-3 hardening follow-up.** Three review-driven

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,11 @@ namespace plus `restgdf.{adapters,compat,utils,errors}`.
   bullet under `## [Unreleased]`.
 - **`README.md`** — user-facing usage; **`SECURITY.md`** — vuln reporting + supply-chain.
 
-> Companion docs predate the 3.0 release in places and carry **known drift** (e.g. SECURITY.md
-> supported-versions table, CONTRIBUTING's `integration/3.0-rewrite` branch target,
-> ARCHITECTURE.md's `ErrorPayload`/`.env`/logger-name claims, an empty `## [3.0.0]` CHANGELOG
-> header). **When code and companion prose disagree, the code is the source of truth.** The
-> `audit-recommendations/` directory catalogs the specific drift.
+> Companion docs predate the 3.0 release in places and carry **known drift** (e.g.
+> CONTRIBUTING's `integration/3.0-rewrite` branch target and ARCHITECTURE.md's
+> `ErrorPayload`/`.env`/logger-name claims). **When code and companion prose disagree, the
+> code is the source of truth.** The `audit-recommendations/` directory catalogs the specific
+> drift; the remediation program is closing it item by item.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,9 @@
 
 ## What this is
 
-`restgdf` is a **lightweight async Esri/ArcGIS REST client** for Python ≥ 3.9, published to
-PyPI as a Production/Stable library (currently v3.0.0). The light core depends only on
+`restgdf` is a **lightweight async Esri/ArcGIS REST client** for Python ≥ 3.11, published to
+PyPI as a Production/Stable library (currently v3.0.0; a 3.1.0 release carrying the Python
+floor bump and other `## [Unreleased]` CHANGELOG entries is pending). The light core depends only on
 `aiohttp` + `pydantic` v2; GeoPandas/pandas, retry/rate-limiting, and OpenTelemetry are
 **optional extras** (`geo`, `resilience`, `telemetry`). The two public entry points are
 `FeatureLayer` (one ArcGIS feature layer) and `Directory` (service discovery / crawl).
@@ -71,7 +72,8 @@ on its own (so `git bisect` stays useful).
 - **Public surface is lazy (PEP 562):** `restgdf/__init__.py` resolves a 54-name `__all__`
   through `_LAZY_EXPORTS` via module `__getattr__`. Three internal duplications (`__all__`,
   `_LAZY_EXPORTS`, the `TYPE_CHECKING` import block) must stay in sync — they can drift
-  undetected (`FieldDoesNotExistError` is already missing from the `TYPE_CHECKING` block).
+  undetected (all three surfaces list `FieldDoesNotExistError` as of #193/W5-7; watch for the
+  next name that drifts).
 - **`FeatureLayer.from_url()` issues exactly two network calls** (metadata `?f=json` GET, count
   POST), then everything else is lazy. `.where(clause)` reuses the parent's cached metadata and
   only re-issues the scoped count.
@@ -133,9 +135,14 @@ on its own (so `git bisect` stays useful).
 - **Per-instance caches are not concurrency-safe:** `FeatureLayer.uniquevalues/valuecounts/`
   `nestedcount/gdf` are plain dicts with no lock; concurrent awaiters double-fetch, and
   multi-field results are returned by reference (mutating the result mutates the cache).
-- **Token transport:** a token in the `data` dict on a *plain* `aiohttp` session can be GET-
-  serialized into the URL when the encoded request is < 8192 bytes (the credential-leak guard
-  only triggers for body/query transport on an `ArcGISTokenSession`). Prefer header transport.
+- **Token transport (fixed in 3.1, AUTH-01):** a token in the `data` dict on a *plain*
+  `aiohttp` session used to be GET-serializable into the URL when the encoded request was
+  < 8192 bytes (the credential-leak guard previously only triggered for body/query transport
+  on an `ArcGISTokenSession`). `restgdf/utils/_http.py` now forces `POST` whenever the
+  outgoing body carries a token, regardless of session type or encoded length. Prefer header
+  transport regardless — it never touches this length-based routing at all.
 - **CI surprises:** the PR-gating `pytest.yml` does **not** run coverage (the 97% floor is only
-  checked post-merge in `coverage.yml`), and there is no CI gate on direct push/merge to `main`
-  (`pytest.yml` is `pull_request`-only). Run the local gate before merging.
+  checked post-merge in `coverage.yml` — this gap closes once W1-3 lands). `ci-offline` (a
+  `pytest.yml` job) IS now a required GitHub branch-protection status check on `main`, so a PR
+  cannot merge until it is green; `pytest.yml` itself still only triggers on `pull_request`
+  (no separate workflow re-runs it on a direct push). Run the local gate before merging.


### PR DESCRIPTION
## Summary
The M1 slice of W6-5 plus agent-doc hygiene:
- **CHANGELOG**: populated the empty `## [3.0.0]` section with a git-and-tree-grounded narrative (every bullet fact-checked against the code; the mislabeled duplicate `## [2.0.0]` header carrying the 3.0 body is disambiguated — each version header now appears exactly once, which the W1-4 release gate requires). The 3.1.0 release notes can now truthfully reference a real 3.0.0 baseline.
- **CLAUDE.md**: corrected only the claims this program falsified — floor ≥3.11, AUTH-01 token-transport pitfall (fixed in #195), `ci-offline` now a required check on `main`, `FieldDoesNotExistError` TYPE_CHECKING sync (fixed in #193), and the known-drift examples list. Everything else byte-preserved.

## Evidence
W1-4 gate logic re-run for 3.0.0: PASS (header count 1, body non-empty) · duplicate scan clean · pre-commit green · suite untouched (1181/4/4). **Adversarial verify (Opus, default-refute): ADJUSTED → 2 mustFix, both applied** (dropped a wrong "synchronous" qualifier; removed the now-false empty-3.0.0 drift example — plus the equally-falsified SECURITY.md example, W6-1/#193). Every remaining narrative claim was independently evidence-traced (verifier quoted sources per bullet).

Merge after #195 (the CLAUDE.md token-transport wording describes the post-AUTH-01 state — already true on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk