### PR TITLE
docs: remove false .env file-loading claims (W3-5, CONFIG-04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to restgdf are documented here. This project follows
 
 ## [Unreleased]
 
+### Fixed
+
+- Removed the false `.env` file-loading claims from `docs/configuration.rst`'s
+  precedence list and `docs/authentication.rst`'s credentials recipe. `restgdf`
+  has never read `.env` files or depended on `python-dotenv`/`pydantic-settings`
+  — `Config.from_env()` resolves only from the process environment (`os.environ`).
+  The docs now show how to opt in explicitly with `python-dotenv` yourself
+  (W3-5, CONFIG-04).
+
 ## [3.1.0] - 2026-07-24
 ### Added
 

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -98,13 +98,27 @@ Load credentials from environment variables:
        password=os.environ["ARCGIS_PASSWORD"],
    )
 
-Or use a ``.env`` file (supported by pydantic-settings):
+``restgdf`` does not load ``.env`` files itself (``python-dotenv``/``pydantic-settings``
+are not dependencies). If you keep credentials in a ``.env`` file, load it explicitly
+with a package such as `python-dotenv <https://pypi.org/project/python-dotenv/>`_
+before reading ``os.environ``:
 
 .. code-block:: bash
 
    # .env (add to .gitignore!)
    ARCGIS_USER=my-username
    ARCGIS_PASSWORD=my-password
+
+.. code-block:: python
+
+   from dotenv import load_dotenv
+
+   load_dotenv()  # populates os.environ from .env
+
+   credentials = AGOLUserPass(
+       username=os.environ["ARCGIS_USER"],
+       password=os.environ["ARCGIS_PASSWORD"],
+   )
 
 ``AGOLUserPass.password`` is stored as a :class:`pydantic.SecretStr` — it
 is never shown in ``repr()`` output or log messages.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -8,8 +8,20 @@ Values resolve in this order (highest precedence first):
 1. **Explicit constructor arguments** — e.g. ``FeatureLayer.from_url(timeout=…)``
 2. **``Config(...)`` instance** passed explicitly
 3. **Process environment variables** (``RESTGDF_*``)
-4. **``.env`` file** in the working directory
-5. **Library defaults**
+4. **Library defaults**
+
+``restgdf`` does not read a ``.env`` file itself — ``Config.from_env()`` resolves values
+from the process environment (``os.environ``) only, and ``python-dotenv`` is not a
+``restgdf`` dependency. If you want ``.env``-file support, load it explicitly and pass
+the merged mapping in:
+
+.. code-block:: python
+
+   from dotenv import dotenv_values
+   from restgdf import Config
+   import os
+
+   cfg = Config.from_env(env={**dotenv_values(".env"), **os.environ})
 
 Quick start
 -----------


### PR DESCRIPTION
M2 wave 1, lane D — doc-only per the recorded maintainer decision (delete the .env precedence claims rather than implement; no python-dotenv). Adversarially verified: CONFIRMED, 0 mustFix (verifier grepped the runtime to prove each deleted claim false and rebuilt sphinx -n -W). ARCHITECTURE.md's broader claims remain for W6-3 (M3) by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk