### PR TITLE
fix: auth logger factory, NaN/Inf retry-after, broken-optional-dep detection (W2-6/7/8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to restgdf are documented here. This project follows
   `get_logger("auth")` factory instead of a raw `logging.getLogger(...)`
   call, so it carries the documented `NullHandler` like every other
   `restgdf.*` logger (it previously silently lacked one).
+- `restgdf.resilience._errors._parse_retry_after` now rejects non-finite
+  `Retry-After` header values (`"nan"`, `"inf"`, `"-inf"`, `"Infinity"`,
+  etc.) instead of returning them as a poisoned `float`. Previously a
+  `NaN`/`+Inf` value passed the existing negative-value guard unmolested
+  and could reach the 429 cooldown deadline computation and the public
+  `RateLimitError.retry_after` attribute.
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- `restgdf.utils.token._auth_logger` (the `restgdf.auth` logger backing
+  token-refresh debug logging) is now created through the library's
+  `get_logger("auth")` factory instead of a raw `logging.getLogger(...)`
+  call, so it carries the documented `NullHandler` like every other
+  `restgdf.*` logger (it previously silently lacked one).
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ All notable changes to restgdf are documented here. This project follows
   `NaN`/`+Inf` value passed the existing negative-value guard unmolested
   and could reach the 429 cooldown deadline computation and the public
   `RateLimitError.retry_after` attribute.
+- The optional-dependency gate (`require_pandas`/`require_geopandas`/
+  `require_pyogrio` and friends) now catches `ImportError` instead of only
+  `ModuleNotFoundError`, so a present-but-broken geo dependency (e.g. a
+  native GDAL/shapely load failure) surfaces as `OptionalDependencyError`
+  naming the `restgdf[geo]` hint instead of escaping as a raw, unwrapped
+  `ImportError`.
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/restgdf/resilience/_errors.py
+++ b/restgdf/resilience/_errors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import time
 from email.utils import parsedate_to_datetime
 
@@ -12,7 +13,8 @@ def _parse_retry_after(value: str) -> float | None:
     Supports both integer-seconds (``"120"``) and RFC 7231 HTTP-date
     formats (``"Sun, 06 Nov 1994 08:49:37 GMT"``).
 
-    Returns ``None`` for empty, unparsable, or negative values.
+    Returns ``None`` for empty, unparsable, negative, or non-finite
+    (NaN/Inf/-Inf) values.
     """
     if not value or not value.strip():
         return None
@@ -22,7 +24,7 @@ def _parse_retry_after(value: str) -> float | None:
     # Try integer/float seconds first
     try:
         seconds = float(value)
-        if seconds < 0:
+        if not math.isfinite(seconds) or seconds < 0:
             return None
         return seconds
     except ValueError:

--- a/restgdf/utils/_optional.py
+++ b/restgdf/utils/_optional.py
@@ -30,7 +30,7 @@ def _import_optional_module(module_name: str, feature: str) -> ModuleType:
     """Import an optional dependency with a restgdf-specific error message."""
     try:
         return import_module(module_name)
-    except ModuleNotFoundError as exc:
+    except ImportError as exc:
         missing_module = exc.name or module_name
         raise _optional_dependency_error(feature, missing_module) from exc
 

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -14,11 +14,11 @@ from __future__ import annotations
 import asyncio
 import datetime
 import importlib
-import logging
 from dataclasses import dataclass, field
 
 import aiohttp
 
+from restgdf._logging import get_logger
 from restgdf._models._drift import _parse_response
 from restgdf._models.credentials import AGOLUserPass, TokenSessionConfig
 from restgdf._models.responses import TokenResponse
@@ -34,7 +34,7 @@ from restgdf.errors import (
 
 from pydantic import SecretStr
 
-_auth_logger = logging.getLogger("restgdf.auth")
+_auth_logger = get_logger("auth")
 
 _MAX_TOKEN_RETRIES: int = 3  # Max /generateToken POST attempts
 

--- a/tests/test_base_install.py
+++ b/tests/test_base_install.py
@@ -6,7 +6,9 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from restgdf.errors import OptionalDependencyError
 from restgdf.featurelayer.featurelayer import FeatureLayer
+from restgdf.utils._optional import require_geopandas
 from restgdf.utils.getgdf import (
     get_gdf,
     get_query_data_batches,
@@ -524,3 +526,49 @@ async def test_featurelayer_get_gdf_requires_geo_extra_before_query():
             match=r"FeatureLayer\.get_gdf\(\).*restgdf\[geo\]",
         ):
             await layer.get_gdf()
+
+
+def test_require_geopandas_wraps_broken_but_present_import_error():
+    """W2-8/OPTDEPS-01: a present-but-unimportable geo dependency (e.g. a
+    broken GDAL/shapely native layer surfacing as a bare ImportError with
+    no ``.name``, such as a DLL load failure) must still surface as
+    OptionalDependencyError naming the restgdf[geo] hint, not escape as a
+    raw ImportError."""
+    broken_import_error = ImportError("DLL load failed while importing ogrext")
+    assert broken_import_error.name is None
+
+    with patch(
+        "restgdf.utils._optional.import_module",
+        side_effect=broken_import_error,
+    ):
+        with pytest.raises(OptionalDependencyError, match=r"restgdf\[geo\]"):
+            require_geopandas("test feature")
+
+
+def test_require_geopandas_missing_package_still_raises_optional_dependency_error():
+    """Existing missing-package path (ModuleNotFoundError) is unaffected by
+    widening the except clause to ImportError."""
+    with patch(
+        "restgdf.utils._optional.import_module",
+        side_effect=_missing_optional_import("geopandas"),
+    ):
+        with pytest.raises(
+            OptionalDependencyError,
+            match=r"'geopandas'.*restgdf\[geo\]",
+        ):
+            require_geopandas("test feature")
+
+
+def test_require_geopandas_unrelated_exception_still_propagates_raw():
+    """A genuinely unrelated (non-ImportError) exception during import must
+    NOT be swallowed by the widened except clause."""
+
+    def _raise_runtime_error(module_name: str) -> ModuleType:
+        raise RuntimeError("unrelated failure, not an import problem")
+
+    with patch(
+        "restgdf.utils._optional.import_module",
+        side_effect=_raise_runtime_error,
+    ):
+        with pytest.raises(RuntimeError, match="unrelated failure"):
+            require_geopandas("test feature")

--- a/tests/test_resilience_retry.py
+++ b/tests/test_resilience_retry.py
@@ -16,6 +16,7 @@ from restgdf.errors import (
     TransportError,
 )
 from restgdf.resilience import ResilientSession
+from restgdf.resilience._errors import _parse_retry_after
 
 
 # ---------------------------------------------------------------------------
@@ -227,3 +228,34 @@ class TestRetryStaminaActive:
                 await resp.read()
         assert stub._call_count >= 3
         assert any(d > 0 for d in delays)
+
+
+class TestParseRetryAfterNonFinite:
+    """W2-7/TRANSPORT-02: _parse_retry_after must reject NaN/Inf/-Inf.
+
+    Non-finite floats parse successfully from ``float("nan")``/``float("inf")``
+    and pass the existing ``seconds < 0`` guard unmolested (NaN comparisons
+    are always False; +Inf is not negative), so they can poison the 429
+    cooldown deadline (``min(nan, cap)``) and the public
+    ``RateLimitError.retry_after`` attribute. Reject at the single parse
+    source.
+    """
+
+    @pytest.mark.parametrize("value", ["nan", "NaN", "inf", "-inf", "Infinity"])
+    def test_rejects_non_finite_values(self, value: str) -> None:
+        assert _parse_retry_after(value) is None
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("120", 120.0),
+            ("-5", None),
+            ("not-a-number-or-date", None),
+        ],
+    )
+    def test_existing_parametric_cases_unaffected(
+        self,
+        value: str,
+        expected: float | None,
+    ) -> None:
+        assert _parse_retry_after(value) == expected

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from restgdf._logging import get_logger
 from restgdf.utils.token import (
     AGOLUserPass,
     ArcGISTokenSession,
     TokenSessionConfig,
+    _auth_logger,
     get_token,
 )
 
@@ -289,3 +292,29 @@ async def test_arcgistokensession_respects_explicit_token_in_request():
     assert session.post_calls[-1][1]["data"]["token"] == "explicit"
     assert session.get_calls[-1][1]["headers"] == {"X-Test": "yes"}
     assert session.get_calls[-1][1]["params"]["token"] == "explicit"
+
+
+def test_auth_logger_routes_through_get_logger_factory():
+    """W2-6 / TELEMETRY-03: importing ``restgdf.utils.token`` must itself
+    route the module-level auth logger through the ``get_logger`` factory
+    (not a raw ``logging.getLogger("restgdf.auth")`` call), so it already
+    carries the documented ``NullHandler`` before any test code calls the
+    factory itself. Asserting handler state BEFORE calling ``get_logger``
+    here is load-bearing: ``get_logger`` is idempotent and would silently
+    attach the missing handler if called first, masking a raw-getLogger
+    regression in ``token.py``."""
+    assert any(
+        isinstance(h, logging.NullHandler) for h in _auth_logger.handlers
+    ), (
+        "restgdf.utils.token._auth_logger has no NullHandler at import "
+        "time; it is not routed through restgdf._logging.get_logger"
+    )
+
+    # Now confirm identity against a fresh factory call (idempotent — must
+    # not stack a second NullHandler nor a duplicate _SpanContextFilter).
+    factory_logger = get_logger("auth")
+    assert _auth_logger is factory_logger
+    assert (
+        sum(isinstance(h, logging.NullHandler) for h in _auth_logger.handlers)
+        == 1
+    )

--- a/tests/test_token.py
+++ b/tests/test_token.py
@@ -303,9 +303,7 @@ def test_auth_logger_routes_through_get_logger_factory():
     here is load-bearing: ``get_logger`` is idempotent and would silently
     attach the missing handler if called first, masking a raw-getLogger
     regression in ``token.py``."""
-    assert any(
-        isinstance(h, logging.NullHandler) for h in _auth_logger.handlers
-    ), (
+    assert any(isinstance(h, logging.NullHandler) for h in _auth_logger.handlers), (
         "restgdf.utils.token._auth_logger has no NullHandler at import "
         "time; it is not routed through restgdf._logging.get_logger"
     )
@@ -314,7 +312,4 @@ def test_auth_logger_routes_through_get_logger_factory():
     # not stack a second NullHandler nor a duplicate _SpanContextFilter).
     factory_logger = get_logger("auth")
     assert _auth_logger is factory_logger
-    assert (
-        sum(isinstance(h, logging.NullHandler) for h in _auth_logger.handlers)
-        == 1
-    )
+    assert sum(isinstance(h, logging.NullHandler) for h in _auth_logger.handlers) == 1


### PR DESCRIPTION
M2 wave 1, lane B — three red-first fixes, each red committed separately and proven failing for the right reason (adversarially verified: CONFIRMED, 0 mustFix). W2-6: restgdf.auth logger now routes through get_logger (NullHandler parity); token.py diff confirmed minimal for the W2-10 handoff. W2-7: _parse_retry_after rejects NaN/Inf so no non-finite retry_after escapes into RateLimitError. W2-8: require_* catches ImportError (broken-but-present optional deps) not just ModuleNotFoundError, still naming the extra. Suite 1228/4/4 (+12) · coverage 98% · mypy 0 · compat 50 · pre-commit fixed point. Lane self-caught and fixed an edit mistake before any commit landed (disclosed in report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk