### PR TITLE
fix: gate bumpver on the just-bumped version's CHANGELOG section (W1-8b)

### DIFF
--- a/scripts/bumpver_stamp_date.py
+++ b/scripts/bumpver_stamp_date.py
@@ -14,21 +14,28 @@ Behaviour
 This hook runs between bumpver's file-pattern substitution step and its
 commit step. It performs two independent checks/actions, in order:
 
-1. **CHANGELOG fail-fast (CICD-02 / W1-8, fail-fast-only per maintainer
-   decision):** read ``CHANGELOG.md`` and exit non-zero if the
-   ``## [Unreleased]`` section has no non-blank body. This is a hard
-   assertion only — it does NOT rename ``## [Unreleased]`` or otherwise
-   consolidate the changelog (that would be the heavier option the
+1. **CHANGELOG fail-fast (CICD-02 / W1-8b, fail-fast-only per maintainer
+   decision):** read the just-bumped version from ``pyproject.toml``
+   (``[tool.bumpver] current_version`` — already rewritten by bumpver's
+   file-pattern step when this hook runs) and exit non-zero unless
+   ``CHANGELOG.md`` has a ``## [{version}]`` section with a non-blank
+   body. This matches what the publish-time W1-4 gate will require at
+   the tag, so a bump that would fail publish fails HERE instead —
+   before any tag exists. Intended flow: consolidate ``[Unreleased]``
+   into ``## [X.Y.Z]`` in a release-prep PR, then dispatch bumpver.
+   This is a hard assertion only — it does NOT rename ``[Unreleased]``
+   or otherwise consolidate the changelog (the heavier option the
    maintainer decision explicitly declined). Runs first, before touching
    ``CITATION.cff``, so a rejected release leaves no partial file writes.
 2. Rewrites the ``date-released:`` line in ``CITATION.cff`` with today's
    UTC date (ISO 8601, ``YYYY-MM-DD``) and ``git add``s the file so
    bumpver's subsequent commit picks up the change.
 
-Exits non-zero if ``CHANGELOG.md`` has no populated ``## [Unreleased]``
-section, or if ``CITATION.cff`` does not contain exactly one
-``date-released:`` line (which would indicate the file has drifted from
-the shape ``tests/test_citation_cff_version.py`` expects).
+Exits non-zero if the just-bumped version has no populated
+``## [{version}]`` section in ``CHANGELOG.md``, if the version cannot be
+read from ``pyproject.toml``, or if ``CITATION.cff`` does not contain
+exactly one ``date-released:`` line (which would indicate the file has
+drifted from the shape ``tests/test_citation_cff_version.py`` expects).
 """
 
 from __future__ import annotations
@@ -39,15 +46,16 @@ import re
 import shutil
 import subprocess  # nosec B404 - used only to `git add` the file we just rewrote
 import sys
+import tomllib
 
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
 _CITATION_CFF = _REPO_ROOT / "CITATION.cff"
 _CHANGELOG_MD = _REPO_ROOT / "CHANGELOG.md"
+_PYPROJECT_TOML = _REPO_ROOT / "pyproject.toml"
 _DATE_RELEASED_RE = re.compile(
     r'^(?P<prefix>date-released:\s*)"\d{4}-\d{2}-\d{2}"\s*$',
     re.MULTILINE,
 )
-_UNRELEASED_HEADER_RE = re.compile(r"^## \[Unreleased\]\s*$", re.MULTILINE)
 _NEXT_VERSION_HEADER_RE = re.compile(r"^## \[", re.MULTILINE)
 
 
@@ -55,12 +63,36 @@ def _today_utc_iso() -> str:
     return _dt.datetime.now(tz=_dt.timezone.utc).date().isoformat()
 
 
-def _unreleased_section_body(text: str) -> str | None:
-    """Return the raw text between ``## [Unreleased]`` and the next
-    ``## [`` header (exclusive of both), or ``None`` if no
-    ``## [Unreleased]`` header is present in ``text``.
+def _read_bumped_version() -> str | None:
+    """Return ``[tool.bumpver] current_version`` from ``pyproject.toml``.
+
+    The hook runs after bumpver's file-pattern substitution, so this is
+    the NEW (just-bumped) version. ``None`` on any missing/unparseable
+    shape — the caller turns that into a fail-fast exit.
     """
-    header_match = _UNRELEASED_HEADER_RE.search(text)
+    try:
+        with _PYPROJECT_TOML.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+    version = data.get("tool", {}).get("bumpver", {}).get("current_version")
+    return version if isinstance(version, str) and version else None
+
+
+def _release_section_body(text: str, version: str) -> str | None:
+    """Return the raw text between ``## [{version}]`` (with or without a
+    trailing ``- <date>`` suffix) and the next ``## [`` header, or
+    ``None`` if no such header is present. ``version`` is matched
+    literally — dots are not regex wildcards.
+    """
+    header_re = re.compile(
+        # [ \t]* (not \s*): \s matches newlines, which would let the
+        # optional date suffix swallow the section's first body line
+        # when the header is undated.
+        rf"^## \[{re.escape(version)}\](?:[ \t]*-[^\n]*)?[ \t]*$",
+        re.MULTILINE,
+    )
+    header_match = header_re.search(text)
     if header_match is None:
         return None
     start = header_match.end()
@@ -69,13 +101,16 @@ def _unreleased_section_body(text: str) -> str | None:
     return text[start:end]
 
 
-def _check_changelog_unreleased_populated() -> int:
-    """Fail fast (non-zero) when ``CHANGELOG.md``'s ``## [Unreleased]``
-    section has no non-blank body.
+def _check_changelog_release_section_populated() -> int:
+    """Fail fast (non-zero) unless the just-bumped version's own
+    ``## [{version}]`` section exists in ``CHANGELOG.md`` with a
+    non-blank body.
 
-    Mirrors the ``date-released`` guard's fail-fast discipline (clear
-    stderr message, non-zero exit on any unexpected shape) rather than
-    silently letting an empty-Unreleased release ship. This is a hard
+    This asserts at BUMP time exactly what the publish-time W1-4 gate
+    asserts at the tag, so a release that would fail publish fails here
+    — before bumpver creates the release commit/tag. Mirrors the
+    ``date-released`` guard's fail-fast discipline (clear stderr
+    message, non-zero exit on any unexpected shape). This is a hard
     assertion ONLY: it never rewrites ``CHANGELOG.md`` (no auto-rename,
     no consolidation) per the recorded maintainer decision for W1-8.
     """
@@ -83,22 +118,34 @@ def _check_changelog_unreleased_populated() -> int:
         print(f"[bumpver_stamp_date] {_CHANGELOG_MD} not found", file=sys.stderr)
         return 5
 
+    version = _read_bumped_version()
+    if version is None:
+        print(
+            "[bumpver_stamp_date] could not read [tool.bumpver] "
+            f"current_version from {_PYPROJECT_TOML}.",
+            file=sys.stderr,
+        )
+        return 8
+
     text = _CHANGELOG_MD.read_text(encoding="utf-8")
-    body = _unreleased_section_body(text)
+    body = _release_section_body(text, version)
 
     if body is None:
         print(
-            '[bumpver_stamp_date] expected a "## [Unreleased]" header in '
-            f"{_CHANGELOG_MD}; found none.",
+            f'[bumpver_stamp_date] expected a "## [{version}]" section in '
+            f"{_CHANGELOG_MD}; found none. Consolidate the "
+            f'"## [Unreleased]" entries into "## [{version}] - <date>" in '
+            "a release-prep PR before dispatching the bump "
+            "(see CONTRIBUTING.md).",
             file=sys.stderr,
         )
         return 6
 
     if not body.strip():
         print(
-            '[bumpver_stamp_date] the "## [Unreleased]" section in '
-            f"{_CHANGELOG_MD} has no body. Add a changelog entry before "
-            "bumping the version (see CONTRIBUTING.md).",
+            f'[bumpver_stamp_date] the "## [{version}]" section in '
+            f"{_CHANGELOG_MD} has no body. Populate it before bumping "
+            "the version (see CONTRIBUTING.md).",
             file=sys.stderr,
         )
         return 7
@@ -107,7 +154,7 @@ def _check_changelog_unreleased_populated() -> int:
 
 
 def main() -> int:
-    changelog_status = _check_changelog_unreleased_populated()
+    changelog_status = _check_changelog_release_section_populated()
     if changelog_status != 0:
         return changelog_status
 

--- a/tests/test_bumpver_stamp_date.py
+++ b/tests/test_bumpver_stamp_date.py
@@ -1,16 +1,26 @@
-"""W1-8 (CICD-02): red-first tests for the bumpver CHANGELOG fail-fast guard.
+"""W1-8b: red-first tests for the bumpver release-section fail-fast guard.
 
 ``scripts/bumpver_stamp_date.py`` runs as bumpver's ``pre_commit_hook``
-between file-pattern substitution and the release commit. Per the
-recorded maintainer decision (fail-fast-ONLY — no ``## [Unreleased]``
-consolidation/rename), it now also fails the hook when ``CHANGELOG.md``'s
-``## [Unreleased]`` section has no non-blank body, so an empty-Unreleased
-release can no longer ship silently.
+between file-pattern substitution and the release commit — i.e. AFTER
+``[tool.bumpver] current_version`` has been rewritten to the new version.
+
+Composing the shipped W1-8 guard (require non-empty ``## [Unreleased]``
+at bump time) with the W1-4 publish gate (require a non-empty
+``## [X.Y.Z]`` section at tag time) deadlocks every release: bumpver
+never rewrites the CHANGELOG, so pre-consolidating starves the bump gate
+and not consolidating starves the publish gate. Per the fail-fast-only
+maintainer decision (no consolidation logic in the hook), the guard now
+asserts the thing the release actually needs: the JUST-BUMPED version's
+own ``## [{version}]`` section exists with a non-blank body. The intended
+flow becomes: consolidate ``[Unreleased]`` -> ``[X.Y.Z]`` in a release-prep
+PR, then dispatch bumpver. A bump without a populated release section
+fails fast with an actionable message — which still (more directly than
+before) blocks the 3.0.0-class empty-section ship.
 
 The script is loaded fresh per-test by file path (``scripts/`` has no
-``__init__.py`` and is not an importable package) and its module-level
-path constants are monkeypatched to an isolated ``tmp_path`` "repo root"
-so no test ever reads or writes the real ``CHANGELOG.md``/``CITATION.cff``.
+``__init__.py``) and its module-level path constants are monkeypatched to
+an isolated ``tmp_path`` "repo root" so no test ever reads or writes the
+real ``CHANGELOG.md``/``CITATION.cff``/``pyproject.toml``.
 """
 
 from __future__ import annotations
@@ -45,19 +55,44 @@ def script(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> ModuleType:
     monkeypatch.setattr(module, "_REPO_ROOT", tmp_path)
     monkeypatch.setattr(module, "_CITATION_CFF", tmp_path / "CITATION.cff")
     monkeypatch.setattr(module, "_CHANGELOG_MD", tmp_path / "CHANGELOG.md")
+    # raising=False: against the pre-W1-8b script this attribute does not
+    # exist yet — the red state fails inside test bodies (missing seam),
+    # not at fixture setup.
+    monkeypatch.setattr(
+        module,
+        "_PYPROJECT_TOML",
+        tmp_path / "pyproject.toml",
+        raising=False,
+    )
     return module
 
 
-def _write_changelog(tmp_path: Path, unreleased_body: str) -> Path:
-    text = (
-        "# Changelog\n\n"
-        "## [Unreleased]\n"
-        f"{unreleased_body}"
-        "## [1.0.0] - 2026-01-01\n"
-        "- Initial release.\n"
+def _write_pyproject(tmp_path: Path, *, version: str = "3.1.0") -> Path:
+    """A minimal post-file_patterns pyproject: current_version already bumped."""
+    path = tmp_path / "pyproject.toml"
+    path.write_text(
+        f'[tool.bumpver]\ncurrent_version = "{version}"\n',
+        encoding="utf-8",
     )
+    return path
+
+
+def _write_changelog(
+    tmp_path: Path,
+    *,
+    unreleased_body: str = "",
+    release_header: str | None = None,
+    release_body: str = "",
+) -> Path:
+    """Build a CHANGELOG with an Unreleased section, an optional release
+    section (header given verbatim, e.g. ``## [3.1.0] - 2026-07-24``), and
+    a fixed 1.0.0 tail."""
+    parts = ["# Changelog\n\n", "## [Unreleased]\n", unreleased_body]
+    if release_header is not None:
+        parts += [f"{release_header}\n", release_body]
+    parts += ["## [1.0.0] - 2026-01-01\n", "- Initial release.\n"]
     path = tmp_path / "CHANGELOG.md"
-    path.write_text(text, encoding="utf-8")
+    path.write_text("".join(parts), encoding="utf-8")
     return path
 
 
@@ -84,69 +119,76 @@ def _init_git_repo(path: Path) -> None:
     )  # nosec B603 B607
 
 
-class TestUnreleasedSectionBody:
-    """Pure-parsing coverage for ``_unreleased_section_body`` — no file I/O."""
+class TestReleaseSectionBody:
+    """Pure-parsing coverage for ``_release_section_body`` — no file I/O."""
 
-    def test_populated_section_returns_full_body(self, script: ModuleType) -> None:
-        text = "## [Unreleased]\n### Fixed\n\n- A real fix.\n\n## [1.0.0]\n- x\n"
+    def test_populated_dated_section_returns_full_body(
+        self,
+        script: ModuleType,
+    ) -> None:
+        text = (
+            "## [Unreleased]\n\n"
+            "## [3.1.0] - 2026-07-24\n### Fixed\n\n- A real fix.\n\n"
+            "## [1.0.0]\n- x\n"
+        )
 
-        body = script._unreleased_section_body(text)
+        body = script._release_section_body(text, "3.1.0")
 
         assert body is not None
         assert "A real fix" in body
         assert "## [1.0.0]" not in body
 
+    def test_bare_undated_header_also_matches(self, script: ModuleType) -> None:
+        text = "## [3.1.0]\n- Something.\n## [1.0.0]\n- x\n"
+
+        body = script._release_section_body(text, "3.1.0")
+
+        assert body is not None
+        assert "Something" in body
+
     def test_empty_section_returns_blank_body(self, script: ModuleType) -> None:
-        text = "## [Unreleased]\n## [1.0.0]\n- x\n"
+        text = "## [3.1.0] - 2026-07-24\n## [1.0.0]\n- x\n"
 
-        body = script._unreleased_section_body(text)
-
-        assert body is not None
-        assert body.strip() == ""
-
-    def test_whitespace_only_section_returns_blank_body(
-        self,
-        script: ModuleType,
-    ) -> None:
-        text = "## [Unreleased]\n\n   \n\n## [1.0.0]\n- x\n"
-
-        body = script._unreleased_section_body(text)
+        body = script._release_section_body(text, "3.1.0")
 
         assert body is not None
         assert body.strip() == ""
 
-    def test_missing_header_returns_none(self, script: ModuleType) -> None:
-        text = "## [1.0.0]\n- x\n"
+    def test_missing_version_header_returns_none(self, script: ModuleType) -> None:
+        text = "## [Unreleased]\n- Pending.\n## [1.0.0]\n- x\n"
 
-        assert script._unreleased_section_body(text) is None
+        assert script._release_section_body(text, "3.1.0") is None
 
-    def test_unreleased_at_end_of_file_returns_full_remainder(
+    def test_version_dots_are_not_regex_wildcards(self, script: ModuleType) -> None:
+        """``3.1.0`` must not match a ``3x1x0``-style header (dot-metachar trap
+        — the same class of bug the W1-4 verify found in the plan's awk)."""
+        text = "## [3x1x0] - 2026-07-24\n- decoy\n## [1.0.0]\n- x\n"
+
+        assert script._release_section_body(text, "3.1.0") is None
+
+    def test_section_at_end_of_file_returns_remainder(
         self,
         script: ModuleType,
     ) -> None:
-        text = "## [Unreleased]\n### Added\n\n- Only entry, no version header after.\n"
+        text = "## [3.1.0] - 2026-07-24\n### Added\n\n- Only entry.\n"
 
-        body = script._unreleased_section_body(text)
+        body = script._release_section_body(text, "3.1.0")
 
         assert body is not None
         assert "Only entry" in body
 
-    def test_does_not_mis_parse_a_triple_hash_subsection_as_a_version_header(
+    def test_triple_hash_subsections_do_not_truncate_the_body(
         self,
         script: ModuleType,
     ) -> None:
-        """A populated section containing ``### Added``/``### Fixed`` subsections
-        must not be truncated early by the next-header search (guards against the
-        risk named in plan/01 W1-8: 'an awk pattern that mis-parses a legitimately
-        populated section blocks a real release')."""
         text = (
-            "## [Unreleased]\n"
+            "## [3.1.0] - 2026-07-24\n"
             "### Added\n\n- Item one.\n\n"
             "### Fixed\n\n- Item two.\n\n"
             "## [1.0.0]\n- old\n"
         )
 
-        body = script._unreleased_section_body(text)
+        body = script._release_section_body(text, "3.1.0")
 
         assert body is not None
         assert "Item one" in body
@@ -154,67 +196,110 @@ class TestUnreleasedSectionBody:
         assert "old" not in body
 
 
-class TestCheckChangelogUnreleasedPopulated:
-    """File-reading wrapper: ``_check_changelog_unreleased_populated``."""
+class TestCheckChangelogReleaseSectionPopulated:
+    """File-reading wrapper: ``_check_changelog_release_section_populated``."""
 
-    def test_empty_unreleased_section_fails(
+    def test_populated_release_section_passes(
+        self,
+        script: ModuleType,
+        tmp_path: Path,
+    ) -> None:
+        _write_pyproject(tmp_path, version="3.1.0")
+        _write_changelog(
+            tmp_path,
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="### Fixed\n\n- Something real got fixed.\n\n",
+        )
+
+        assert script._check_changelog_release_section_populated() == 0
+
+    def test_missing_release_section_fails_with_consolidation_hint(
         self,
         script: ModuleType,
         tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        _write_changelog(tmp_path, unreleased_body="")
+        """Populated Unreleased but no ## [3.1.0] section: the pre-W1-8b
+        guard passed this state, and the publish gate then failed AFTER the
+        tag was pushed. It must now fail at the bump with an actionable
+        message."""
+        _write_pyproject(tmp_path, version="3.1.0")
+        _write_changelog(tmp_path, unreleased_body="- Pending entry.\n")
 
-        status = script._check_changelog_unreleased_populated()
+        status = script._check_changelog_release_section_populated()
 
-        assert status != 0
+        assert status == 6
         err = capsys.readouterr().err
-        assert "Unreleased" in err
+        assert "3.1.0" in err
+        assert "consolidat" in err.lower()
 
-    def test_whitespace_only_unreleased_section_fails(
+    def test_empty_release_section_fails(
         self,
         script: ModuleType,
         tmp_path: Path,
     ) -> None:
-        _write_changelog(tmp_path, unreleased_body="\n   \n\n")
+        _write_pyproject(tmp_path, version="3.1.0")
+        _write_changelog(
+            tmp_path,
+            unreleased_body="- Pending.\n",
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="",
+        )
 
-        status = script._check_changelog_unreleased_populated()
+        assert script._check_changelog_release_section_populated() == 7
 
-        assert status != 0
+    def test_whitespace_only_release_section_fails(
+        self,
+        script: ModuleType,
+        tmp_path: Path,
+    ) -> None:
+        _write_pyproject(tmp_path, version="3.1.0")
+        _write_changelog(
+            tmp_path,
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="\n   \n\n",
+        )
 
-    def test_populated_unreleased_section_passes(
+        assert script._check_changelog_release_section_populated() == 7
+
+    def test_missing_changelog_file_fails(
+        self,
+        script: ModuleType,
+        tmp_path: Path,
+    ) -> None:
+        _write_pyproject(tmp_path, version="3.1.0")
+
+        assert script._check_changelog_release_section_populated() == 5
+
+    def test_missing_pyproject_fails(
         self,
         script: ModuleType,
         tmp_path: Path,
     ) -> None:
         _write_changelog(
             tmp_path,
-            unreleased_body="### Fixed\n\n- Something real got fixed.\n\n",
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="- Real.\n",
         )
 
-        status = script._check_changelog_unreleased_populated()
+        assert script._check_changelog_release_section_populated() == 8
 
-        assert status == 0
-
-    def test_missing_unreleased_header_fails(
+    def test_pyproject_without_bumpver_version_fails(
         self,
         script: ModuleType,
         tmp_path: Path,
     ) -> None:
-        path = tmp_path / "CHANGELOG.md"
-        path.write_text(
-            "# Changelog\n\n## [1.0.0] - 2026-01-01\n- Initial release.\n",
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "x"\n',
             encoding="utf-8",
         )
+        _write_changelog(
+            tmp_path,
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="- Real.\n",
+        )
 
-        status = script._check_changelog_unreleased_populated()
-
-        assert status != 0
-
-    def test_missing_changelog_file_fails(self, script: ModuleType) -> None:
-        status = script._check_changelog_unreleased_populated()
-
-        assert status != 0
+        assert script._check_changelog_release_section_populated() == 8
 
 
 class TestMainOrdering:
@@ -225,7 +310,12 @@ class TestMainOrdering:
         script: ModuleType,
         tmp_path: Path,
     ) -> None:
-        _write_changelog(tmp_path, unreleased_body="")
+        _write_pyproject(tmp_path, version="3.1.0")
+        _write_changelog(
+            tmp_path,
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="",
+        )
         # Deliberately no CITATION.cff at all: if the guard did not run
         # first, main() would instead fail with the (different) "CITATION.cff
         # not found" error -- proving the ordering, not just "some" failure.
@@ -233,7 +323,7 @@ class TestMainOrdering:
 
         exit_code = script.main()
 
-        assert exit_code != 0
+        assert exit_code == 7
         assert not (tmp_path / "CITATION.cff").exists()
 
     def test_main_fails_fast_even_when_citation_cff_would_otherwise_succeed(
@@ -241,13 +331,14 @@ class TestMainOrdering:
         script: ModuleType,
         tmp_path: Path,
     ) -> None:
-        _write_changelog(tmp_path, unreleased_body="")
+        _write_pyproject(tmp_path, version="3.1.0")
+        _write_changelog(tmp_path, unreleased_body="- Pending.\n")
         citation = _write_citation_cff(tmp_path)
         before = citation.read_text(encoding="utf-8")
 
         exit_code = script.main()
 
-        assert exit_code != 0
+        assert exit_code == 6
         # CITATION.cff must be untouched -- the changelog guard ran before
         # any write.
         assert citation.read_text(encoding="utf-8") == before
@@ -256,15 +347,17 @@ class TestMainOrdering:
 class TestCitationCffStampUnaffected:
     """Existing CITATION.cff date-stamp behavior is unchanged by the new guard."""
 
-    def test_main_stamps_date_when_changelog_is_populated(
+    def test_main_stamps_date_when_release_section_is_populated(
         self,
         script: ModuleType,
         tmp_path: Path,
     ) -> None:
         _init_git_repo(tmp_path)
+        _write_pyproject(tmp_path, version="3.1.0")
         _write_changelog(
             tmp_path,
-            unreleased_body="### Fixed\n\n- A real fix.\n\n",
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="### Fixed\n\n- A real fix.\n\n",
         )
         citation = _write_citation_cff(tmp_path, date="2020-01-01")
 
@@ -275,14 +368,16 @@ class TestCitationCffStampUnaffected:
         assert '"2020-01-01"' not in rewritten
         assert "date-released:" in rewritten
 
-    def test_main_still_fails_on_malformed_citation_cff_when_changelog_is_populated(
+    def test_main_still_fails_on_malformed_citation_cff_when_guard_passes(
         self,
         script: ModuleType,
         tmp_path: Path,
     ) -> None:
+        _write_pyproject(tmp_path, version="3.1.0")
         _write_changelog(
             tmp_path,
-            unreleased_body="### Fixed\n\n- A real fix.\n\n",
+            release_header="## [3.1.0] - 2026-07-24",
+            release_body="### Fixed\n\n- A real fix.\n\n",
         )
         citation = tmp_path / "CITATION.cff"
         citation.write_text("cff-version: 1.2.0\nversion: 1.0.0\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
Coordinator-discovered composition defect: the two independently-verified release gates deadlock. W1-8 (merged #197) requires a non-empty `[Unreleased]` at **bump** time; W1-4 (merged #194) requires a non-empty `[X.Y.Z]` section at **publish** time; bumpver never rewrites the CHANGELOG — so consolidating first fails the bump, and not consolidating fails the publish *after the tag exists*. Each gate passed its own adversarial verify; the end-to-end pipeline was nobody's brief until release prep exercised it.

Fix (fail-fast-only preserved): the hook now reads the just-bumped version from `pyproject.toml` (rewritten by `file_patterns` before the hook runs) and requires **that version's own section** to be populated — the same predicate W1-4 enforces, moved to the earliest gate. Intended flow: release-prep PR consolidates `[Unreleased]` → `[X.Y.Z]`, then dispatch. A bump without a populated release section fails with an explicit consolidation instruction; the 3.0.0-class empty-section ship stays blocked (more directly than before).

Red-first: the first commit rewrites the guard tests to the corrected semantics (17 of 18 fail against the shipped guard); the second commit implements it. Development note: the undated-header test case caught a newline-swallowing `\s*` in my own first regex — fixed to same-line whitespace.

## Evidence
18/18 guard tests · full offline suite **1202 / 4 / 4** · pre-commit fixed-point green. Squash-merge (red+green PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk