### PR TITLE
fix: raise on silent geo truncation, deterministic OID ordering, config-honoring bare session (W4-1, W4-2, W4-5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ All notable changes to restgdf are documented here. This project follows
   session built with `verify_ssl=False` (self-signed ArcGIS Enterprise)
   no longer fails TLS verification on the actual query/metadata requests.
   A caller-supplied `ssl=` still wins (W2-10 / CONFIG-01 / AUTH-03).
+- The library-owned session that `get_gdf` builds when called with
+  `session=None` is now constructed with a `TCPConnector` whose `ssl`
+  policy comes from `get_config().transport.verify_ssl` (default `True`),
+  so `RESTGDF_TRANSPORT_VERIFY_SSL=false` / `TransportConfig(verify_ssl=False)`
+  is finally honored on the flagship GeoDataFrame data path — previously
+  the bare `ClientSession()` used the default connector and silently kept
+  TLS verification on. A **caller-supplied** session is passed through
+  untouched (its own connector owns its TLS policy). This completes the
+  three-seam verify_ssl wiring (config source W3-1, token/`_http` W2-10,
+  getgdf connector W4-5 / CONFIG-01 / AUTH-03).
 - `FeatureLayer.get_gdf`/`get_unique_values`/`get_value_counts`/
   `get_nested_count` now return an independent copy of the cached
   frame/list on every call (W5-1, ASYNC-02) instead of the shared cached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to restgdf are documented here. This project follows
 ## [Unreleased]
 ### Changed
 
+- **The GeoDataFrame path now raises on truncated responses instead of
+  silently dropping rows.** `get_gdf` and `stream_gdf_chunks` (via
+  `chunk_generator` → `get_sub_gdf`) now inspect each page's parsed JSON for
+  `exceededTransferLimit=true` and raise `restgdf.errors.PaginationError`
+  (mirroring the raw-feature engine), rather than returning a GeoDataFrame
+  that is silently missing rows when ArcGIS hits its byte/geometry transfer
+  cap (W4-1 / PAGINATION-01, the audit's flagship silent-data-loss fix).
+  The flag is read from the response JSON directly because pyogrio/`read_file`
+  discards the top-level member. **Behavior change:** code that previously
+  received a short-but-successful GeoDataFrame on a capped layer now gets a
+  `PaginationError`; page the layer (smaller `resultRecordCount`, a tighter
+  `where`, or the `iter_pages` engine with `on_truncation='split'`) to read it
+  completely.
 - The default `User-Agent` on ArcGIS REST data requests is now sourced from
   `get_config().transport.user_agent` (default `restgdf/<version>`, e.g.
   `restgdf/3.1.0`) instead of the hardcoded `"Mozilla/5.0"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to restgdf are documented here. This project follows
 ## [Unreleased]
 ### Changed
 
+- **Multi-page offset/count pagination now sends a deterministic
+  `orderByFields`.** When a layer is traversed with explicit
+  `resultOffset`/`resultRecordCount` pages (the `get_gdf` / `get_df` /
+  `stream_*` common path), each batch now defaults `orderByFields` to the
+  layer's resolved OID field unless the caller already supplied one — Esri's
+  documented remedy for reliable `resultOffset` paging, which otherwise leaves
+  row order server-dependent and can silently duplicate or drop features
+  across page boundaries (W4-2 / PAGINATION-02). A caller-supplied
+  `orderByFields` (any case) is never overridden, and a layer whose OID cannot
+  be resolved degrades gracefully to today's un-sorted batches. **Wire-payload
+  change** (semver-relevant): explicit-pagination request bodies now carry an
+  `orderByFields` member. The OID-chunked WHERE-fallback and
+  `on_truncation='split'` paths are unchanged.
 - **The GeoDataFrame path now raises on truncated responses instead of
   silently dropping rows.** `get_gdf` and `stream_gdf_chunks` (via
   `chunk_generator` → `get_sub_gdf`) now inspect each page's parsed JSON for

--- a/audit-recommendations/plan/PROGRAM-LEDGER.md
+++ b/audit-recommendations/plan/PROGRAM-LEDGER.md
@@ -14,7 +14,7 @@
 | P0D Turn CI into policy | **COMPLETE** 2026-07-23: `ci-offline` required on `main` (enforce_admins=false, no approval rule — solo-repo decision); `release` env reviewer = joshuasundance-swca; exports in git-excluded `scratch/p0d/*.json` | offline aggregate required on `main`; `release` env reviewer set; ruleset exported |
 | V0 Establish baseline | **COMPLETE** 2026-07-23 (fresh clone @ `70ebe00` + fresh 3.11 venv: all gates green — pytest 1169/4/2, cov 98%, 34/34 hooks, sphinx, base_install 15, compat 50, build+twine; report `scratch/v0/`) | fresh main clone passes the complete gate |
 | M1 Validation/security | **COMPLETE** 2026-07-24 (items: PRs #193 #194 #195 #196 #197 #198 #199 #200 — see log; 3.1.0 release evidence added on publish) | M1 exit gate plus 3.1.0 release evidence |
-| M2 High correctness | not started | all five high findings closed with regression evidence |
+| M2 High correctness | **COMPLETE** 2026-07-24 (PRs #203–#207 + this PR; all five high findings closed with regression evidence — verifier-run census: AUTH-01 ×3, PAGINATION-01 ×7, PAGINATION-02 ×4, CONFIG-01/AUTH-03 ×8 test nodes green; CICD-01 = the structural release gate. verify_ssl proven end-to-end via real-connector introspection) | all five high findings closed with regression evidence |
 | M3 Medium correctness | not started | M3 item/decision gates green |
 | M4 Docs/polish | not started | 61/61 findings closed or explicitly dispositioned |
 | R32 Release 3.2.0 | not started | clean tag-to-PyPI-to-install verification |

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -11,7 +11,7 @@ from collections.abc import AsyncGenerator, Mapping
 from functools import reduce
 from typing import TYPE_CHECKING, Any, Literal, cast
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, TCPConnector
 
 from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._config import get_config
@@ -508,11 +508,24 @@ async def get_gdf(
 ) -> GeoDataFrame:
     _require_geo_query_support("get_gdf()")
     owns_session = session is None
-    # A bare aiohttp ClientSession satisfies AsyncHTTPSession at runtime
-    # (runtime_checkable presence check) but is not a static structural
-    # subtype under current aiohttp stubs (see _protocols.AsyncHTTPSession);
-    # cast bridges that gap rather than forcing aiohttp to conform (TYPING-04).
-    session = session or cast(AsyncHTTPSession, ClientSession())
+    if session is None:
+        # W4-5 (CONFIG-01/AUTH-03 part C): build the library-owned bare
+        # session with a connector whose TLS policy comes from the
+        # TransportConfig source of truth (W3-1), so
+        # RESTGDF_TRANSPORT_VERIFY_SSL=false is honored on the GeoDataFrame
+        # data path. A caller-supplied session is left untouched -- its own
+        # connector owns its TLS policy (no per-leaf ssl= injection).
+        #
+        # A bare aiohttp ClientSession satisfies AsyncHTTPSession at runtime
+        # (runtime_checkable presence check) but is not a static structural
+        # subtype under current aiohttp stubs (see _protocols.AsyncHTTPSession);
+        # cast bridges that gap rather than forcing aiohttp to conform (TYPING-04).
+        session = cast(
+            AsyncHTTPSession,
+            ClientSession(
+                connector=TCPConnector(ssl=get_config().transport.verify_ssl),
+            ),
+        )
     datadict = default_data(kwargs.pop("data", None) or {})
     if where is not None:
         datadict["where"] = where

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -20,6 +20,7 @@ from restgdf._logging import get_logger
 from restgdf._models._drift import _parse_response
 from restgdf._models.responses import FeaturesResponse, LayerMetadata
 from restgdf.errors import (
+    FieldDoesNotExistError,
     PaginationError,
     PaginationInconsistencyWarning,
     RestgdfResponseError,
@@ -31,6 +32,7 @@ from restgdf.utils.getinfo import (
     get_feature_count,
     get_max_record_count,
     get_metadata,
+    get_object_id_field,
     get_object_ids,
     supports_pagination,
 )
@@ -228,6 +230,33 @@ def _advertised_max_record_count_factor(
     return value
 
 
+def _resolve_order_by_oid(
+    request_data: Mapping[str, Any],
+    metadata: Mapping[str, Any] | LayerMetadata,
+) -> dict[str, str]:
+    """Return ``{"orderByFields": <resolved OID>}`` to merge into explicit
+    pagination batches, or ``{}`` when injection must be skipped (W4-2).
+
+    Skips injection when the caller already supplied an ``orderByFields``
+    (checked **case-insensitively** so a key arriving via ``QueryOptions.extra``
+    is never clobbered), and degrades gracefully -- returning ``{}`` -- when the
+    layer's OID cannot be resolved (``FieldDoesNotExistError`` on
+    ambiguous/missing OID). OID-resolution failure must never break a query that
+    works today.
+    """
+    if any(key.lower() == "orderbyfields" for key in request_data):
+        return {}
+    try:
+        oid_field = get_object_id_field(metadata)
+    except FieldDoesNotExistError:
+        _METADATA_LOG.debug(
+            "pagination.order_by.oid_unresolved; emitting un-sorted "
+            "offset/count batches (PAGINATION-02 graceful degrade)",
+        )
+        return {}
+    return {"orderByFields": oid_field}
+
+
 async def get_query_data_batches(
     url: str,
     session: AsyncHTTPSession,
@@ -264,10 +293,16 @@ async def get_query_data_batches(
         return [request_data]
 
     if supports_pagination(metadata) and supports_pagination_explicitly(metadata):
+        # W4-2 (PAGINATION-02): default orderByFields to the resolved OID so
+        # multi-page offset/count traversal is deterministic (Esri's own
+        # remedy for reliable resultOffset paging). Resolved once; skipped when
+        # the caller sorted or the OID is unresolvable (see helper).
+        order_by = _resolve_order_by_oid(request_data, metadata)
         if isinstance(requested_page_size, int) and requested_page_size > 0:
             return [
                 {
                     **request_data,
+                    **order_by,
                     "resultOffset": offset,
                     "resultRecordCount": min(page_size, feature_count - offset),
                 }
@@ -288,6 +323,7 @@ async def get_query_data_batches(
         return [
             {
                 **request_data,
+                **order_by,
                 "resultOffset": offset,
                 "resultRecordCount": count,
             }

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import io
+import json
 import math
 import warnings
 from asyncio import gather
@@ -328,8 +329,29 @@ async def get_sub_gdf(
         headers=default_headers(kwargs.pop("headers", None)),
         **kwargs,
     )
+    # W4-1 (PAGINATION-01): read the body once, then inspect the parsed JSON
+    # for exceededTransferLimit BEFORE handing the text to read_file. pyogrio /
+    # read_file discards the top-level flag (both ESRIJSON and the Esri-emitted
+    # GeoJSON FeatureCollection carry it at top level), so this path must parse
+    # the dict directly. Raising here mirrors the raw-feature engine
+    # _get_sub_features and closes the silent-data-loss gap on the flagship geo
+    # call. response.text() is a one-shot stream, so read into a local and reuse.
+    text = await response.text()
+    try:
+        raw = json.loads(text)
+    except (ValueError, TypeError):
+        # Non-JSON bodies (unexpected for f=GeoJSON/ESRIJSON) fall through to
+        # read_file, which will surface its own parse error rather than a
+        # misleading truncation raise.
+        raw = None
+    if isinstance(raw, dict) and raw.get("exceededTransferLimit") is True:
+        raise PaginationError(
+            f"{url}/query returned exceededTransferLimit=true; the GeoDataFrame "
+            "page is incomplete and rows are missing.",
+            page_size=query_data.get("resultRecordCount"),
+        )
     sub_gdf = read_file(
-        io.StringIO(await response.text()),
+        io.StringIO(text),
         # driver=gdfdriver,  # this line raises a warning when using pyogrio w/ ESRIJSON
         engine="pyogrio",
     )

--- a/tests/test_gdf_exceeded_transfer_limit.py
+++ b/tests/test_gdf_exceeded_transfer_limit.py
@@ -196,6 +196,31 @@ async def test_get_sub_gdf_allows_non_truncated_page(sample_feature_gdf) -> None
 
 
 @pytest.mark.asyncio
+async def test_get_sub_gdf_non_json_body_falls_through_to_read_file(
+    sample_feature_gdf,
+) -> None:
+    """A non-JSON body must NOT misfire a truncation raise: the guard falls
+    through to ``read_file`` (which owns its own parse errors)."""
+    session = _TextSession("this is not json at all")
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        return_value=sample_feature_gdf,
+    ) as mock_read_file:
+        result = await get_sub_gdf(
+            "https://example.com/layer/0",
+            session,
+            query_data={"where": "1=1"},
+        )
+
+    assert result.equals(sample_feature_gdf)
+    mock_read_file.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_get_gdf_raises_on_truncated_page(sample_feature_gdf) -> None:
     """End-to-end through the public ``get_gdf``: a truncated page propagates
     a PaginationError instead of a silently-short GeoDataFrame.

--- a/tests/test_gdf_exceeded_transfer_limit.py
+++ b/tests/test_gdf_exceeded_transfer_limit.py
@@ -1,0 +1,251 @@
+"""W4-1 (PAGINATION-01): the GeoDataFrame path must detect
+``exceededTransferLimit`` and RAISE instead of silently returning a
+truncated GeoDataFrame.
+
+``get_sub_gdf`` (the only page primitive behind ``get_gdf`` and
+``chunk_generator`` / ``stream_gdf_chunks``) previously read the page
+straight into geopandas with no envelope inspection, so an ArcGIS response
+carrying ``exceededTransferLimit=true`` (byte/geometry cap hit) yielded a
+GeoDataFrame silently missing rows -- silent data loss on the flagship geo
+call. These tests drive the REAL reader seam with both ESRIJSON and GeoJSON
+driver shapes and assert a ``PaginationError`` (mirroring the raw-feature
+engine ``_get_sub_features``).
+
+Implementation hazard covered: pyogrio/``read_file`` discards the top-level
+``exceededTransferLimit`` member, so the flag must be detected from the parsed
+JSON dict -- ``test_..._detects_flag_before_read_file`` asserts the raise fires
+without ``read_file`` ever being called.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from restgdf.errors import PaginationError
+from restgdf.utils.getgdf import chunk_generator, get_gdf, get_sub_gdf
+
+
+_ESRIJSON_TRUNCATED = json.dumps(
+    {
+        "objectIdFieldName": "OBJECTID",
+        "geometryType": "esriGeometryPoint",
+        "spatialReference": {"wkid": 4326},
+        "features": [
+            {"attributes": {"OBJECTID": 101}, "geometry": {"x": -117.1, "y": 34.0}},
+        ],
+        "exceededTransferLimit": True,
+    },
+)
+
+_GEOJSON_TRUNCATED = json.dumps(
+    {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"OBJECTID": 101},
+                "geometry": {"type": "Point", "coordinates": [-117.1, 34.0]},
+            },
+        ],
+        "exceededTransferLimit": True,
+    },
+)
+
+_GEOJSON_COMPLETE = json.dumps(
+    {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "properties": {"OBJECTID": 101},
+                "geometry": {"type": "Point", "coordinates": [-117.1, 34.0]},
+            },
+        ],
+        "exceededTransferLimit": False,
+    },
+)
+
+
+class _TextSession:
+    """ArcGIS session double: every request returns the same body text."""
+
+    def __init__(self, response_text: str) -> None:
+        self.response_text = response_text
+        self.post_calls: list[tuple[str, dict]] = []
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def close(self) -> None:
+        self._closed = True
+
+    async def post(self, url: str, **kwargs):
+        self.post_calls.append((url, kwargs))
+
+        class Response:
+            def __init__(self, text_payload: str) -> None:
+                self._text_payload = text_payload
+
+            async def text(self) -> str:
+                return self._text_payload
+
+        return Response(self.response_text)
+
+    async def get(self, url: str, **kwargs):
+        if "params" in kwargs:
+            kwargs.setdefault("data", kwargs.pop("params"))
+        return await self.post(url, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_get_sub_gdf_raises_on_truncation_esrijson() -> None:
+    """ESRIJSON driver shape: exceededTransferLimit=true must raise."""
+    session = _TextSession(_ESRIJSON_TRUNCATED)
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"ESRIJSON": "rw"},
+    ), patch(
+        # Patch the reader so the red failure is unambiguously "did not raise"
+        # (a returned GeoDataFrame), not a pyogrio parse error on the string.
+        "restgdf.utils.getgdf.read_file",
+        new=Mock(name="read_file"),
+    ):
+        with pytest.raises(PaginationError, match="exceededTransferLimit") as exc_info:
+            await get_sub_gdf(
+                "https://example.com/layer/0",
+                session,
+                query_data={"where": "1=1", "resultRecordCount": 500},
+            )
+
+    # page_size context comes from the query batch's resultRecordCount.
+    assert exc_info.value.page_size == 500
+
+
+@pytest.mark.asyncio
+async def test_get_sub_gdf_raises_on_truncation_geojson() -> None:
+    """GeoJSON driver shape: the top-level flag pyogrio strips must raise."""
+    session = _TextSession(_GEOJSON_TRUNCATED)
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        new=Mock(name="read_file"),
+    ):
+        with pytest.raises(PaginationError, match="exceededTransferLimit"):
+            await get_sub_gdf(
+                "https://example.com/layer/0",
+                session,
+                query_data={"where": "1=1"},
+            )
+
+
+@pytest.mark.asyncio
+async def test_get_sub_gdf_detects_flag_before_read_file() -> None:
+    """The flag is read from the parsed JSON, not from ``read_file`` output
+    (pyogrio discards it). Assert the raise fires without ``read_file`` being
+    called at all."""
+    session = _TextSession(_GEOJSON_TRUNCATED)
+    read_file_spy = Mock(name="read_file")
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        new=read_file_spy,
+    ):
+        with pytest.raises(PaginationError, match="exceededTransferLimit"):
+            await get_sub_gdf(
+                "https://example.com/layer/0",
+                session,
+                query_data={"where": "1=1"},
+            )
+
+    read_file_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_sub_gdf_allows_non_truncated_page(sample_feature_gdf) -> None:
+    """A complete page (exceededTransferLimit=false) still returns a
+    GeoDataFrame -- no false positive."""
+    session = _TextSession(_GEOJSON_COMPLETE)
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        return_value=sample_feature_gdf,
+    ) as mock_read_file:
+        result = await get_sub_gdf(
+            "https://example.com/layer/0",
+            session,
+            query_data={"where": "1=1"},
+        )
+
+    assert result.equals(sample_feature_gdf)
+    mock_read_file.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_get_gdf_raises_on_truncated_page(sample_feature_gdf) -> None:
+    """End-to-end through the public ``get_gdf``: a truncated page propagates
+    a PaginationError instead of a silently-short GeoDataFrame.
+
+    ``read_file`` is stubbed to a valid GeoDataFrame so that in the RED state
+    the failure is unambiguously "did not raise" (get_gdf returns a frame),
+    not an incidental pyogrio parse error. In the GREEN state the raise fires
+    inside ``get_sub_gdf`` before ``read_file`` is ever reached.
+    """
+    session = _TextSession(_GEOJSON_TRUNCATED)
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        return_value=sample_feature_gdf,
+    ), patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}]),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value={}),
+    ):
+        with pytest.raises(PaginationError, match="exceededTransferLimit"):
+            await get_gdf("https://example.com/layer/0", session=session)
+
+
+@pytest.mark.asyncio
+async def test_chunk_generator_raises_on_truncated_page(sample_feature_gdf) -> None:
+    """Through ``chunk_generator`` (the impl behind ``stream_gdf_chunks``):
+    a truncated chunk raises rather than yielding a short GeoDataFrame."""
+    session = _TextSession(_GEOJSON_TRUNCATED)
+
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        return_value=sample_feature_gdf,
+    ), patch(
+        "restgdf.utils.getgdf.get_query_data_batches",
+        new=AsyncMock(return_value=[{"where": "1=1"}]),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value={}),
+    ):
+        with pytest.raises(PaginationError, match="exceededTransferLimit"):
+            async for _chunk in chunk_generator(
+                "https://example.com/layer/0",
+                session,
+            ):
+                pass

--- a/tests/test_getgdf_verify_ssl_connector.py
+++ b/tests/test_getgdf_verify_ssl_connector.py
@@ -1,0 +1,127 @@
+"""W4-5 (CONFIG-01 / AUTH-03 part C): the ``get_gdf`` bare session must be
+built with a ``TCPConnector`` whose ``ssl`` policy comes from the configured
+``TransportConfig.verify_ssl`` source of truth (W3-1).
+
+Before this change ``get_gdf`` built ``ClientSession()`` with the default
+connector (``ssl=True``), so a caller who set
+``RESTGDF_TRANSPORT_VERIFY_SSL=false`` (self-signed ArcGIS Enterprise) still
+saw TLS verification on the library-owned data-request path. These tests drive
+the REAL consumer (``get_gdf`` with ``session=None``) via the env var + cache
+reset and introspect the connector the library actually built.
+
+A caller-supplied session is passed through untouched -- its own connector owns
+its TLS policy (anti-recommendation: never override a caller connector's SSL).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from restgdf import reset_config_cache
+from restgdf.utils.getgdf import get_gdf
+
+
+@pytest.fixture
+def _reset_config_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset the config cache around the test so env overrides take effect
+    and do not leak into sibling tests (LRU size-1 singleton)."""
+    monkeypatch.delenv("RESTGDF_TRANSPORT_VERIFY_SSL", raising=False)
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+class _ConnectorSslCapture:
+    """gdf_by_concat stand-in that snapshots the session's connector ssl
+    policy *at call time* -- get_gdf closes an owned session in its
+    ``finally`` block (which nulls ``ClientSession.connector``), so the
+    connector must be introspected before get_gdf returns."""
+
+    def __init__(self) -> None:
+        self.ssl: Any = "NOT_CALLED"
+        self.session: Any = None
+
+    async def __call__(self, url: str, session: Any, **kwargs: Any) -> str:
+        self.session = session
+        connector = getattr(session, "connector", "NO_CONNECTOR")
+        # aiohttp stores the resolved ssl policy on ``TCPConnector._ssl``.
+        self.ssl = getattr(connector, "_ssl", "NO_CONNECTOR")
+        return "sentinel"
+
+
+class _PassthroughSession:
+    """Caller-supplied session double: records only that it was used as-is."""
+
+    def __init__(self) -> None:
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def close(self) -> None:
+        self._closed = True
+
+
+@pytest.mark.asyncio
+async def test_get_gdf_owned_session_connector_honors_env_verify_ssl(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_config_env: None,
+) -> None:
+    """``get_gdf(session=None)`` with ``RESTGDF_TRANSPORT_VERIFY_SSL=false``
+    must build a session whose connector carries ``ssl=False``.
+
+    RED before W4-5: the bare ``ClientSession()`` has a default connector
+    with ``_ssl is True``, so this assertion fails (no configured connector).
+    """
+    monkeypatch.setenv("RESTGDF_TRANSPORT_VERIFY_SSL", "false")
+    reset_config_cache()
+
+    capture = _ConnectorSslCapture()
+    with patch("restgdf.utils.getgdf.gdf_by_concat", new=capture):
+        result = await get_gdf("https://example.com/layer/0", session=None)
+
+    assert result == "sentinel"
+    # Introspect the REAL aiohttp connector the library built (not a wrapper
+    # dict): the configured verify_ssl=False must reach ``TCPConnector.ssl``.
+    assert capture.ssl is False
+
+
+@pytest.mark.asyncio
+async def test_get_gdf_owned_session_connector_defaults_verify_ssl_true(
+    _reset_config_env: None,
+) -> None:
+    """With no override, the owned session's connector keeps ``ssl=True``
+    (the config default) -- the fix must not silently disable TLS."""
+    reset_config_cache()
+
+    capture = _ConnectorSslCapture()
+    with patch("restgdf.utils.getgdf.gdf_by_concat", new=capture):
+        await get_gdf("https://example.com/layer/0", session=None)
+
+    assert capture.ssl is True
+
+
+@pytest.mark.asyncio
+async def test_get_gdf_passes_caller_session_through_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    _reset_config_env: None,
+) -> None:
+    """A caller-supplied session is used as-is: no connector override even
+    when ``RESTGDF_TRANSPORT_VERIFY_SSL=false`` (the caller connector owns TLS)."""
+    monkeypatch.setenv("RESTGDF_TRANSPORT_VERIFY_SSL", "false")
+    reset_config_cache()
+
+    supplied = _PassthroughSession()
+    capture = _ConnectorSslCapture()
+    with patch("restgdf.utils.getgdf.gdf_by_concat", new=capture):
+        await get_gdf("https://example.com/layer/0", session=supplied)
+
+    # The exact object is threaded through untouched (no connector rebuilt),
+    # and get_gdf did NOT close it (owns_session is False).
+    assert capture.session is supplied
+    assert supplied.closed is False

--- a/tests/test_pagination_order_by_oid.py
+++ b/tests/test_pagination_order_by_oid.py
@@ -1,0 +1,138 @@
+"""W4-2 (PAGINATION-02): explicit offset/count pagination must default
+``orderByFields`` to the layer's resolved OID field so multi-page traversal is
+deterministic.
+
+ArcGIS does not guarantee a stable row order across separate
+``resultOffset``/``resultRecordCount`` requests unless ``orderByFields`` is
+supplied, so without it a feature can be duplicated across adjacent pages or
+dropped between page boundaries. These tests pin that both explicit-pagination
+sub-branches (caller ``resultRecordCount`` and the planner) now inject the OID,
+that a caller-supplied sort (any case) is never clobbered, and that an
+unresolvable OID degrades gracefully (skip injection, never break the happy
+path). The OID-chunked WHERE fallback branch is deliberately untouched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from restgdf.utils.getgdf import get_query_data_batches
+
+
+_OID_METADATA = {
+    "maxRecordCount": 2,
+    "advancedQueryCapabilities": {"supportsPagination": True},
+    "fields": [
+        {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+        {"name": "NAME", "type": "esriFieldTypeString"},
+    ],
+}
+
+# Two OID-typed fields -> get_object_id_field raises FieldDoesNotExistError.
+_AMBIGUOUS_OID_METADATA = {
+    "maxRecordCount": 2,
+    "advancedQueryCapabilities": {"supportsPagination": True},
+    "fields": [
+        {"name": "OBJECTID", "type": "esriFieldTypeOID"},
+        {"name": "FID", "type": "esriFieldTypeOID"},
+    ],
+}
+
+
+@pytest.mark.asyncio
+async def test_planner_branch_injects_orderby_oid() -> None:
+    """Planner sub-branch (no caller resultRecordCount): every batch carries
+    orderByFields=<OID>."""
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=5),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value=_OID_METADATA),
+    ):
+        batches = await get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "1=1"},
+        )
+
+    assert len(batches) == 3
+    assert all(batch["orderByFields"] == "OBJECTID" for batch in batches)
+    # Offsets/counts are still the planner's; injection is additive.
+    assert [(b["resultOffset"], b["resultRecordCount"]) for b in batches] == [
+        (0, 2),
+        (2, 2),
+        (4, 1),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_caller_result_record_count_branch_injects_orderby_oid() -> None:
+    """Caller-resultRecordCount sub-branch: every batch carries the OID sort."""
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=5),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value=_OID_METADATA),
+    ):
+        batches = await get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "1=1", "resultRecordCount": 2},
+        )
+
+    assert len(batches) == 3
+    assert all(batch["orderByFields"] == "OBJECTID" for batch in batches)
+
+
+@pytest.mark.asyncio
+async def test_caller_orderby_is_not_clobbered_case_insensitive() -> None:
+    """A caller-supplied sort (differently cased key) is preserved and the OID
+    is NOT injected on top."""
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=5),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value=_OID_METADATA),
+    ):
+        batches = await get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "1=1", "orderbyfields": "NAME DESC"},
+        )
+
+    assert len(batches) == 3
+    for batch in batches:
+        assert batch["orderbyfields"] == "NAME DESC"
+        assert "orderByFields" not in batch
+
+
+@pytest.mark.asyncio
+async def test_unresolvable_oid_degrades_gracefully() -> None:
+    """An ambiguous/unresolvable OID must NOT break the happy path: batches are
+    produced without orderByFields and no exception escapes."""
+    with patch(
+        "restgdf.utils.getgdf.get_feature_count",
+        new=AsyncMock(return_value=5),
+    ), patch(
+        "restgdf.utils.getgdf.get_metadata",
+        new=AsyncMock(return_value=_AMBIGUOUS_OID_METADATA),
+    ):
+        batches = await get_query_data_batches(
+            "https://example.com/layer/0",
+            object(),
+            data={"where": "1=1"},
+        )
+
+    assert len(batches) == 3
+    assert all("orderByFields" not in batch for batch in batches)
+    # Still a valid offset/count plan.
+    assert [(b["resultOffset"], b["resultRecordCount"]) for b in batches] == [
+        (0, 2),
+        (2, 2),
+        (4, 1),
+    ]

--- a/tests/test_transport_config_integration.py
+++ b/tests/test_transport_config_integration.py
@@ -1,0 +1,186 @@
+"""M2 wave-2 integration: end-to-end proof that a single env-driven
+``TransportConfig`` is honored at BOTH the library data path and the token
+seams.
+
+Sets ``RESTGDF_TRANSPORT_VERIFY_SSL=false`` and a custom
+``RESTGDF_TRANSPORT_USER_AGENT`` via env (with a cache reset), then drives:
+
+* the **library-built data session** (``get_gdf`` with ``session=None``) —
+  proving the env ``verify_ssl`` reaches the real ``TCPConnector`` (W4-5) and
+  the env ``user_agent`` reaches the wire headers of a real data request
+  (W2-10 ``default_headers``); and
+* a **token mint** plus a **token-attached data request** — proving the
+  ``/generateToken`` POST honors the session's ``verify_ssl`` and that the env
+  ``user_agent`` also reaches token-path data requests (W2-10).
+
+Per the W2X handoff, the env-var ``verify_ssl`` proof is taken through the
+library-built connector (W4-5), because the token POST forwards a per-request
+``ssl=self.verify_ssl`` that would override a connector's ssl; the token
+session's ``verify_ssl`` is set consistently (``False``) to assert the token
+seam coherently alongside the connector.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from restgdf import reset_config_cache
+from restgdf.utils._http import _arcgis_request, default_headers
+from restgdf.utils.getgdf import get_gdf, get_sub_gdf
+from restgdf.utils.token import AGOLUserPass, ArcGISTokenSession
+
+_CUSTOM_UA = "restgdf-integration-probe/9.9"
+_FAR_FUTURE_MS = 32503680000000  # ~year 3000, in epoch milliseconds
+
+
+@pytest.fixture
+def _transport_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Set verify_ssl=false + a custom user_agent via env and reset the config
+    cache so the singleton reflects them; scrub + reset on teardown."""
+    monkeypatch.setenv("RESTGDF_TRANSPORT_VERIFY_SSL", "false")
+    monkeypatch.setenv("RESTGDF_TRANSPORT_USER_AGENT", _CUSTOM_UA)
+    reset_config_cache()
+    yield
+    reset_config_cache()
+
+
+class _RecordingDataSession:
+    """Plain-session double that records the kwargs of each data request."""
+
+    def __init__(self, response_text: str) -> None:
+        self.response_text = response_text
+        self.post_calls: list[tuple[str, dict]] = []
+
+    async def post(self, url: str, **kwargs: Any):
+        self.post_calls.append((url, kwargs))
+
+        class Response:
+            def __init__(self, text_payload: str) -> None:
+                self._text_payload = text_payload
+
+            async def text(self) -> str:
+                return self._text_payload
+
+        return Response(self.response_text)
+
+    async def get(self, url: str, **kwargs: Any):
+        if "params" in kwargs:
+            kwargs.setdefault("data", kwargs.pop("params"))
+        return await self.post(url, **kwargs)
+
+
+class _MintContext:
+    """Async CM double for the /generateToken POST."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    async def __aenter__(self) -> _MintContext:
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        return None
+
+    async def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _DataResponse:
+    status = 200
+
+
+class _RecordingInnerSession:
+    """Inner session the ArcGISTokenSession wraps: ``post`` serves the mint
+    (async CM); ``get`` serves token-attached data requests (awaitable)."""
+
+    def __init__(self) -> None:
+        self.mint_kwargs: dict[str, Any] = {}
+        self.data_kwargs: dict[str, Any] = {}
+
+    def post(self, url: str, **kwargs: Any) -> _MintContext:
+        self.mint_kwargs = kwargs
+        return _MintContext({"token": "minted-tok", "expires": _FAR_FUTURE_MS})
+
+    async def get(self, url: str, **kwargs: Any) -> _DataResponse:
+        self.data_kwargs = kwargs
+        return _DataResponse()
+
+
+class _ConnectorSslCapture:
+    """gdf_by_concat stand-in snapshotting the connector ssl at call time."""
+
+    def __init__(self) -> None:
+        self.ssl: Any = "NOT_CALLED"
+
+    async def __call__(self, url: str, session: Any, **kwargs: Any) -> str:
+        connector = getattr(session, "connector", None)
+        self.ssl = getattr(connector, "_ssl", "NO_CONNECTOR")
+        return "sentinel"
+
+
+@pytest.mark.asyncio
+async def test_env_config_reaches_library_data_path(_transport_env: None) -> None:
+    """The library-built data session honors BOTH env knobs: the connector
+    carries ssl=False (W4-5) and a real data request carries the custom
+    User-Agent (W2-10)."""
+    # (a) connector ssl introspection on the get_gdf-owned session.
+    capture = _ConnectorSslCapture()
+    with patch("restgdf.utils.getgdf.gdf_by_concat", new=capture):
+        await get_gdf("https://example.com/layer/0", session=None)
+    assert capture.ssl is False
+
+    # (b) the env user_agent reaches the wire headers of a real data request.
+    session = _RecordingDataSession('{"type":"FeatureCollection","features":[]}')
+    with patch(
+        "restgdf.utils.getgdf.supported_drivers",
+        new={"GeoJSON": "rw"},
+    ), patch(
+        "restgdf.utils.getgdf.read_file",
+        return_value=object(),
+    ):
+        await get_sub_gdf(
+            "https://example.com/layer/0",
+            session,
+            query_data={"where": "1=1"},
+        )
+    assert session.post_calls, "expected the data request to be issued"
+    _url, kwargs = session.post_calls[0]
+    assert kwargs["headers"]["User-Agent"] == _CUSTOM_UA
+
+
+@pytest.mark.asyncio
+async def test_env_config_reaches_token_mint_and_data_request(
+    _transport_env: None,
+) -> None:
+    """A token mint honors verify_ssl, and a token-attached data request honors
+    both the forwarded verify_ssl and the env user_agent."""
+    inner = _RecordingInnerSession()
+    token_session = ArcGISTokenSession(
+        session=inner,
+        credentials=AGOLUserPass(username="u", password="p"),
+        verify_ssl=False,  # set consistently with the data-path connector
+    )
+
+    # Token mint: the /generateToken POST forwards the session verify_ssl.
+    await token_session.update_token()
+    assert inner.mint_kwargs["ssl"] is False
+
+    # Token-attached data request through the real _arcgis_request seam: the
+    # env user_agent (via default_headers) reaches the wire, and verify_ssl is
+    # forwarded onto the data call too. The freshly minted token has a
+    # far-future expiry, so this issues no second mint.
+    await _arcgis_request(
+        token_session,
+        "https://example.com/layer/0/query",
+        {"where": "1=1"},
+        headers=default_headers(None),
+    )
+    assert inner.data_kwargs["ssl"] is False
+    assert inner.data_kwargs["headers"]["User-Agent"] == _CUSTOM_UA


### PR DESCRIPTION
## Summary
The M2-closing PR — the audit's flagship data-integrity fixes, serial red-first, adversarially verified (**CONFIRMED, 0 mustFix**; the verifier re-ran the reds raw, introspected the real `TCPConnector._ssl`, ran every census node, and confirmed the iter_pages engine's `on_truncation` semantics untouched — 83 pagination tests green):

- **W4-1** (PAGINATION-01, high): `get_gdf`/`stream_gdf_chunks` now **raise `PaginationError` on `exceededTransferLimit`** instead of silently returning truncated data — in both ESRIJSON and GeoJSON shapes, flag checked before the reader. The library's flagship silent-data-loss fix; CHANGELOG `### Changed` with semver callout.
- **W4-2** (PAGINATION-02, high): multi-page offset plans default `orderByFields` to the **resolved** OID field (probe-proven with a custom `GlobalGID`; case-insensitive caller override respected; unresolvable-OID degrades gracefully — happy path intact).
- **W4-5** (CONFIG-01/AUTH-03, high, closes the trio with the merged W2-10): `get_gdf`'s bare session is built with the configured ssl connector + UA.
- **Integration proof**: one module drives env-driven `verify_ssl=False` + custom UA through both the mint and data seams, asserting the real connector/wire values.
- **M2 exit census** (verifier-run): all five high findings green — AUTH-01 ×3, PAGINATION-01 ×7, PAGINATION-02 ×4, CONFIG-01/AUTH-03 ×8 test nodes; CICD-01 is the structural release gate. Ledger row updated in this PR.

Suite 1272/4/4 (+16) · mypy 0 · coverage 98% · compat 50 · pre-commit fixed point. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk