### PR TITLE
ci: enforce the 97% coverage floor on PRs (W1-3, W1-7, W6-2)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,6 +61,34 @@ jobs:
       - name: Run tests
         run: python -m pytest -q -m "not network"
 
+  coverage:
+    name: coverage (>=97%)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package with all test extras
+        # Mirrors coverage.yml's environment (single Python version, all
+        # extras) so the PR-time number matches the post-merge badge job.
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,geo,resilience,telemetry]"
+      - name: Run coverage (offline suite only, marker-explicit)
+        # NEVER a bare `coverage run` here: [tool.coverage.run]
+        # command_line defaults to "-m pytest" with no marker filter, so
+        # an unqualified `coverage run` (as coverage.yml uses, since it
+        # only regenerates the post-merge badge) would silently pull in
+        # the live `network`/`stress` suites. Pass the markers explicitly
+        # to match CONTRIBUTING.md gate #2 exactly, then enforce the
+        # floor as its own step so a shortfall fails loudly.
+        run: |
+          python -m coverage run -m pytest -q -m "not network"
+          python -m coverage report --fail-under=97
+
   mypy:
     name: mypy (deps-present)
     runs-on: ubuntu-latest
@@ -206,13 +234,13 @@ jobs:
   ci:
     name: ci
     if: always()
-    needs: [lint, test, mypy, install_combinations, base_install, network, stress, docs]
+    needs: [lint, test, mypy, coverage, install_combinations, base_install, network, stress, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate job results
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.mypy.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.stress.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
-            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} mypy=${{ needs.mypy.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} stress=${{ needs.stress.result }} docs=${{ needs.docs.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.mypy.result }}" != "success" ] || [ "${{ needs.coverage.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.network.result }}" != "success" ] || [ "${{ needs.stress.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} mypy=${{ needs.mypy.result }} coverage=${{ needs.coverage.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} network=${{ needs.network.result }} stress=${{ needs.stress.result }} docs=${{ needs.docs.result }}"
             exit 1
           fi
           echo "All required jobs succeeded."
@@ -220,13 +248,13 @@ jobs:
   ci-offline:
     name: ci-offline
     if: always()
-    needs: [lint, test, mypy, install_combinations, base_install, docs]
+    needs: [lint, test, mypy, coverage, install_combinations, base_install, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Aggregate offline job results
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.mypy.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
-            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} mypy=${{ needs.mypy.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} docs=${{ needs.docs.result }}"
+          if [ "${{ needs.lint.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.mypy.result }}" != "success" ] || [ "${{ needs.coverage.result }}" != "success" ] || [ "${{ needs.install_combinations.result }}" != "success" ] || [ "${{ needs.base_install.result }}" != "success" ] || [ "${{ needs.docs.result }}" != "success" ]; then
+            echo "One or more required jobs failed: lint=${{ needs.lint.result }} test=${{ needs.test.result }} mypy=${{ needs.mypy.result }} coverage=${{ needs.coverage.result }} install-combinations=${{ needs.install_combinations.result }} base-install=${{ needs.base_install.result }} docs=${{ needs.docs.result }}"
             exit 1
           fi
           echo "All required jobs succeeded."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,10 @@ All notable changes to restgdf are documented here. This project follows
   minutes) and the deprecated synchronous `get_token` helper sends
   `expiration=60`. Behaviourally equivalent to the ArcGIS server-side
   default of 60 minutes; the value is now explicit on the wire.
+- The `dev` extra now composes `restgdf[doc]` and adds `build`+`twine`,
+  so `pip install -e ".[dev]"` alone is enough to run every gate in
+  `CONTRIBUTING.md`'s gate suite (docs build, packaging metadata sanity)
+  without installing `doc` separately.
 
 ### Security
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,12 @@ The gate suite below:
 | 6 | `python -m pytest -q tests/test_compat.py`                                                   | 2.x legacy patch-seam stays stable      |
 | 7 | `python -m build && python -m twine check --strict dist/*`                                   | Packaging metadata sanity               |
 
-CI will re-run the same gates; running them locally saves round-trips.
+On pull requests, CI (`pytest.yml`) re-runs gates 1–3, 5, and 6 (the offline
+suite, the coverage floor, pre-commit, the base-install smoke, and the compat
+suite). Gate 7's `build` + `twine check` also runs on packaging / `restgdf/**`
+PRs via `publish_on_pypi.yml`, while the PyPI publish and Sigstore attestation
+run only on the tagged release path. The docs build (gate 4) is verified by
+Read the Docs. Running the gates locally still saves round-trips.
 
 ## Extras matrix
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 Thanks for your interest in restgdf! This document captures the local
 workflow, commit conventions, and the gate suite contributors are
-expected to run before opening a pull request against
-`integration/3.0-rewrite` (or `main` once 3.0 is released).
+expected to run before opening a pull request against `main`.
 
 See also:
 
@@ -27,10 +26,11 @@ python -m pip install -e ".[dev,resilience,telemetry,geo]"
 python -m pre_commit install
 ```
 
-`.[dev]` covers testing + linting + docs tooling; adding
-`resilience`, `telemetry`, and `geo` gives you the full extras matrix
-locally. See [ARCHITECTURE.md §Extras](ARCHITECTURE.md#extras-matrix)
-for the trade-offs.
+`.[dev]` covers testing + linting + docs tooling + packaging (it
+composes `restgdf[doc]` and adds `build`/`twine`); adding `resilience`,
+`telemetry`, and `geo` gives you the full extras matrix locally. See
+[ARCHITECTURE.md §Extras](ARCHITECTURE.md#extras-matrix) for the
+trade-offs.
 
 ## Pull-request checklist
 
@@ -64,8 +64,9 @@ Before you open the PR, verify:
   `test:`, `docs:`, `ci:`, `build:`, `chore:`.
 - First line ≤ 72 characters, imperative mood.
 - Body wrapped at ~72 columns. Explain *why* first, then *what*.
-  Reference plan item IDs (e.g. `BL-46`) and backlog rows when
-  applicable.
+  Illustrative plan item IDs (e.g. `BL-46`) are welcome shorthand when a
+  change traces to a specific backlog entry — no `plan.md`/backlog file
+  ships in this repo, so treat the ID as context, not a cross-reference.
 - Sign commits with `Co-authored-by:` trailers for any shared work.
 - Keep each commit self-contained — each commit must pass the full
   gate suite on its own so `git bisect` stays useful.
@@ -83,7 +84,7 @@ implementation in a single commit.
 All commands assume the project root and an activated venv (or invoke
 `.venv\Scripts\python.exe` directly on Windows).
 
-Gates mirror plan.md §2 exactly:
+The gate suite below:
 
 | # | Command                                                                                      | Purpose                                 |
 |---|----------------------------------------------------------------------------------------------|-----------------------------------------|
@@ -106,7 +107,8 @@ light core (`aiohttp`, `pydantic`) plus opt-in extras:
 - `resilience` — `stamina`-based retry on transient network / HTTP 5xx.
 - `telemetry` — OpenTelemetry tracing hooks.
 - `geo` — `geopandas` / `pyogrio` GeoDataFrame conversion.
-- `dev` — testing + linting + docs (not shipped to end users).
+- `dev` — testing + linting + docs + packaging tooling (composes
+  `restgdf[doc]`, adds `build`/`twine`; not shipped to end users).
 
 Prefer `[extras]` over unconditional `install_requires` whenever a
 feature is optional. See [ARCHITECTURE.md §Extras](ARCHITECTURE.md#extras-matrix).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ telemetry = [
 ]
 
 dev = [
+    "restgdf[doc]",
     "aioresponses>=0.7.8",
+    "build",
     "bumpver",
     "coverage",
     "hypothesis",
@@ -92,6 +94,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "setuptools>=82.0.1",
+    "twine",
 ]
 
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ pre_commit_hook = "scripts/bumpver_stamp_date.py"
 
 [tool.coverage.run]
 branch = true
-omit = ["*tests/*.py", "restgdf/app.py"]
+omit = ["*tests/*.py"]
 command_line = "-m pytest"
 source = ["restgdf"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,9 +141,11 @@ source = ["restgdf"]
 
 [tool.coverage.report]
 show_missing = true
-# Floor reflects current measured coverage (98.16% as of v3-followup).
-# Targeted tests for resilience/_retry, telemetry, credentials, and
-# getgdf edge paths lifted measured coverage from 96.53% to 98.16%.
+# fail_under is the 97% floor; latest measured coverage is 98.1271%
+# (2026-07-24). Real-shape spatial-filter tests for restgdf/utils/_geometry.py
+# (curve/envelope/Z-M/multipart/error branches) restored the margin after
+# PR #175 dropped measured coverage to 96.9069%; earlier resilience/_retry,
+# telemetry, credentials, and getgdf edge-path tests keep it above the floor.
 fail_under = 97
 # Regexes for lines to exclude from consideration
 exclude_also = [

--- a/tests/test_spatial_filter_payload.py
+++ b/tests/test_spatial_filter_payload.py
@@ -7,6 +7,8 @@ import json
 from aiohttp import ClientResponseError
 import pytest
 
+from restgdf.utils._geometry import _apply_dimension_flags
+from restgdf.utils._geometry import _iter_coordinate_lists
 from restgdf.utils.getinfo import build_spatial_filter_payload
 
 
@@ -270,3 +272,238 @@ def test_build_spatial_filter_payload_rejects_feature_collections() -> None:
                 ],
             },
         )
+
+
+# --- ArcGIS-JSON passthrough branches (mapping already in ArcGIS shape) ---
+
+
+def test_build_spatial_filter_payload_passes_through_arcgis_point() -> None:
+    # A native ArcGIS point geometry (esri geometry JSON), not GeoJSON.
+    payload = build_spatial_filter_payload(
+        {"x": -118.2437, "y": 34.0522, "spatialReference": {"wkid": 4326}},
+        in_sr=4326,
+    )
+
+    assert payload == {
+        "geometry": {
+            "x": -118.2437,
+            "y": 34.0522,
+            "spatialReference": {"wkid": 4326},
+        },
+        "geometryType": "esriGeometryPoint",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_passes_through_arcgis_multipoint() -> None:
+    # Native ArcGIS multipoint geometry JSON.
+    payload = build_spatial_filter_payload(
+        {
+            "points": [[-118.24, 34.05], [-117.16, 32.72]],
+            "spatialReference": {"wkid": 4326},
+        },
+    )
+
+    assert payload == {
+        "geometry": {
+            "points": [[-118.24, 34.05], [-117.16, 32.72]],
+            "spatialReference": {"wkid": 4326},
+        },
+        "geometryType": "esriGeometryMultipoint",
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_rejects_ambiguous_arcgis_mapping() -> None:
+    # Looks like ArcGIS geometry (has "x") but carries no "y" -> unsupported.
+    with pytest.raises(ValueError, match="Unsupported ArcGIS geometry mapping"):
+        build_spatial_filter_payload({"x": -118.24})
+
+
+# --- GeoJSON array geometries: Z/M flags, MultiPoint, MultiLineString, MultiPolygon ---
+
+
+def test_build_spatial_filter_payload_sets_z_and_m_flags_for_multipoint() -> None:
+    # GeoJSON MultiPoint with (x, y, z, m) ordinates -> hasZ and hasM.
+    payload = build_spatial_filter_payload(
+        {
+            "type": "MultiPoint",
+            "coordinates": [
+                [-118.24, 34.05, 100.0, 1.0],
+                [-117.16, 32.72, 120.0, 2.0],
+            ],
+        },
+        in_sr=4326,
+    )
+
+    assert payload == {
+        "geometry": {
+            "points": [
+                [-118.24, 34.05, 100.0, 1.0],
+                [-117.16, 32.72, 120.0, 2.0],
+            ],
+            "hasZ": True,
+            "hasM": True,
+        },
+        "geometryType": "esriGeometryMultipoint",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_converts_multilinestring() -> None:
+    payload = build_spatial_filter_payload(
+        {
+            "type": "MultiLineString",
+            "coordinates": [
+                [[-118.5, 34.0], [-118.4, 34.1]],
+                [[-118.3, 34.2], [-118.2, 34.3]],
+            ],
+        },
+        in_sr=4326,
+    )
+
+    assert payload == {
+        "geometry": {
+            "paths": [
+                [[-118.5, 34.0], [-118.4, 34.1]],
+                [[-118.3, 34.2], [-118.2, 34.3]],
+            ],
+        },
+        "geometryType": "esriGeometryPolyline",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_flattens_multipolygon_rings() -> None:
+    # GeoJSON MultiPolygon (two disjoint square polygons) -> flat esri rings.
+    payload = build_spatial_filter_payload(
+        {
+            "type": "MultiPolygon",
+            "coordinates": [
+                [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]]],
+                [[[5.0, 5.0], [6.0, 5.0], [6.0, 6.0], [5.0, 6.0], [5.0, 5.0]]],
+            ],
+        },
+        in_sr=4326,
+    )
+
+    assert payload == {
+        "geometry": {
+            "rings": [
+                [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [0.0, 0.0]],
+                [[5.0, 5.0], [6.0, 5.0], [6.0, 6.0], [5.0, 6.0], [5.0, 5.0]],
+            ],
+        },
+        "geometryType": "esriGeometryPolygon",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+# --- GeoJSON Feature wrapper handling ---
+
+
+def test_build_spatial_filter_payload_unwraps_geojson_feature() -> None:
+    payload = build_spatial_filter_payload(
+        {
+            "type": "Feature",
+            "properties": {"name": "downtown"},
+            "geometry": {"type": "Point", "coordinates": [-118.24, 34.05]},
+        },
+        in_sr=4326,
+    )
+
+    assert payload == {
+        "geometry": {"x": -118.24, "y": 34.05},
+        "geometryType": "esriGeometryPoint",
+        "inSR": 4326,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+def test_build_spatial_filter_payload_rejects_feature_without_geometry() -> None:
+    with pytest.raises(ValueError, match="Feature input must include a geometry"):
+        build_spatial_filter_payload(
+            {"type": "Feature", "properties": {}, "geometry": None},
+        )
+
+
+# --- error branches: malformed point, wrong input type ---
+
+
+def test_build_spatial_filter_payload_rejects_underspecified_point() -> None:
+    with pytest.raises(ValueError, match="at least x and y"):
+        build_spatial_filter_payload({"type": "Point", "coordinates": [-118.24]})
+
+
+def test_build_spatial_filter_payload_rejects_unsupported_geojson_type() -> None:
+    with pytest.raises(ValueError, match="Unsupported geometry type"):
+        build_spatial_filter_payload(
+            {
+                "type": "GeometryCollection",
+                "geometries": [{"type": "Point", "coordinates": [-118.24, 34.05]}],
+            },
+        )
+
+
+def test_build_spatial_filter_payload_rejects_non_mapping_input() -> None:
+    with pytest.raises(TypeError, match="__geo_interface__"):
+        build_spatial_filter_payload("POINT(-118.24 34.05)")
+
+
+# --- spatial reference: WKT-only reference has no EPSG, preserved as raw inSR ---
+
+
+def test_build_spatial_filter_payload_preserves_wkt_spatial_reference() -> None:
+    # A WKT-defined spatial reference carries no wkid/latestWkid, so the payload
+    # must fall back to emitting the raw reference dict as inSR (BL-23 raw path).
+    wkt_sr = {
+        "wkt": (
+            'PROJCS["NAD_1983_UTM_Zone_11N",'
+            'GEOGCS["GCS_North_American_1983",'
+            'DATUM["D_North_American_1983",'
+            'SPHEROID["GRS_1980",6378137.0,298.257222101]]]]'
+        ),
+    }
+    payload = build_spatial_filter_payload(
+        {"x": 500000.0, "y": 3762000.0},
+        in_sr=wkt_sr,
+    )
+
+    assert payload == {
+        "geometry": {"x": 500000.0, "y": 3762000.0},
+        "geometryType": "esriGeometryPoint",
+        "inSR": wkt_sr,
+        "spatialRel": "esriSpatialRelIntersects",
+    }
+
+
+# --- direct helper coverage for defensive branches unreachable via public shapes ---
+
+
+def test_apply_dimension_flags_is_noop_when_flags_unsupported() -> None:
+    # Envelope-style geometries never carry per-vertex Z/M, so callers pass
+    # supports_flags=False and the geometry is returned untouched.
+    geometry: dict[str, object] = {
+        "xmin": -118.5,
+        "ymin": 34.0,
+        "xmax": -118.0,
+        "ymax": 34.5,
+    }
+    result = _apply_dimension_flags(
+        geometry,
+        [[-118.5, 34.0, 10.0, 1.0]],
+        supports_flags=False,
+    )
+
+    assert result is geometry
+    assert "hasZ" not in result
+    assert "hasM" not in result
+
+
+def test_iter_coordinate_lists_ignores_scalar_leaves() -> None:
+    # Defensive guard: a bare scalar (not a coordinate sequence) yields nothing.
+    assert list(_iter_coordinate_lists(34.05)) == []


### PR DESCRIPTION
## Summary
The last M1 work items — and a live proof of why they matter:

- **W1-3**: dedicated PR coverage job (Python 3.14, marker-explicit `coverage run -m pytest -q -m "not network"` — never the bare command that would pull network/stress via the `command_line` default), wired fail-closed into both `ci` and `ci-offline`. `coverage.yml` (post-merge badge) untouched.
- **The finding that validated it**: `main`'s true coverage was **96.9069%** — under the floor since #175 merged, with 7 consecutive silent post-merge `coverage.yml` failures (exactly the audit's TESTS-01/CICD-04 gap: post-merge-only enforcement). This PR restores it to **98.1271%** with real-shape tests taking `_geometry.py` from 73.78% → **100%** (fixtures byte-identical to the adversarially-verified probe cases from the #175 review; assertions pin full payload content).
- **W1-7**: dropped the dead `restgdf/app.py` coverage omit (tests glob intact).
- **W6-2 + PACKAGING-03**: `dev` extra now composes `restgdf[doc]` + `build` + `twine` (pip dry-run proven: the documented "`.[dev]` covers docs+packaging" claim is finally true); CONTRIBUTING's stale branch target and gate claims corrected to the *actual* CI mapping.

## Verification
Adversarial verify (Opus, default-refute): **CONFIRMED, 0 mustFix** — independently re-ran the coverage pair (98.127%), proved the floor is not a no-op (fail-under=99 exits 2), re-derived aggregator wiring, dry-ran the dev extra, default-refuted 7 geometry fixtures against the ArcGIS REST spec. Suite: 1213 passed / 4 skipped / 4 deselected. One cosmetic note logged for M4 docs (compat "gate 6" phrasing).

This PR's own CI run exercises the new coverage job end-to-end. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk