### PR TITLE
fix: cached-frame copies, permissive-field tolerance, surface-sync guard, span-safe logging (W5-1/4/8/12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- `FeatureLayer.get_gdf`/`get_unique_values`/`get_value_counts`/
+  `get_nested_count` now return an independent copy of the cached
+  frame/list on every call (W5-1, ASYNC-02) instead of the shared cached
+  object by reference. Previously, mutating a returned `GeoDataFrame` or
+  `DataFrame` in place (e.g. `df.rename(..., inplace=True)`) silently
+  corrupted what every later call on the same instance returned. Cache
+  *population* is unaffected and remains non-atomic under concurrent
+  `asyncio.gather` awaiters — this fix protects reads only, not writes.
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,18 @@ All notable changes to restgdf are documented here. This project follows
   dropped (documented in the affected docstrings); a missing/`None`
   `type` defaults to `""` instead of crashing on `None.replace(...)`.
   `get_fields(types=False)` gained the same nameless-field guard.
+- The `_SpanContextFilter` log-correlation filter now always stamps
+  `record.trace_id`/`record.span_id` (defaulting to `""` outside a
+  valid OpenTelemetry span) instead of leaving them unset (W5-12,
+  TELEMETRY-01). Previously, any `restgdf.*` log record emitted
+  outside a `feature_layer.stream` span — e.g. the `auth.refresh.start`
+  DEBUG record or the pagination `exceededTransferLimit` warning — had
+  no `trace_id`/`span_id` attributes at all, so the documented
+  `%(trace_id)s` log-correlation recipe raised
+  `ValueError: Formatting field not found in record: 'trace_id'`
+  (surfaced by stdlib `logging` as a swallowed stderr
+  "--- Logging error ---" dump). `span_context_fields()` is unaffected
+  and still returns `{}` outside a span.
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ All notable changes to restgdf are documented here. This project follows
   corrupted what every later call on the same instance returned. Cache
   *population* is unaffected and remains non-atomic under concurrent
   `asyncio.gather` awaiters — this fix protects reads only, not writes.
+- `get_fields(types=True)`, `_field_rows`, and `get_fields_frame` no
+  longer raise `KeyError`/`AttributeError` on a permissive-tier field
+  entry missing `name` and/or `type` (W5-4, ADAPTERS-01) — a real
+  ArcGIS server can emit such entries and `FieldSpec` already declares
+  both as optional. A field with no resolvable `name` is now silently
+  dropped (documented in the affected docstrings); a missing/`None`
+  `type` defaults to `""` instead of crashing on `None.replace(...)`.
+  `get_fields(types=False)` gained the same nameless-field guard.
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/restgdf/_logging.py
+++ b/restgdf/_logging.py
@@ -176,9 +176,22 @@ class _SpanContextFilter(logging.Filter):
 
         span = trace.get_current_span()
         ctx = span.get_span_context()
+        # W5-12 (TELEMETRY-01): ALWAYS stamp trace_id/span_id, defaulting to
+        # "" outside a valid span. Previously these attributes were only
+        # set inside `if ctx is not None and ctx.is_valid:` with no else,
+        # so any record emitted outside a `feature_layer.stream` span (the
+        # common case -- auth.refresh.start DEBUG, the pagination
+        # exceededTransferLimit warning, ...) had no trace_id/span_id at
+        # all, and the documented `%(trace_id)s` formatter recipe raised
+        # KeyError, swallowed by logging into a stderr "--- Logging
+        # error ---" dump. An empty-string default is indistinguishable
+        # from a degenerate all-zero context -- accepted as cosmetic.
         if ctx is not None and ctx.is_valid:
             record.trace_id = format(ctx.trace_id, "032x")  # type: ignore[attr-defined]
             record.span_id = format(ctx.span_id, "016x")  # type: ignore[attr-defined]
+        else:
+            record.trace_id = ""  # type: ignore[attr-defined]
+            record.span_id = ""  # type: ignore[attr-defined]
         return True
 
 

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -294,11 +294,23 @@ class FeatureLayer:
         metadata envelope (R-65) when the layer advertises a spatial
         reference via ``extent.spatialReference`` or top-level
         ``spatialReference``.
+
+        Each call returns an independent copy of the cached frame (W5-1)
+        — mutating the returned ``GeoDataFrame`` in place does not affect
+        the cache or any other call's result. This copy-on-return only
+        protects the *read* side: the cache *population* (``if self.gdf
+        is None: ...``) is not itself concurrency-safe — concurrent
+        awaiters via ``asyncio.gather`` can still both observe a cache
+        miss and double-fetch. Do not rely on this fix for task-safety.
         """
         if self.gdf is None:
             _require_featurelayer_geo_support("FeatureLayer.get_gdf()")
             self.gdf = await get_gdf(self.url, self.session, **self.kwargs)
-        return self.gdf
+        # W5-1 (ASYNC-02): return a copy so a caller mutating the frame in
+        # place cannot corrupt the cached instance a later call returns.
+        # ``.copy()`` propagates ``.attrs`` (including R-65's
+        # ``spatial_reference``), so this preserves that contract too.
+        return self.gdf.copy()
 
     # -----------------------------------------------------------------
     # Streaming primitives (BL-24 / Q-A11). ``iter_pages`` is the single
@@ -570,7 +582,9 @@ class FeatureLayer:
         -------
         list or DataFrame
             A plain list when *fields* is a single string, or a DataFrame
-            when *fields* is a tuple.
+            when *fields* is a tuple. Each call returns an independent
+            copy (W5-1) — mutating the returned value does not affect the
+            cache or any other call's result.
 
         Raises
         ------
@@ -594,7 +608,13 @@ class FeatureLayer:
                 sortby,
                 **self.kwargs,
             )
-        return self.uniquevalues[cache_key]
+        # W5-1 (ASYNC-02): copy-on-return so callers cannot mutate the
+        # cached value in place. The cache stores either a plain ``list``
+        # (single-field) or a ``DataFrame`` (multi-field) — branch on that.
+        cached = self.uniquevalues[cache_key]
+        if isinstance(cached, list):
+            return list(cached)
+        return cached.copy()
 
     async def get_value_counts(self, field: str) -> DataFrame:
         """Get value counts for a single field.
@@ -610,7 +630,9 @@ class FeatureLayer:
         -------
         DataFrame
             A pandas DataFrame with one row per distinct value and an
-            associated count column.
+            associated count column. Each call returns an independent
+            copy (W5-1) — mutating the returned frame does not affect
+            the cache or any other call's result.
 
         Raises
         ------
@@ -629,7 +651,8 @@ class FeatureLayer:
                 self.session,
                 **self.kwargs,
             )
-        return self.valuecounts[field]
+        # W5-1 (ASYNC-02): copy-on-return, same rationale as get_gdf above.
+        return self.valuecounts[field].copy()
 
     async def get_nested_count(self, fields: tuple) -> DataFrame:
         """Get nested (cross-tabulated) value counts for multiple fields.
@@ -647,6 +670,9 @@ class FeatureLayer:
         DataFrame
             A pandas DataFrame with one row per unique combination of
             values across the requested fields and an associated count.
+            Each call returns an independent copy (W5-1) — mutating the
+            returned frame does not affect the cache or any other call's
+            result.
 
         Raises
         ------
@@ -665,7 +691,8 @@ class FeatureLayer:
                 self.session,
                 **self.kwargs,
             )
-        return self.nestedcount[fields]
+        # W5-1 (ASYNC-02): copy-on-return, same rationale as get_gdf above.
+        return self.nestedcount[fields].copy()
 
     # -----------------------------------------------------------------
     # Deprecated legacy method names (Phase 6). Emit DeprecationWarning

--- a/restgdf/utils/_metadata.py
+++ b/restgdf/utils/_metadata.py
@@ -151,7 +151,7 @@ def get_fields(layer_metadata: LayerMetadataLike, types: bool = False):
     dropped from the result (mirroring ``get_object_id_field``'s
     ``isinstance(field.get("name"), str)`` guard); this is an
     intentional, contract-aligned skip, not silent data loss of a
-    resolvable field. ``types=True`` routes through :func:`_field_rows`
+    resolvable field. ``types=True`` routes through ``_field_rows``
     so the dict/list/DataFrame views agree on the surviving field set.
     """
     layer_metadata = _as_dict(layer_metadata)
@@ -181,7 +181,7 @@ def _field_rows(layer_metadata: LayerMetadataLike) -> list[tuple[str, str]]:
 def get_fields_frame(layer_metadata: LayerMetadataLike) -> DataFrame:
     """Get the fields of a layer as a DataFrame.
 
-    Routes through :func:`_field_rows`, so a field with no resolvable
+    Routes through ``_field_rows``, so a field with no resolvable
     ``name`` is dropped (W5-4/ADAPTERS-01) -- see that function's
     docstring for the full skip-behavior contract.
     """

--- a/restgdf/utils/_metadata.py
+++ b/restgdf/utils/_metadata.py
@@ -142,23 +142,49 @@ def get_name(metadata: LayerMetadataLike) -> str:
 
 
 def get_fields(layer_metadata: LayerMetadataLike, types: bool = False):
-    """Get the fields of a layer."""
+    """Get the fields of a layer.
+
+    W5-4 (ADAPTERS-01): a permissive-tier ``FieldSpec`` allows ``name``
+    and ``type`` to be missing or ``None`` -- real ArcGIS servers do
+    occasionally emit such entries. A field whose ``name`` cannot be
+    resolved to a ``str`` has no addressable identity and is silently
+    dropped from the result (mirroring ``get_object_id_field``'s
+    ``isinstance(field.get("name"), str)`` guard); this is an
+    intentional, contract-aligned skip, not silent data loss of a
+    resolvable field. ``types=True`` routes through :func:`_field_rows`
+    so the dict/list/DataFrame views agree on the surviving field set.
+    """
     layer_metadata = _as_dict(layer_metadata)
     fields = layer_metadata.get("fields") or []
     if types:
-        return {f["name"]: f["type"].replace("esriFieldType", "") for f in fields}
-    return [f["name"] for f in fields]
+        return dict(_field_rows(layer_metadata))
+    return [f["name"] for f in fields if isinstance(f.get("name"), str)]
 
 
 def _field_rows(layer_metadata: LayerMetadataLike) -> list[tuple[str, str]]:
-    """Return ``(name, type)`` rows for the layer fields."""
+    """Return ``(name, type)`` rows for the layer fields.
+
+    W5-4 (ADAPTERS-01): entries with a missing/non-``str`` ``name`` are
+    dropped (see :func:`get_fields`); a missing or explicit-``None``
+    ``type`` defaults to ``""`` rather than raising ``AttributeError``
+    on ``None.replace(...)``.
+    """
     layer_metadata = _as_dict(layer_metadata)
     fields: list[dict[str, Any]] = layer_metadata.get("fields") or []
-    return [(f["name"], f["type"].replace("esriFieldType", "")) for f in fields]
+    return [
+        (f["name"], (f.get("type") or "").replace("esriFieldType", ""))
+        for f in fields
+        if isinstance(f.get("name"), str)
+    ]
 
 
 def get_fields_frame(layer_metadata: LayerMetadataLike) -> DataFrame:
-    """Get the fields of a layer as a DataFrame."""
+    """Get the fields of a layer as a DataFrame.
+
+    Routes through :func:`_field_rows`, so a field with no resolvable
+    ``name`` is dropped (W5-4/ADAPTERS-01) -- see that function's
+    docstring for the full skip-behavior contract.
+    """
     DataFrame = require_pandas_dataframe("get_fields_frame()")
     return DataFrame(
         _field_rows(layer_metadata),

--- a/tests/id_schema_fixtures.py
+++ b/tests/id_schema_fixtures.py
@@ -99,6 +99,22 @@ _ID_SCHEMA_FIXTURES: dict[str, dict[str, Any]] = {
             {"name": "UPDATED_AT", "type": "esriFieldTypeDate"},
         ],
     },
+    # W5-4 (ADAPTERS-01): a permissive-tier ``FieldSpec`` declares both
+    # ``name`` and ``type`` as ``str | None = None`` -- unlike
+    # "malformed-field-entry" above (a *wrong-typed* value that fails
+    # validation and gets dropped with a drift log), these entries are
+    # each individually VALID FieldSpec instances that simply omit one
+    # of the two keys, exactly as a real permissive-tier ArcGIS service
+    # can emit (vendor variance the model is explicitly designed to
+    # tolerate). No drift is logged for either entry.
+    "field-missing-name-or-type": {
+        "name": "Partially Described Fields",
+        "fields": [
+            {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+            {"type": "esriFieldTypeString"},  # server omitted `name`
+            {"name": "UPDATED_AT"},  # server omitted `type`
+        ],
+    },
 }
 
 

--- a/tests/test_FeatureLayer.py
+++ b/tests/test_FeatureLayer.py
@@ -373,6 +373,56 @@ async def test_featurelayer_getgdf_caches_result(sample_feature_gdf):
 
 
 @pytest.mark.asyncio
+async def test_featurelayer_getgdf_cache_hit_returns_copy_not_shared_reference(
+    sample_feature_gdf,
+):
+    """W5-1 (ASYNC-02): mutating a cache-returned GeoDataFrame must not
+
+    corrupt what a later ``get_gdf()`` call returns — the cache holds the
+    canonical frame, callers get an independent copy.
+    """
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.get_gdf",
+        new=AsyncMock(return_value=sample_feature_gdf),
+    ):
+        first = await layer.get_gdf()
+        first.rename(columns={"CITY": "MUTATED"}, inplace=True)
+        second = await layer.get_gdf()
+
+    assert first is not second
+    assert "CITY" in second.columns
+    assert "MUTATED" not in second.columns
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_getgdf_cache_copy_preserves_spatial_reference_attrs(
+    sample_feature_gdf,
+):
+    """W5-1 / R-65 regression guard: ``.attrs['spatial_reference']`` must
+
+    survive the copy-on-return introduced for the cache-hit path.
+    """
+    sample_feature_gdf.attrs["spatial_reference"] = {"wkid": 4326}
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.get_gdf",
+        new=AsyncMock(return_value=sample_feature_gdf),
+    ):
+        result = await layer.get_gdf()
+
+    assert result.attrs["spatial_reference"] == {"wkid": 4326}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("method_name", "args"),
     [("sample_gdf", (10,)), ("head_gdf", (2,))],
@@ -510,6 +560,64 @@ async def test_getuniquevalues_cache_includes_sortby():
 
 
 @pytest.mark.asyncio
+async def test_featurelayer_getuniquevalues_multi_field_cache_hit_returns_copy():
+    """W5-1 (ASYNC-02): the multi-field DataFrame branch of get_unique_values
+
+    must not hand back the cached DataFrame by reference.
+    """
+    from pandas import DataFrame as _PandasDataFrame
+
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY", "STATE")
+    values_df = _PandasDataFrame({"CITY": ["DAYTONA"], "STATE": ["FL"]})
+
+    async def fake_get_unique_values(url, fields, session, sortby=None, **kwargs):
+        return values_df
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.get_unique_values",
+        side_effect=fake_get_unique_values,
+    ):
+        first = await layer.get_unique_values(("CITY", "STATE"))
+        first.rename(columns={"CITY": "MUTATED"}, inplace=True)
+        second = await layer.get_unique_values(("CITY", "STATE"))
+
+    assert first is not second
+    assert "CITY" in second.columns
+    assert "MUTATED" not in second.columns
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_getuniquevalues_single_field_cache_hit_returns_copy():
+    """W5-1: the single-field list branch of get_unique_values must not
+
+    hand back the cached list by reference either.
+    """
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY",)
+
+    async def fake_get_unique_values(url, fields, session, sortby=None, **kwargs):
+        return ["DAYTONA", "ORMOND"]
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.get_unique_values",
+        side_effect=fake_get_unique_values,
+    ):
+        first = await layer.get_unique_values("CITY")
+        first.append("MUTATED")
+        second = await layer.get_unique_values("CITY")
+
+    assert first is not second
+    assert second == ["DAYTONA", "ORMOND"]
+
+
+@pytest.mark.asyncio
 async def test_featurelayer_getuniquevalues_rejects_unknown_fields():
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
@@ -526,20 +634,30 @@ async def test_featurelayer_getuniquevalues_rejects_unknown_fields():
 
 @pytest.mark.asyncio
 async def test_featurelayer_getvaluecounts_caches_and_validates_fields():
+    """The bare helper always returns a DataFrame (see its ``-> DataFrame``
+
+    annotation in ``restgdf/utils/_stats.py``); a real DataFrame mock keeps
+    this fixture aligned with what the real producer returns (see W5-1
+    below for the copy-on-return regression it also now guards).
+    """
+    from pandas import DataFrame as _PandasDataFrame
+
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
         session=MockArcGISSession(),
     )
     layer.fields = ("CITY", "STATE")
+    counts_df = _PandasDataFrame({"CITY": ["DAYTONA"], "Count": [3]})
 
     with patch(
         "restgdf.featurelayer.featurelayer.get_value_counts",
-        new=AsyncMock(return_value="counts"),
+        new=AsyncMock(return_value=counts_df),
     ) as mock_get_value_counts:
         first = await layer.get_value_counts("CITY")
         second = await layer.get_value_counts("CITY")
 
-    assert first == second == "counts"
+    assert first.equals(counts_df)
+    assert second.equals(counts_df)
     mock_get_value_counts.assert_awaited_once()
 
     with pytest.raises(FieldDoesNotExistError):
@@ -547,25 +665,92 @@ async def test_featurelayer_getvaluecounts_caches_and_validates_fields():
 
 
 @pytest.mark.asyncio
+async def test_featurelayer_getvaluecounts_cache_hit_returns_copy():
+    """W5-1 (ASYNC-02): mutating a returned value-counts frame must not
+
+    corrupt the cache a later call reads from.
+    """
+    from pandas import DataFrame as _PandasDataFrame
+
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY",)
+    counts_df = _PandasDataFrame({"CITY": ["DAYTONA"], "Count": [3]})
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.get_value_counts",
+        new=AsyncMock(return_value=counts_df),
+    ):
+        first = await layer.get_value_counts("CITY")
+        first.loc[0, "Count"] = 999
+        second = await layer.get_value_counts("CITY")
+
+    assert first is not second
+    assert second.loc[0, "Count"] == 3
+
+
+@pytest.mark.asyncio
 async def test_featurelayer_getnestedcount_caches_and_validates_fields():
+    """Real DataFrame mock — see the note on the sibling value-counts
+
+    fixture above; the bare ``nested_count`` helper always returns a
+    DataFrame too.
+    """
+    from pandas import DataFrame as _PandasDataFrame
+
     layer = FeatureLayer(
         "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
         session=MockArcGISSession(),
     )
     layer.fields = ("CITY", "STATE")
+    nested_df = _PandasDataFrame(
+        {"CITY": ["DAYTONA"], "STATE": ["FL"], "Count": [2]},
+    )
 
     with patch(
         "restgdf.featurelayer.featurelayer.nested_count",
-        new=AsyncMock(return_value="nested"),
+        new=AsyncMock(return_value=nested_df),
     ) as mock_nested_count:
         first = await layer.get_nested_count(("CITY", "STATE"))
         second = await layer.get_nested_count(("CITY", "STATE"))
 
-    assert first == second == "nested"
+    assert first.equals(nested_df)
+    assert second.equals(nested_df)
     mock_nested_count.assert_awaited_once()
 
     with pytest.raises(FieldDoesNotExistError):
         await layer.get_nested_count(("CITY", "ZIP"))
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_getnestedcount_cache_hit_returns_copy():
+    """W5-1 (ASYNC-02): mutating a returned nested-count frame must not
+
+    corrupt the cache a later call reads from.
+    """
+    from pandas import DataFrame as _PandasDataFrame
+
+    layer = FeatureLayer(
+        "https://example.com/arcgis/rest/services/Secured/FeatureServer/0",
+        session=MockArcGISSession(),
+    )
+    layer.fields = ("CITY", "STATE")
+    nested_df = _PandasDataFrame(
+        {"CITY": ["DAYTONA"], "STATE": ["FL"], "Count": [2]},
+    )
+
+    with patch(
+        "restgdf.featurelayer.featurelayer.nested_count",
+        new=AsyncMock(return_value=nested_df),
+    ):
+        first = await layer.get_nested_count(("CITY", "STATE"))
+        first.loc[0, "Count"] = 999
+        second = await layer.get_nested_count(("CITY", "STATE"))
+
+    assert first is not second
+    assert second.loc[0, "Count"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_id_schema_fixtures.py
+++ b/tests/test_id_schema_fixtures.py
@@ -13,6 +13,7 @@ def test_id_schema_fixture_names_are_stable() -> None:
         "unique-id-info-no-oid",
         "new-field-types",
         "malformed-field-entry",
+        "field-missing-name-or-type",
     )
 
 

--- a/tests/test_metadata_bl23_coverage.py
+++ b/tests/test_metadata_bl23_coverage.py
@@ -8,12 +8,18 @@ from __future__ import annotations
 
 import pytest
 
+from restgdf._models._drift import _parse_response
+from restgdf._models.responses import LayerMetadata
 from restgdf.errors import FieldDoesNotExistError
 from restgdf.utils._metadata import (
+    _field_rows,
+    get_fields,
+    get_fields_frame,
     get_max_record_count,
     get_object_id_field,
     normalize_spatial_reference,
 )
+from tests.id_schema_fixtures import load_id_schema_fixture
 
 
 class TestNormalizeSpatialReference:
@@ -78,3 +84,70 @@ class TestGetMaxRecordCount:
 
     def test_returns_value_for_canonical_key(self):
         assert get_max_record_count({"maxRecordCount": 2000}) == 2000
+
+
+class TestFieldsPermissiveTierMissingNameOrType:
+    """W5-4 (ADAPTERS-01).
+
+    ``FieldSpec`` declares both ``name`` and ``type`` as
+    ``str | None = None`` (permissive tier) -- a field entry missing
+    either key is individually VALID and validates cleanly with no
+    drift logged. Before the fix, ``get_fields(types=True)``/
+    ``_field_rows``/``get_fields_frame`` raised ``KeyError`` (missing
+    key) or ``AttributeError`` (explicit ``None``) instead of returning
+    the resolvable subset.
+    """
+
+    @staticmethod
+    def _validated_metadata() -> LayerMetadata:
+        # Real permissive-tier shape: goes through the SAME validated-model
+        # path production code uses (FeatureLayer.prep -> LayerMetadata),
+        # not a hand-built dict -- see the fixture's own docstring for why
+        # this differs from "malformed-field-entry".
+        payload = load_id_schema_fixture("field-missing-name-or-type")
+        return _parse_response(
+            LayerMetadata,
+            payload,
+            context="field-missing-name-or-type",
+        )
+
+    def test_get_fields_drops_the_nameless_field(self):
+        layer = self._validated_metadata()
+        assert get_fields(layer) == ["OBJECTID", "UPDATED_AT"]
+
+    def test_get_fields_types_true_defaults_missing_type_and_drops_nameless(self):
+        layer = self._validated_metadata()
+        assert get_fields(layer, types=True) == {
+            "OBJECTID": "OID",
+            "UPDATED_AT": "",
+        }
+
+    def test_field_rows_defaults_missing_type_and_drops_nameless(self):
+        layer = self._validated_metadata()
+        assert _field_rows(layer) == [
+            ("OBJECTID", "OID"),
+            ("UPDATED_AT", ""),
+        ]
+
+    def test_get_fields_frame_agrees_with_field_rows_and_get_fields(self):
+        layer = self._validated_metadata()
+        frame = get_fields_frame(layer)
+        assert list(frame["name"]) == ["OBJECTID", "UPDATED_AT"]
+        assert list(frame["type"]) == ["OID", ""]
+
+    def test_raw_dict_explicit_none_type_does_not_attributeerror(self):
+        """Anti-recommendation case (per audit-recommendations/08): a raw
+
+        dict bypassing model validation where a server sent an explicit
+        ``"type": null`` must not surface
+        ``AttributeError: 'NoneType' object has no attribute 'replace'``.
+        """
+        raw = {
+            "fields": [
+                {"name": "OBJECTID", "type": None},
+                {"name": None, "type": "esriFieldTypeString"},
+            ],
+        }
+        assert get_fields(raw) == ["OBJECTID"]
+        assert get_fields(raw, types=True) == {"OBJECTID": ""}
+        assert _field_rows(raw) == [("OBJECTID", "")]

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -6,7 +6,9 @@ importable and of the expected kind (class / callable / module).
 
 from __future__ import annotations
 
+import ast
 import inspect
+from pathlib import Path
 
 import pytest
 
@@ -164,3 +166,94 @@ def test_models_are_pydantic_basemodels() -> None:
 
 def test_error_is_exception_subclass() -> None:
     assert issubclass(restgdf.RestgdfResponseError, Exception)
+
+
+def _is_type_checking_test(test: ast.expr) -> bool:
+    """Match ``if TYPE_CHECKING:`` and ``if typing.TYPE_CHECKING:`` forms."""
+    if isinstance(test, ast.Name):
+        return test.id == "TYPE_CHECKING"
+    if isinstance(test, ast.Attribute):
+        return test.attr == "TYPE_CHECKING"
+    return False
+
+
+def _type_checking_bound_names(source: str) -> set[str]:
+    """Collect every name statically bound inside ``if TYPE_CHECKING:``.
+
+    W5-8 (API-03). ``restgdf/__init__.py`` uses two ``ImportFrom`` shapes
+    inside its ``TYPE_CHECKING`` block and this must handle both:
+
+    * ``from . import adapters, compat, utils`` -- a *module-valued*
+      import (``module`` is ``None``, ``level=1``); each alias binds a
+      submodule name directly (``adapters``, ``compat``, ``utils``).
+      These are exactly ``_EXPECTED_MODULES`` above, and there is
+      nothing to "resolve through" for a module import, so this walker
+      treats them the same as any other bound name rather than special-
+      casing them -- the module names land in the same returned set as
+      every class/callable name and are compared against the full
+      ``__all__`` set (which already includes them) as one axis, per
+      the class docstring below.
+    * ``from ._config import (Name1, Name2, ...)`` /
+      ``from .errors import (...)`` / etc. -- ordinary submodule
+      ``ImportFrom`` nodes; each alias binds ``asname`` if aliased,
+      else its own name.
+
+    A plain ``import x`` node (unused in the current tree, but a
+    plausible future authoring style) is also tolerated: it binds
+    ``asname`` if given, else the first dotted component of the
+    imported name.
+    """
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.If) and _is_type_checking_test(node.test)):
+            continue
+        for stmt in node.body:
+            if isinstance(stmt, (ast.ImportFrom, ast.Import)):
+                for alias in stmt.names:
+                    names.add(alias.asname or alias.name.split(".")[0])
+    return names
+
+
+def test_type_checking_block_matches_all_and_lazy_exports() -> None:
+    """W5-8 (API-03): the static ``TYPE_CHECKING`` import block must stay
+
+    set-equal to the runtime public-surface sources of truth.
+
+    ``set(restgdf.__all__) == set(restgdf._LAZY_EXPORTS)`` already holds
+    by construction at runtime -- ``test_public_all_is_complete`` and
+    ``test_all_names_in_all_are_attributes`` above cover that axis. The
+    ONLY axis nothing previously guarded is the static
+    ``if TYPE_CHECKING:`` block that a type-checker (mypy/pyright)
+    actually reads: a name present in ``__all__``/``_LAZY_EXPORTS`` but
+    missing there resolves to the module's ``def __getattr__(name) ->
+    Any`` fallback under static analysis instead of its real type --
+    exactly what happened to ``FieldDoesNotExistError`` before W5-7
+    (API-02). This test does not touch or weaken that ``__getattr__``
+    lazy-import boundary (``test_lazy_imports.py`` covers it
+    separately) -- it only checks type-*precision*, not type-*safety*:
+    a drifted name here still works fine at runtime, it just loses its
+    static type.
+    """
+    source = Path(restgdf.__file__).read_text(encoding="utf-8")
+    type_checking_names = _type_checking_bound_names(source)
+
+    all_names = set(restgdf.__all__)
+    lazy_export_names = set(restgdf._LAZY_EXPORTS)
+    assert all_names == lazy_export_names, (
+        "sanity precondition for this test: __all__ and _LAZY_EXPORTS "
+        "were assumed set-equal at runtime, but drifted -- that is a "
+        "different bug than the one this test guards"
+    )
+
+    missing_from_type_checking = all_names - type_checking_names
+    assert not missing_from_type_checking, (
+        f"names in __all__/_LAZY_EXPORTS but missing from the static "
+        f"`if TYPE_CHECKING:` import block (unresolved under mypy/"
+        f"pyright): {sorted(missing_from_type_checking)}"
+    )
+    extra_in_type_checking = type_checking_names - all_names
+    assert not extra_in_type_checking, (
+        f"names statically imported under `if TYPE_CHECKING:` but not "
+        f"exported via __all__: {sorted(extra_in_type_checking)}"
+    )

--- a/tests/test_telemetry_log_span_correlation.py
+++ b/tests/test_telemetry_log_span_correlation.py
@@ -57,14 +57,42 @@ async def test_span_context_fields_still_works_for_user_loggers(
         assert fields.get("trace_id") == active_trace_id
 
 
-def test_restgdf_log_record_outside_span_has_no_trace_id(caplog):
-    """Outside an active span, the filter stamps nothing (no-op)."""
+def test_restgdf_log_record_outside_span_has_empty_trace_id_sentinel(caplog):
+    """W5-12 (TELEMETRY-01): outside an active span, the filter stamps the
+
+    empty-string sentinel rather than leaving the attribute unset --
+    see ``test_formatter_with_trace_id_field_does_not_error_outside_span``
+    below for why an unset attribute is the actual bug this replaces.
+    """
     reset_config_cache()
     with caplog.at_level(logging.INFO, logger="restgdf.transport"):
         logging.getLogger("restgdf.transport").info("no-span record")
     record = next(r for r in caplog.records if r.message == "no-span record")
-    assert not hasattr(record, "trace_id")
-    assert not hasattr(record, "span_id")
+    assert record.trace_id == ""
+    assert record.span_id == ""
+
+
+def test_formatter_with_trace_id_field_does_not_error_outside_span(caplog):
+    """W5-12 (TELEMETRY-01): the documented ``%(trace_id)s`` log-correlation
+
+    recipe must render cleanly for a record emitted OUTSIDE any active
+    span -- the common case (an ``auth.refresh.start`` DEBUG record, the
+    pagination ``exceededTransferLimit`` warning, ...). Before the fix,
+    ``_SpanContextFilter`` left ``trace_id``/``span_id`` unset outside a
+    span, so formatting such a record raised ``KeyError: 'trace_id'``
+    (which stdlib ``logging`` normally swallows into a stderr
+    "--- Logging error ---" dump via ``Handler.handleError``) instead of
+    rendering the empty-string sentinel.
+    """
+    reset_config_cache()
+    with caplog.at_level(logging.INFO, logger="restgdf.transport"):
+        logging.getLogger("restgdf.transport").info("outside-span record")
+    record = next(r for r in caplog.records if r.message == "outside-span record")
+
+    formatter = logging.Formatter("%(trace_id)s|%(span_id)s|%(message)s")
+    formatted = formatter.format(record)  # must not raise KeyError
+
+    assert formatted == "||outside-span record"
 
 
 def test_span_context_fields_empty_outside_span():


### PR DESCRIPTION
M2 wave 1, lane C (adversarially verified: CONFIRMED, 0 mustFix). W5-1 (ASYNC-02): cached DataFrame/GeoDataFrame results now return copies — mutating a result no longer corrupts the cache. W5-4 (ADAPTERS-01): get_fields/_field_rows tolerate permissive-tier fields missing name/type (realistic drift fixtures). W5-8 (API-03): three-way set-equality test over __all__/_LAZY_EXPORTS/TYPE_CHECKING (desync-detection proven by scratch-desync). W5-12 (TELEMETRY-01): the log-correlation filter stamps sentinels outside an active span instead of erroring. Process disclosure: red states for behavior changes were proven via stash-runs with raw outputs retained (scratch/m2/gates/), bundled test+fix per item rather than separate red commits; two full-worktree integration drift fixes ride as follow-up commits. Suite 1229/4/4 (+13) · coverage 98% · mypy 0 · sphinx -n -W green · pre-commit fixed point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk