### PR TITLE
fix: verify_ssl/UA at the transport seams, request-time Referer, single-flight refresh (W2-10, W2-4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ All notable changes to restgdf are documented here. This project follows
 
 ### Fixed
 
+- `ArcGISTokenSession` reactive token refresh is now single-flight under
+  concurrent `498 Invalid Token` responses: it snapshots the token before
+  the request and, inside the refresh lock, only re-mints when the token is
+  still unchanged. Previously N concurrent 498s issued N `/generateToken`
+  calls; now they collapse onto one, and the later requests retry with the
+  freshly minted token (W2-4 / ASYNC-01).
 - A **referer-bound** `ArcGISTokenSession` (built from
   `AGOLUserPass(referer=...)` / `TokenSessionConfig.referer`) now attaches a
   matching `Referer` HTTP header to its data requests, not only to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,28 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Changed
+
+- The default `User-Agent` on ArcGIS REST data requests is now sourced from
+  `get_config().transport.user_agent` (default `restgdf/<version>`, e.g.
+  `restgdf/3.1.0`) instead of the hardcoded `"Mozilla/5.0"`
+  (`restgdf.utils._http.default_headers`, W2-10 / CONFIG-01 / AUTH-03).
+  **Wire-visible behavior change:** some Esri deployments sniff the
+  `User-Agent`, so a WAF or usage policy keyed on `"Mozilla/5.0"` may now
+  see `restgdf/<version>`. Override it explicitly per request
+  (`headers={"User-Agent": ...}`, still wins) or globally via
+  `RESTGDF_TRANSPORT_USER_AGENT` / `TransportConfig.user_agent`. The
+  exported `DEFAULT_METADATA_HEADERS` constant keeps its historical value
+  for back-compat but no longer determines the wire `User-Agent`.
+
 ### Fixed
 
+- `ArcGISTokenSession` now forwards its own `verify_ssl` flag to
+  token-attached **data** requests (not just the `/generateToken` POST), via
+  `setdefault("ssl", self.verify_ssl)` in `_call_with_auth_retry` — so a
+  session built with `verify_ssl=False` (self-signed ArcGIS Enterprise)
+  no longer fails TLS verification on the actual query/metadata requests.
+  A caller-supplied `ssl=` still wins (W2-10 / CONFIG-01 / AUTH-03).
 - `restgdf.utils.token._auth_logger` (the `restgdf.auth` logger backing
   token-refresh debug logging) is now created through the library's
   `get_logger("auth")` factory instead of a raw `logging.getLogger(...)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to restgdf are documented here. This project follows
 
 ### Fixed
 
+- A **referer-bound** `ArcGISTokenSession` (built from
+  `AGOLUserPass(referer=...)` / `TokenSessionConfig.referer`) now attaches a
+  matching `Referer` HTTP header to its data requests, not only to the
+  `/generateToken` mint — so a `client="referer"` token is honoured
+  end-to-end instead of being rejected (498/499) on the query. A
+  `client="requestip"` (non-referer) session attaches no `Referer` header
+  (no referer leak). Closes the "planned follow-up" limitation noted in
+  MIGRATION.md for the 3.1 referer feature (#175 review NOTE-1).
 - `ArcGISTokenSession` now forwards its own `verify_ssl` flag to
   token-attached **data** requests (not just the `/generateToken` POST), via
   `setdefault("ssl", self.verify_ssl)` in `_call_with_auth_retry` — so a

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,17 +19,19 @@ the ArcGIS `client` field switches to `"referer"` and `referer=<url>`
 is added to the mint payload. Tokens are now minted as **referer-bound**
 instead of **IP-bound** for these callers.
 
-**Known limitation (planned follow-up).** restgdf does not yet send a
-matching `Referer` HTTP header on subsequent data requests — the referer
-is used only at mint time. ArcGIS binds a `client="referer"` token to
-that referer and can reject queries whose `Referer` header does not match
-(HTTP 498/499). So a caller who previously relied on
-`AGOLUserPass(referer=...)` and received a working IP-bound token may,
-after this change, receive a referer-bound token that services enforcing
-referer will reject. Request-time `Referer`-header propagation is planned
-follow-up work. If a referer-bound token is rejected and you cannot yet
-supply the header out-of-band, drop the `referer` argument to fall back to
-the previous IP-bound (`client="requestip"`) behaviour.
+**Request-time `Referer` propagation.** A referer-bound session now also
+attaches a matching `Referer` HTTP header to its data requests (query,
+metadata, count), not only to the mint call — so a `client="referer"`
+token is honoured end-to-end. The header is sourced from the same referer
+used at mint time (`TokenSessionConfig.referer` / `AGOLUserPass.referer`),
+with config taking precedence, and is injected through the token session's
+header seam. A `client="requestip"` (non-referer) session attaches **no**
+`Referer` header, so nothing leaks for callers who never set a referer. An
+explicit caller `Referer` on a referer-bound session is overridden by the
+session's referer (a mismatched `Referer` would fail the token); pass a
+non-referer session if you need to control the header yourself. If a
+referer-bound token is still rejected, drop the `referer` argument to fall
+back to the IP-bound (`client="requestip"`) behaviour.
 
 The token-mint payload also now carries an explicit `expiration` field
 (`AGOLUserPass.expiration`, default 60 minutes; the deprecated

--- a/restgdf/utils/_http.py
+++ b/restgdf/utils/_http.py
@@ -33,16 +33,16 @@ def default_headers(headers: dict | None = None) -> dict:
     """Return request headers merged with ArcGIS-compatible defaults.
 
     The ``User-Agent`` default is sourced from
-    :attr:`restgdf._config.TransportConfig.user_agent` (resolved through
+    ``get_config().transport.user_agent`` (see
     :func:`restgdf.get_config`) -- the single source of truth for the
     data-path UA (CONFIG-01 / AUTH-03, W2-10). Callers change it there (or
     via ``RESTGDF_TRANSPORT_USER_AGENT``) rather than editing a hardcoded
-    leaf value. It is read on every call, so
-    :func:`restgdf.reset_config_cache` takes effect immediately. The
-    exported :data:`DEFAULT_METADATA_HEADERS` constant keeps its historical
-    ``"Mozilla/5.0"`` value for back-compat, but that value no longer
-    reaches the wire -- the config default overrides it here. An explicit
-    caller ``User-Agent`` header still wins (merge order preserved).
+    leaf value. It is read on every call, so ``reset_config_cache`` takes
+    effect immediately. The exported ``DEFAULT_METADATA_HEADERS`` constant
+    keeps its historical ``"Mozilla/5.0"`` value for back-compat, but that
+    value no longer reaches the wire -- the config default overrides it
+    here. An explicit caller ``User-Agent`` header still wins (merge order
+    preserved).
     """
     defaults = {
         **DEFAULT_METADATA_HEADERS,

--- a/restgdf/utils/_http.py
+++ b/restgdf/utils/_http.py
@@ -30,8 +30,25 @@ DEFAULTDICT: dict = {
 
 
 def default_headers(headers: dict | None = None) -> dict:
-    """Return request headers merged with ArcGIS-compatible defaults."""
-    return {**DEFAULT_METADATA_HEADERS, **(headers or {})}
+    """Return request headers merged with ArcGIS-compatible defaults.
+
+    The ``User-Agent`` default is sourced from
+    :attr:`restgdf._config.TransportConfig.user_agent` (resolved through
+    :func:`restgdf.get_config`) -- the single source of truth for the
+    data-path UA (CONFIG-01 / AUTH-03, W2-10). Callers change it there (or
+    via ``RESTGDF_TRANSPORT_USER_AGENT``) rather than editing a hardcoded
+    leaf value. It is read on every call, so
+    :func:`restgdf.reset_config_cache` takes effect immediately. The
+    exported :data:`DEFAULT_METADATA_HEADERS` constant keeps its historical
+    ``"Mozilla/5.0"`` value for back-compat, but that value no longer
+    reaches the wire -- the config default overrides it here. An explicit
+    caller ``User-Agent`` header still wins (merge order preserved).
+    """
+    defaults = {
+        **DEFAULT_METADATA_HEADERS,
+        "User-Agent": get_config().transport.user_agent,
+    }
+    return {**defaults, **(headers or {})}
 
 
 def default_data(

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -406,6 +406,9 @@ class ArcGISTokenSession:
         kwargs.setdefault("ssl", self.verify_ssl)
 
         session_method = getattr(self.session, method)
+        # W2-4 (ASYNC-01): snapshot the token BEFORE issuing the request so
+        # concurrent 498s collapse onto a single refresh (see the 498 branch).
+        tok_before = self.token
         resp = await session_method(
             url,
             **{payload_key: request_payload},
@@ -422,11 +425,19 @@ class ArcGISTokenSession:
             )
 
         if status == 498:
-            # Single-flight refresh, then retry exactly once.
+            # Single-flight refresh, then retry exactly once. Under N
+            # concurrent 498s every task serializes on the lock; only the
+            # first (whose snapshot still matches self.token) mints. Later
+            # winners observe self.token != tok_before and skip the redundant
+            # /generateToken, then retry with the freshly minted token. This
+            # mirrors the proactive update_token_if_needed double-check; do
+            # NOT gate on token_needs_update() -- after a server-side
+            # invalidation the local token still looks valid.
             if self._refresh_lock is None:
                 self._refresh_lock = asyncio.Lock()
             async with self._refresh_lock:
-                await self.update_token()
+                if self.token == tok_before:
+                    await self.update_token()
 
             # Rebuild auth for the retry.
             request_headers = (

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -222,11 +222,35 @@ class ArcGISTokenSession:
         return "X-Esri-Authorization"
 
     @property
+    def _referer(self) -> str | None:
+        """Return the referer this session's token is bound to, if any.
+
+        Resolved with the same precedence as
+        :attr:`token_request_payload` (config referer wins over the
+        credential's referer) so a request-time ``Referer`` header matches
+        the referer sent at mint time. ``None`` for a ``client="requestip"``
+        (non-referer) token or a credential-less session.
+        """
+        if self.config is not None:
+            return self.config.referer
+        return getattr(self.credentials, "referer", None)
+
+    @property
     def auth_headers(self) -> dict[str, str]:
-        """Return authentication headers with the token if available."""
+        """Return authentication headers with the token if available.
+
+        For a **referer-bound** session (``AGOLUserPass(referer=...)`` /
+        ``TokenSessionConfig.referer``) a matching ``Referer`` header is
+        attached so the ``client="referer"`` token is honoured on data
+        requests, not only at mint time (#175 NOTE-1). No ``Referer`` is
+        attached for a ``client="requestip"`` token (no referer leak).
+        """
         headers: dict[str, str] = {}
         if self.token and self._transport == "header":
             headers[self._header_name] = f"Bearer {self.token}"
+        referer = self._referer
+        if referer:
+            headers["Referer"] = referer
         return headers
 
     def update_headers(self, headers: dict | None = None) -> dict:

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -375,6 +375,11 @@ class ArcGISTokenSession:
         )
         request_payload = self.update_dict(payload)
         kwargs.setdefault("timeout", default_timeout())
+        # W2-10 (CONFIG-01/AUTH-03): forward the token session's own
+        # verify_ssl to token-attached data requests, mirroring the
+        # /generateToken POST. setdefault so a caller-supplied ssl= wins;
+        # it also carries into the 498-retry call below (shared **kwargs).
+        kwargs.setdefault("ssl", self.verify_ssl)
 
         session_method = getattr(self.session, method)
         resp = await session_method(

--- a/tests/test_base_install.py
+++ b/tests/test_base_install.py
@@ -300,10 +300,7 @@ async def test_row_dict_generator_uses_query_batch_data_without_duplicate_kwargs
     }
     assert post_kwargs["headers"]["Accept"] == "application/json,text/plain,*/*"
     # W2-10: default UA now sourced from get_config().transport.user_agent.
-    assert (
-        post_kwargs["headers"]["User-Agent"]
-        == get_config().transport.user_agent
-    )
+    assert post_kwargs["headers"]["User-Agent"] == get_config().transport.user_agent
 
 
 @pytest.mark.asyncio

--- a/tests/test_base_install.py
+++ b/tests/test_base_install.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from restgdf import get_config
 from restgdf.errors import OptionalDependencyError
 from restgdf.featurelayer.featurelayer import FeatureLayer
 from restgdf.utils._optional import require_geopandas
@@ -298,7 +299,11 @@ async def test_row_dict_generator_uses_query_batch_data_without_duplicate_kwargs
         "outFields": "CITY",
     }
     assert post_kwargs["headers"]["Accept"] == "application/json,text/plain,*/*"
-    assert post_kwargs["headers"]["User-Agent"] == "Mozilla/5.0"
+    # W2-10: default UA now sourced from get_config().transport.user_agent.
+    assert (
+        post_kwargs["headers"]["User-Agent"]
+        == get_config().transport.user_agent
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -18,6 +18,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from pandas import DataFrame
 
+from restgdf import get_config
 from restgdf.featurelayer.featurelayer import FeatureLayer
 from restgdf.utils import crawl as crawl_mod
 from restgdf.utils import getgdf as getgdf_mod
@@ -56,7 +57,9 @@ async def test_get_feature_count_sends_minimal_count_payload(fake_session):
     }
     # default_headers are merged in
     assert kwargs["headers"]["Accept"] == "application/json,text/plain,*/*"
-    assert kwargs["headers"]["User-Agent"] == "Mozilla/5.0"
+    # W2-10: default UA now sourced from get_config().transport.user_agent
+    # (was the hardcoded "Mozilla/5.0"); this characterizes the new default.
+    assert kwargs["headers"]["User-Agent"] == get_config().transport.user_agent
 
 
 @pytest.mark.asyncio

--- a/tests/test_getgdf.py
+++ b/tests/test_getgdf.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, call, patch
 import pytest
 from geopandas import GeoDataFrame
 
+from restgdf import get_config
 from restgdf._models import RestgdfResponseError
 from restgdf.errors import PaginationError
 from tests.pagination_fixtures import load_pagination_fixture
@@ -300,7 +301,8 @@ async def test_get_sub_gdf_uses_geojson_driver_when_esrijson_missing(
                 "data": {"where": "1=1", "f": "GeoJSON"},
                 "headers": {
                     "Accept": "application/json,text/plain,*/*",
-                    "User-Agent": "Mozilla/5.0",
+                    # W2-10: default UA sourced from transport config.
+                    "User-Agent": get_config().transport.user_agent,
                     "X-Test": "yes",
                 },
                 "timeout": 12,

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -6,6 +6,7 @@ import pytest
 from aiohttp import ClientSession
 from pandas import DataFrame
 
+from restgdf import get_config
 from restgdf.errors import FieldDoesNotExistError
 from tests.id_schema_fixtures import load_id_schema_fixture
 from restgdf.utils.utils import ends_with_num, where_var_in_list
@@ -231,9 +232,11 @@ def test_default_data():
 
 
 def test_default_headers():
+    # W2-10: the User-Agent default is now sourced from
+    # get_config().transport.user_agent (was the hardcoded "Mozilla/5.0").
     assert default_headers({"X-Test": "yes"}) == {
         "Accept": "application/json,text/plain,*/*",
-        "User-Agent": "Mozilla/5.0",
+        "User-Agent": get_config().transport.user_agent,
         "X-Test": "yes",
     }
 

--- a/tests/test_token_498_499.py
+++ b/tests/test_token_498_499.py
@@ -5,6 +5,7 @@ RED-first — these fail until feat(BL-11) adds _call_with_auth_retry.
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -112,3 +113,121 @@ class TestAuthNotAttachedOn499:
         with pytest.raises(AuthNotAttachedError):
             await ts.get("https://example.com/query")
         ts.update_token.assert_not_awaited()
+
+
+class TestSingleFlightRefreshUnderConcurrent498:
+    """W2-4 (ASYNC-01): N concurrent 498s → exactly ONE /generateToken.
+
+    Without the snapshot double-check inside the 498 branch, every task that
+    won the refresh lock re-mints, so N concurrent 498s produce N mints. The
+    fix captures ``tok_before`` before the request and only refreshes when
+    ``self.token == tok_before`` under the lock (mirroring the proactive
+    ``update_token_if_needed`` double-check).
+    """
+
+    @pytest.mark.asyncio
+    async def test_n_concurrent_498s_trigger_exactly_one_mint(self):
+        from restgdf._models.credentials import AGOLUserPass
+        from restgdf.utils.token import ArcGISTokenSession
+
+        from tests.test_token import RecordingTokenSession
+
+        k = 12
+        session = RecordingTokenSession()
+        ts = ArcGISTokenSession(
+            session=session,
+            credentials=AGOLUserPass(username="user", password="password"),
+            token="tok-0",
+            expires=9999999999999,
+        )
+
+        resp_498 = _make_response(status=498, json_body={"error": {"code": 498}})
+        resp_200 = _make_response(status=200, json_body={"features": []})
+
+        # Barrier: hold every task's FIRST response until all k have issued
+        # their first request, so all k capture the same tok_before ("tok-0")
+        # and receive 498 *before* any refresh runs. This removes timing luck
+        # -- the dedupe must come from the snapshot check, not from tasks
+        # arriving after the first refresh already rotated the token.
+        arrived = 0
+        gate = asyncio.Event()
+        first_seen: set[int] = set()
+
+        async def flaky_get(url, **kwargs):
+            task_id = id(asyncio.current_task())
+            if task_id not in first_seen:
+                first_seen.add(task_id)
+                nonlocal arrived
+                arrived += 1
+                if arrived == k:
+                    gate.set()
+                await gate.wait()
+                return resp_498
+            return resp_200
+
+        session.get = flaky_get
+
+        mint_count = 0
+
+        async def rotating_update_token():
+            nonlocal mint_count
+            mint_count += 1
+            # Rotate the token so later lock-winners see self.token != tok_before
+            # and correctly SKIP the redundant mint.
+            ts.token = f"tok-{mint_count}"
+
+        ts.update_token = rotating_update_token
+
+        results = await asyncio.gather(
+            *(ts.get("https://example.com/query", params={"where": "1=1"}) for _ in range(k))
+        )
+
+        assert all(r.status == 200 for r in results)
+        assert mint_count == 1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_498s_all_retry_with_refreshed_token(self):
+        """Every concurrent task still completes its retry after the single mint."""
+        from restgdf._models.credentials import AGOLUserPass
+        from restgdf.utils.token import ArcGISTokenSession
+
+        from tests.test_token import RecordingTokenSession
+
+        k = 8
+        session = RecordingTokenSession()
+        ts = ArcGISTokenSession(
+            session=session,
+            credentials=AGOLUserPass(username="user", password="password"),
+            token="tok-0",
+            expires=9999999999999,
+        )
+
+        resp_498 = _make_response(status=498, json_body={"error": {"code": 498}})
+        resp_200 = _make_response(status=200, json_body={"features": []})
+
+        arrived = 0
+        gate = asyncio.Event()
+        first_seen: set[int] = set()
+
+        async def flaky_get(url, **kwargs):
+            task_id = id(asyncio.current_task())
+            if task_id not in first_seen:
+                first_seen.add(task_id)
+                nonlocal arrived
+                arrived += 1
+                if arrived == k:
+                    gate.set()
+                await gate.wait()
+                return resp_498
+            return resp_200
+
+        session.get = flaky_get
+        ts.update_token = AsyncMock(side_effect=lambda: setattr(ts, "token", "fresh"))
+
+        results = await asyncio.gather(
+            *(ts.get("https://example.com/query") for _ in range(k))
+        )
+
+        assert len(results) == k
+        assert all(r.status == 200 for r in results)
+        assert ts.update_token.await_count == 1

--- a/tests/test_token_498_499.py
+++ b/tests/test_token_498_499.py
@@ -179,7 +179,10 @@ class TestSingleFlightRefreshUnderConcurrent498:
         ts.update_token = rotating_update_token
 
         results = await asyncio.gather(
-            *(ts.get("https://example.com/query", params={"where": "1=1"}) for _ in range(k))
+            *(
+                ts.get("https://example.com/query", params={"where": "1=1"})
+                for _ in range(k)
+            ),
         )
 
         assert all(r.status == 200 for r in results)
@@ -225,7 +228,7 @@ class TestSingleFlightRefreshUnderConcurrent498:
         ts.update_token = AsyncMock(side_effect=lambda: setattr(ts, "token", "fresh"))
 
         results = await asyncio.gather(
-            *(ts.get("https://example.com/query") for _ in range(k))
+            *(ts.get("https://example.com/query") for _ in range(k)),
         )
 
         assert len(results) == k

--- a/tests/test_token_referer_header.py
+++ b/tests/test_token_referer_header.py
@@ -1,0 +1,97 @@
+"""Referer rider (#175 review NOTE-1): request-time Referer propagation.
+
+Before 3.1, `AGOLUserPass(referer=...)` was honoured only at token-mint time
+(the ArcGIS `client` field switches to `"referer"` and `referer=<url>` joins
+the `/generateToken` payload), but restgdf never sent a matching `Referer`
+HTTP header on the *subsequent data requests*. ArcGIS binds a
+`client="referer"` token to that referer and can reject queries whose
+`Referer` header does not match (498/499), so a referer-bound session was
+incoherent end-to-end.
+
+These tests assert that a referer-bound token session attaches a matching
+`Referer` header on its data requests (through the token session's
+header-injection seam) -- and, critically, that a requestip (non-referer)
+session attaches NO `Referer` header (no referer leak).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
+
+from tests.test_token import RecordingTokenSession
+
+_FAR_FUTURE_MS = 32503680000000  # token never "needs update"
+_REFERER = "https://myapp.example.com"
+
+
+def _session(recording, *, referer: str | None) -> ArcGISTokenSession:
+    return ArcGISTokenSession(
+        session=recording,
+        credentials=AGOLUserPass(username="u", password="p", referer=referer),
+        token="live-token",
+        expires=_FAR_FUTURE_MS,
+    )
+
+
+@pytest.mark.asyncio
+async def test_referer_bound_session_sends_referer_header_on_get() -> None:
+    recording = RecordingTokenSession()
+    ts = _session(recording, referer=_REFERER)
+
+    await ts.get("https://example.com/layer/0/query", params={"where": "1=1"})
+
+    _, kwargs = recording.get_calls[0]
+    assert kwargs["headers"].get("Referer") == _REFERER
+
+
+@pytest.mark.asyncio
+async def test_referer_bound_session_sends_referer_header_on_post() -> None:
+    recording = RecordingTokenSession()
+    ts = _session(recording, referer=_REFERER)
+
+    await ts.post("https://example.com/layer/0/query", data={"where": "1=1"})
+
+    _, kwargs = recording.post_calls[0]
+    assert kwargs["headers"].get("Referer") == _REFERER
+
+
+@pytest.mark.asyncio
+async def test_referer_header_matches_mint_referer() -> None:
+    """The data-request Referer matches the referer sent at mint time."""
+    recording = RecordingTokenSession()
+    ts = _session(recording, referer=_REFERER)
+
+    await ts.get("https://example.com/layer/0/query", params={"where": "1=1"})
+
+    _, kwargs = recording.get_calls[0]
+    assert kwargs["headers"].get("Referer") == ts.token_request_payload["referer"]
+
+
+@pytest.mark.asyncio
+async def test_requestip_session_sends_no_referer_header() -> None:
+    """A non-referer (client='requestip') session leaks NO Referer header."""
+    recording = RecordingTokenSession()
+    ts = _session(recording, referer=None)
+
+    await ts.get("https://example.com/layer/0/query", params={"where": "1=1"})
+
+    _, kwargs = recording.get_calls[0]
+    assert "Referer" not in kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_credentialless_token_session_sends_no_referer_header() -> None:
+    """A bare token session (no credentials) attaches no Referer header."""
+    recording = RecordingTokenSession()
+    ts = ArcGISTokenSession(
+        session=recording,
+        token="live-token",
+        expires=_FAR_FUTURE_MS,
+    )
+
+    await ts.get("https://example.com/layer/0/query", params={"where": "1=1"})
+
+    _, kwargs = recording.get_calls[0]
+    assert "Referer" not in kwargs["headers"]

--- a/tests/test_w2_10_transport_seams.py
+++ b/tests/test_w2_10_transport_seams.py
@@ -1,0 +1,150 @@
+"""W2-10 (CONFIG-01 / AUTH-03): user_agent + verify_ssl at the token/_http seams.
+
+Two application-seam wirings land here (part B of the consolidated
+verify_ssl/user_agent trio; part A is the ``TransportConfig`` source of truth
+in ``restgdf._config``, part C is the ``get_gdf`` connector in ``getgdf``):
+
+1. ``restgdf.utils._http.default_headers`` sources the ``User-Agent`` default
+   from ``get_config().transport.user_agent`` (the data-path UA source of
+   truth) instead of a hardcoded ``"Mozilla/5.0"``.
+2. ``ArcGISTokenSession._call_with_auth_retry`` forwards the token session's
+   own ``self.verify_ssl`` to token-attached **data** requests via
+   ``setdefault`` (never clobbering a caller-supplied ``ssl=``), mirroring the
+   existing ``/generateToken`` POST plumbing (BL-05).
+
+Note on scope: the token session's ``verify_ssl`` is a deliberate *per-session*
+override (``TokenSessionConfig.verify_ssl`` / the dataclass field). Per the
+W3-1 source-of-truth decision, the token path does NOT read the process-wide
+``get_config().transport.verify_ssl`` singleton -- that governs library-owned
+bare sessions (the ``get_gdf`` connector, W4-5). So these tests drive
+``self.verify_ssl`` directly, not ``RESTGDF_TRANSPORT_VERIFY_SSL``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from restgdf import get_config, reset_config_cache
+from restgdf.utils._http import default_headers
+from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
+
+from tests.test_token import RecordingTokenSession
+
+_FAR_FUTURE_MS = 32503680000000  # year 3000 in epoch-ms; token never "needs update"
+
+
+# ── user_agent: the _http data-path header seam ──────────────────────
+
+
+def test_default_headers_uses_configured_user_agent(monkeypatch) -> None:
+    """``default_headers`` emits the configured ``transport.user_agent``.
+
+    Real-consumer proof: ``default_headers`` is the function every ArcGIS
+    data-path call site (``_query``/``_stats``/``getgdf``) merges to build
+    its wire headers.
+    """
+    monkeypatch.setenv("RESTGDF_TRANSPORT_USER_AGENT", "acme-crawler/9.9")
+    reset_config_cache()
+    try:
+        assert default_headers()["User-Agent"] == "acme-crawler/9.9"
+    finally:
+        monkeypatch.delenv("RESTGDF_TRANSPORT_USER_AGENT", raising=False)
+        reset_config_cache()
+
+
+def test_default_headers_default_is_config_default_not_mozilla() -> None:
+    """The default UA is the ``TransportConfig`` default, not ``Mozilla/5.0``."""
+    reset_config_cache()
+    expected = get_config().transport.user_agent
+    assert default_headers()["User-Agent"] == expected
+    assert default_headers()["User-Agent"] != "Mozilla/5.0"
+
+
+def test_default_headers_caller_user_agent_still_wins() -> None:
+    """An explicit caller ``User-Agent`` still overrides the config default."""
+    assert (
+        default_headers({"User-Agent": "caller/1.0"})["User-Agent"] == "caller/1.0"
+    )
+
+
+def test_default_headers_config_read_at_call_time_not_import_time(
+    monkeypatch,
+) -> None:
+    """The UA is resolved per call (cache-reset semantics), not frozen once.
+
+    Guards against a module-level ``get_config()`` freeze: a fresh env value
+    plus ``reset_config_cache()`` must be observed by the very next call.
+    """
+    reset_config_cache()
+    assert default_headers()["User-Agent"] == get_config().transport.user_agent
+    monkeypatch.setenv("RESTGDF_TRANSPORT_USER_AGENT", "second-value/2.0")
+    reset_config_cache()
+    try:
+        assert default_headers()["User-Agent"] == "second-value/2.0"
+    finally:
+        monkeypatch.delenv("RESTGDF_TRANSPORT_USER_AGENT", raising=False)
+        reset_config_cache()
+
+
+# ── verify_ssl: the token-attached data-request seam ─────────────────
+
+
+def _make_token_session(session, *, verify_ssl: bool) -> ArcGISTokenSession:
+    return ArcGISTokenSession(
+        session=session,
+        credentials=AGOLUserPass(username="u", password="p"),
+        token="live-token",
+        expires=_FAR_FUTURE_MS,
+        verify_ssl=verify_ssl,
+    )
+
+
+@pytest.mark.asyncio
+async def test_token_get_data_request_forwards_verify_ssl_false() -> None:
+    session = RecordingTokenSession()
+    ts = _make_token_session(session, verify_ssl=False)
+
+    await ts.get("https://example.com/layer/0/query", params={"where": "1=1"})
+
+    assert len(session.get_calls) == 1
+    _, kwargs = session.get_calls[0]
+    assert kwargs.get("ssl") is False
+
+
+@pytest.mark.asyncio
+async def test_token_post_data_request_forwards_verify_ssl_false() -> None:
+    session = RecordingTokenSession()
+    ts = _make_token_session(session, verify_ssl=False)
+
+    await ts.post("https://example.com/layer/0/query", data={"where": "1=1"})
+
+    assert len(session.post_calls) == 1
+    _, kwargs = session.post_calls[0]
+    assert kwargs.get("ssl") is False
+
+
+@pytest.mark.asyncio
+async def test_token_data_request_forwards_verify_ssl_true() -> None:
+    session = RecordingTokenSession()
+    ts = _make_token_session(session, verify_ssl=True)
+
+    await ts.get("https://example.com/layer/0/query", params={"where": "1=1"})
+
+    _, kwargs = session.get_calls[0]
+    assert kwargs.get("ssl") is True
+
+
+@pytest.mark.asyncio
+async def test_token_data_request_caller_ssl_not_clobbered() -> None:
+    """A caller-supplied ``ssl=`` survives (``setdefault``, not overwrite)."""
+    session = RecordingTokenSession()
+    ts = _make_token_session(session, verify_ssl=False)
+
+    await ts.get(
+        "https://example.com/layer/0/query",
+        params={"where": "1=1"},
+        ssl=True,
+    )
+
+    _, kwargs = session.get_calls[0]
+    assert kwargs.get("ssl") is True

--- a/tests/test_w2_10_transport_seams.py
+++ b/tests/test_w2_10_transport_seams.py
@@ -62,9 +62,7 @@ def test_default_headers_default_is_config_default_not_mozilla() -> None:
 
 def test_default_headers_caller_user_agent_still_wins() -> None:
     """An explicit caller ``User-Agent`` still overrides the config default."""
-    assert (
-        default_headers({"User-Agent": "caller/1.0"})["User-Agent"] == "caller/1.0"
-    )
+    assert default_headers({"User-Agent": "caller/1.0"})["User-Agent"] == "caller/1.0"
 
 
 def test_default_headers_config_read_at_call_time_not_import_time(


### PR DESCRIPTION
## Summary
The token/_http half of M2's high-severity chain — three red-first fixes, adversarially verified (CONFIRMED, 0 mustFix; the verifier re-ran the reds raw, probed for import-time config freezes, Referer leakage to requestip sessions, and ran the concurrency test 20×):

- **W2-10** (CONFIG-01/AUTH-03): the data path's User-Agent now comes from `get_config().transport.user_agent` (was a hardcoded `Mozilla/5.0` — Esri WAFs sniff UA, called out in CHANGELOG); token-session data requests forward the session's own `verify_ssl`. Wired per the merged W3-1 contract (the spec's original token-reads-transport-singleton idea contradicted the merged design; reconciled and documented — the env-var→wire proof rides with W4-5's PR).
- **Referer rider** (from the #175 review): referer-bound token sessions now attach a matching request-time `Referer` header on data requests — `AGOLUserPass(referer=...)` is finally coherent end-to-end; MIGRATION's "planned follow-up" note updated. Never attached for requestip-bound tokens (verifier-probed).
- **W2-4** (ASYNC-01): reactive 498 refresh is single-flight — concurrent 498s now mint exactly one token (red proved 8 duplicate mints; fix stable 20/20 runs).

Suite 1243/4/4 (+15) · mypy 0 · compat 50 · coverage 98% (`_http.py` 100%) · sphinx green · pre-commit fixed point. One disclosed cross-lane touch: a UA assertion in `test_getgdf.py` re-pinned here (subsumes W4-5's UA half; W4-5 merges after this PR by design). Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk