### PR TITLE
ci: drop pytest.yml path filters (required checks must always report)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,21 +1,18 @@
 name: pytest
 
 on:
+  # No `paths:` filter — deliberately. `ci-offline` (below) is a REQUIRED
+  # branch-protection status check on main; with a path filter, a PR that
+  # touches only unlisted files (e.g. root-level markdown) never triggers
+  # this workflow, the required check never reports, and the PR is
+  # unmergeable without an admin bypass. Required checks and path filters
+  # do not compose — the gate must run on every PR.
   pull_request:
     branches: ["main"]
     types:
       - opened
       - synchronize
       - reopened
-    paths:
-      - ".github/workflows/**"
-      - "restgdf/**"
-      - "tests/**"
-      - "docs/**"
-      - "readthedocs.yaml"
-      - "pyproject.toml"
-      - "requirements.txt"
-      - ".pre-commit-config.yaml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
Found live during 3.1.0 release prep: `ci-offline` is a **required** status check, but `pytest.yml` only triggered on a path allowlist — so the docs-only release-prep PR (#201) never got the check and was unmergeable without an admin bypass. Required checks and path filters don't compose: the gate must run on every PR. This drops the filter (with an explanatory comment), at the cost of a ~3-minute CI run on docs-only PRs — cheap compared to normalizing admin bypasses through M4's many docs PRs.

Verification: actionlint via pre-commit at commit time; this PR itself (a `.github/**` change) triggers the full gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk