### PR TITLE
fix: token 4xx taxonomy, deterministic-error retry guard, opt-in from_config (W2-2, W2-3, W2-11, W3-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,46 @@ All notable changes to restgdf are documented here. This project follows
   exported `DEFAULT_METADATA_HEADERS` constant keeps its historical value
   for back-compat but no longer determines the wire `User-Agent`.
 
+### Added
+
+- `ArcGISTokenSession.from_config(session, credentials, config=...)` and
+  `TokenSessionConfig.from_auth_config(auth_config, credentials)` — opt-in
+  factories that thread an `AuthConfig` namespace (its `transport`,
+  `header_name`, `referer`, `token_url`, and `refresh_leeway_s`/`clock_skew_s`
+  refresh knobs) onto a validated token session (W3-3 / W2-11, CONFIG-02 /
+  AUTH-04). This is the **only** sanctioned way `AuthConfig` reaches a session:
+  it is strictly opt-in and read only at call time. `ArcGISTokenSession`
+  construction remains unchanged — `__post_init__` never reads the
+  process-global `get_config()`, so a plain `ArcGISTokenSession(session,
+  credentials)` keeps its dataclass defaults (e.g. `token_refresh_threshold=60`
+  rather than the AuthConfig-derived `150`). When `config` is omitted,
+  `from_config` reads `get_config().auth`.
+
 ### Fixed
+
+- **A 4xx from `/generateToken` no longer escapes as a raw
+  `aiohttp.ClientResponseError`.** `ArcGISTokenSession.update_token` now maps a
+  true-HTTP `400`/`401`/`403` credential rejection to
+  `restgdf.errors.InvalidCredentialsError` and any other non-2xx to
+  `restgdf.errors.RestgdfResponseError`, both under the `RestgdfError` umbrella
+  and chaining the originating aiohttp error as `__cause__` (W2-2 / AUTH-02 /
+  ERRTAX-01). The error is raised deterministically (not retried). The
+  HTTP-200 `{"error": {...}}` bad-credentials envelope path is unchanged (still
+  `RestgdfResponseError` via the strict `TokenResponse` tier). The
+  `InvalidCredentialsError` docstring now describes the 4xx contract, and
+  `TokenRequiredError` is documented as reserved/not-raised (a 499 surfaces as
+  `AuthNotAttachedError`, the single live 499 raise site).
+- **The token refresh retry filter no longer swallows deterministic auth
+  errors.** restgdf's own exceptions co-inherit `OSError` via `PermissionError`
+  (`AuthenticationError` → `PermissionError` → `OSError`), so a None-credentials
+  `AuthenticationError` (and the new W2-2 `InvalidCredentialsError`) were being
+  caught by the `OSError` retry bucket, retried three times, and re-raised as
+  the wrong class (`TokenRefreshFailedError`). An `except RestgdfError: raise`
+  guard now sits *before* the retryable-error handler, so deterministic restgdf
+  errors propagate immediately with zero backoff, distinguished by real
+  exception instance (MRO) rather than by class name. Genuine transient
+  `OSError`/`ConnectionError`/`asyncio.TimeoutError` still hit the retry ladder
+  (W2-3 / ERRTAX-02).
 
 - `ArcGISTokenSession` reactive token refresh is now single-flight under
   concurrent `498 Invalid Token` responses: it snapshots the token before

--- a/restgdf/_models/credentials.py
+++ b/restgdf/_models/credentials.py
@@ -21,12 +21,15 @@ operator-visible bug, not schema drift.
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field, SecretStr, field_validator, model_validator
 
 from restgdf._compat import _warn_deprecated
 from restgdf._models._drift import StrictModel
+
+if TYPE_CHECKING:
+    from restgdf._config import AuthConfig
 
 
 class AGOLUserPass(StrictModel):
@@ -67,6 +70,13 @@ class TokenSessionConfig(StrictModel):
     constructor kwarg split the supplied total into
     ``clock_skew_seconds = min(30, total)`` and
     ``refresh_leeway_seconds = total - clock_skew_seconds``.
+
+    The :class:`~restgdf._config.AuthConfig` refresh knobs
+    (``refresh_leeway_s``/``clock_skew_s``) are **config holders, never
+    auto-applied to a session**. Opt in explicitly via
+    :meth:`from_auth_config` (or :meth:`ArcGISTokenSession.from_config`);
+    the library never constructs a token session from the process-global
+    config on its own.
     """
 
     token_url: str
@@ -123,6 +133,44 @@ class TokenSessionConfig(StrictModel):
         data.setdefault("clock_skew_seconds", skew)
         data.setdefault("refresh_leeway_seconds", leeway)
         return data
+
+    @classmethod
+    def from_auth_config(
+        cls,
+        auth_config: AuthConfig,
+        credentials: AGOLUserPass,
+    ) -> TokenSessionConfig:
+        """Project an :class:`~restgdf._config.AuthConfig` onto a session config (opt-in).
+
+        W2-11 (AUTH-04/CONFIG-02): ``AuthConfig`` is a validated namespace for
+        the ``RESTGDF_AUTH_*`` env vars and is **never** auto-applied to a
+        session. This factory is the explicit opt-in bridge: it threads
+        *auth_config*'s ``transport``/``header_name``/``referer``/``token_url``
+        and its ``refresh_leeway_s``/``clock_skew_s`` refresh knobs onto a
+        validated :class:`TokenSessionConfig`, pairing them with the
+        *credentials* the caller supplies (``AuthConfig`` carries no
+        :class:`AGOLUserPass`).
+
+        ``token_url`` falls back to the ArcGIS Online default when the
+        ``AuthConfig`` leaves it unset; ``referer`` prefers the ``AuthConfig``
+        value, then the credential's own referer. The resulting effective
+        refresh window is ``refresh_leeway_seconds + clock_skew_seconds``
+        (default ``120 + 30 = 150``), reconciling the split with the bare
+        ``ArcGISTokenSession`` dataclass default of ``60``.
+        """
+        token_url = (
+            auth_config.token_url or "https://www.arcgis.com/sharing/rest/generateToken"
+        )
+        referer = auth_config.referer or credentials.referer
+        return cls(
+            token_url=token_url,
+            credentials=credentials,
+            transport=auth_config.transport,
+            header_name=auth_config.header_name,
+            referer=referer,
+            refresh_leeway_seconds=int(auth_config.refresh_leeway_s),
+            clock_skew_seconds=int(auth_config.clock_skew_s),
+        )
 
     @property
     def refresh_threshold_seconds(self) -> int:

--- a/restgdf/_models/credentials.py
+++ b/restgdf/_models/credentials.py
@@ -71,10 +71,10 @@ class TokenSessionConfig(StrictModel):
     ``clock_skew_seconds = min(30, total)`` and
     ``refresh_leeway_seconds = total - clock_skew_seconds``.
 
-    The :class:`~restgdf._config.AuthConfig` refresh knobs
+    The ``AuthConfig`` refresh knobs
     (``refresh_leeway_s``/``clock_skew_s``) are **config holders, never
     auto-applied to a session**. Opt in explicitly via
-    :meth:`from_auth_config` (or :meth:`ArcGISTokenSession.from_config`);
+    ``from_auth_config`` (or :meth:`ArcGISTokenSession.from_config`);
     the library never constructs a token session from the process-global
     config on its own.
     """
@@ -140,7 +140,7 @@ class TokenSessionConfig(StrictModel):
         auth_config: AuthConfig,
         credentials: AGOLUserPass,
     ) -> TokenSessionConfig:
-        """Project an :class:`~restgdf._config.AuthConfig` onto a session config (opt-in).
+        """Project an ``AuthConfig`` onto a session config (opt-in).
 
         W2-11 (AUTH-04/CONFIG-02): ``AuthConfig`` is a validated namespace for
         the ``RESTGDF_AUTH_*`` env vars and is **never** auto-applied to a

--- a/restgdf/errors.py
+++ b/restgdf/errors.py
@@ -266,7 +266,15 @@ class _AuthSubtypeBase(AuthenticationError):
 
 
 class InvalidCredentialsError(_AuthSubtypeBase):
-    """Raised on 400 / bad credentials from ``/generateToken``.
+    """Raised on a 4xx credential rejection from ``/generateToken``.
+
+    A true-HTTP ``400``/``401``/``403`` from the token endpoint is mapped
+    here (W2-2) instead of escaping as a raw ``aiohttp.ClientResponseError``;
+    the originating aiohttp error is chained as ``__cause__``. Other non-2xx
+    token responses surface as :class:`RestgdfResponseError`. The HTTP-200
+    ``{"error": {...}}`` bad-credentials envelope is handled separately by the
+    strict :class:`~restgdf._models.responses.TokenResponse` tier (also a
+    :class:`RestgdfResponseError`).
 
     Inherits :class:`AuthenticationError` → :class:`PermissionError`.
     """
@@ -300,10 +308,17 @@ class TokenExpiredError(_AuthSubtypeBase):
 
 
 class TokenRequiredError(_AuthSubtypeBase):
-    """Raised when ArcGIS returns error code **499** (Token Required).
+    """Reserved auth subtype — **not currently raised** (W2-2 demotion).
 
-    Semantically: the service demands a token but the request did not
-    carry one (or the wrong transport was chosen).
+    Semantically this names the "service demands a token but the request
+    carried none (or the wrong transport)" condition, i.e. Esri **499**.
+    In practice a 499 surfaces as :class:`AuthNotAttachedError` — that is
+    the single live 499 raise site (see
+    ``ArcGISTokenSession._call_with_auth_retry``) and is semantically
+    precise. This class is retained as a back-compat / placeholder type in
+    the taxonomy; there is deliberately no second 499 raise site. Catch
+    :class:`AuthNotAttachedError` (or the parent
+    :class:`AuthenticationError`) for the 499 condition.
     """
 
 

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -15,6 +15,7 @@ import asyncio
 import datetime
 import importlib
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
 
 import aiohttp
 
@@ -28,11 +29,17 @@ from restgdf._compat import _warn_deprecated
 from restgdf.errors import (
     AuthNotAttachedError,
     AuthenticationError,
+    InvalidCredentialsError,
+    RestgdfError,
+    RestgdfResponseError,
     TokenExpiredError,
     TokenRefreshFailedError,
 )
 
 from pydantic import SecretStr
+
+if TYPE_CHECKING:
+    from restgdf._config import AuthConfig
 
 _auth_logger = get_logger("auth")
 
@@ -112,6 +119,15 @@ class ArcGISTokenSession:
     fails fast with :class:`~restgdf._models.RestgdfResponseError`
     rather than surfacing as a 401 or an ``aiohttp`` error deep in
     the request path.
+
+    ``__post_init__`` never reads the process-global
+    :func:`~restgdf._config.get_config`: a plain
+    ``ArcGISTokenSession(session, credentials)`` keeps its dataclass
+    defaults (e.g. ``token_refresh_threshold=60``). The
+    :class:`~restgdf._config.AuthConfig` refresh knobs are config
+    holders, not auto-applied; opt in explicitly with
+    :meth:`from_config` when you want the ``RESTGDF_AUTH_*`` namespace to
+    drive a session's refresh timing / transport.
     """
 
     session: aiohttp.ClientSession
@@ -166,6 +182,37 @@ class ArcGISTokenSession:
             self.token_refresh_threshold = (
                 self.config.refresh_leeway_seconds + self.config.clock_skew_seconds
             )
+
+    @classmethod
+    def from_config(
+        cls,
+        session: aiohttp.ClientSession,
+        credentials: AGOLUserPass,
+        *,
+        config: AuthConfig | None = None,
+    ) -> ArcGISTokenSession:
+        """Build a token session from an :class:`~restgdf._config.AuthConfig` (opt-in).
+
+        W3-3 (CONFIG-02, hybrid decision): this classmethod is the ONLY
+        sanctioned path by which an ``AuthConfig`` namespace flows into a
+        session. It is strictly opt-in — nothing constructs a session this
+        way implicitly, and ``__post_init__`` never reaches into the
+        process-global config.
+
+        When *config* is ``None`` the process-global ``get_config().auth`` is
+        read, but **only here at call time**, never at import time. The
+        ``AuthConfig`` refresh knobs are projected onto a validated
+        :class:`~restgdf._models.credentials.TokenSessionConfig` via
+        :meth:`~restgdf._models.credentials.TokenSessionConfig.from_auth_config`,
+        so the effective refresh window is ``refresh_leeway_s + clock_skew_s``
+        (default ``150``), not the bare dataclass default of ``60``.
+        """
+        if config is None:
+            from restgdf._config import get_config
+
+            config = get_config().auth
+        token_session_config = TokenSessionConfig.from_auth_config(config, credentials)
+        return cls(session=session, config=token_session_config)
 
     @property
     def token_request_payload(self) -> dict:
@@ -307,13 +354,57 @@ class ArcGISTokenSession:
                     timeout=default_timeout(),
                     ssl=self.verify_ssl,
                 ) as resp:
-                    resp.raise_for_status()
+                    # W2-2 (AUTH-02/ERRTAX-01): a true-HTTP 4xx from
+                    # /generateToken must not escape as a raw
+                    # aiohttp.ClientResponseError. Map credential-rejection
+                    # statuses to InvalidCredentialsError and every other
+                    # non-2xx to RestgdfResponseError, both under the
+                    # RestgdfError umbrella, chained from the aiohttp error.
+                    # Scope this to the raise_for_status edge only: the
+                    # HTTP-200 JSON-error-envelope path is left to the strict
+                    # TokenResponse tier below (raise_for_status no-ops on 200).
+                    try:
+                        resp.raise_for_status()
+                    except aiohttp.ClientResponseError as exc:
+                        if exc.status in (400, 401, 403):
+                            raise InvalidCredentialsError(
+                                f"{exc.status} credential rejection from "
+                                f"{self.token_url}",
+                                context=self.token_url,
+                                cause=exc,
+                            ) from exc
+                        raise RestgdfResponseError(
+                            f"{exc.status} non-2xx from {self.token_url}",
+                            context=self.token_url,
+                            status_code=exc.status,
+                        ) from exc
                     data = await resp.json()
                 envelope = _parse_response(TokenResponse, data, context=self.token_url)
                 self.token = envelope.token
                 self.expires = envelope.expires
                 _auth_logger.debug("auth.refresh.success url=%s", self.token_url)
                 return
+            except RestgdfError:
+                # W2-3 (ERRTAX-02): restgdf's own deterministic errors
+                # co-inherit OSError via PermissionError
+                # (AuthenticationError -> PermissionError -> OSError). Without
+                # this guard placed BEFORE `except _RETRYABLE_ERRORS`, the
+                # None-credentials AuthenticationError from
+                # token_request_payload, the W2-2 InvalidCredentialsError, and
+                # the TokenResponse parse RestgdfResponseError would all be
+                # swept into the OSError retry bucket and mislabeled
+                # TokenRefreshFailedError. The match is by real exception
+                # instance (MRO), never by class name. Nothing raised inside
+                # the try that is a RestgdfError is a retryable transient, so
+                # it propagates immediately (no backoff). It is still a refresh
+                # failure, so it emits the documented auth.refresh.failure event.
+                _auth_logger.debug(
+                    "auth.refresh.failure url=%s attempt=%d/%d",
+                    self.token_url,
+                    attempt,
+                    _MAX_TOKEN_RETRIES,
+                )
+                raise
             except _RETRYABLE_ERRORS as exc:
                 last_exc = exc
                 _auth_logger.debug(
@@ -388,6 +479,26 @@ class ArcGISTokenSession:
           raise :class:`TokenExpiredError`.
         * **499** (Token Required): raise :class:`AuthNotAttachedError`
           immediately — no refresh, no retry.
+
+        W2-5 (ERRTAX-03) — **deferred, documented HTTP-status-only scope.**
+        Detection reads ``resp.status`` only; the common ArcGIS in-body
+        envelope shape (HTTP 200 carrying ``{"error": {"code": 498|499}}``)
+        is intentionally NOT inspected here. Reading the body in this retry
+        helper would consume the response stream that every downstream caller
+        re-reads, so in-body detection cannot live at this seam — it requires
+        lifting the refresh/retry decision into the parse layer
+        (``_models/_drift._parse_response``, W5-owned). This is a low-severity
+        resilience/ergonomics enhancement, not a correctness gap: an in-body
+        499 already surfaces as :class:`~restgdf.errors.RestgdfResponseError`
+        via the strict parse tier, so no data is silently lost; only callers
+        catching :class:`~restgdf.errors.TokenExpiredError` /
+        :class:`~restgdf.errors.AuthNotAttachedError` *specifically* miss the
+        in-body shape. **Owner:** a future reactive-auth-detection design pass
+        coordinated with the ``_drift.py`` owner. **Trigger to revisit:** a
+        maintainer go decision to change the documented status-only contract
+        (CHANGELOG BL-11 / MIGRATION R-14 / ARCHITECTURE "HTTP 498/499"), or
+        field reports of ArcGIS servers returning 498/499 as HTTP-200
+        envelopes causing silent auth failures for such callers.
         """
         await self.update_token_if_needed()
 

--- a/restgdf/utils/token.py
+++ b/restgdf/utils/token.py
@@ -121,10 +121,10 @@ class ArcGISTokenSession:
     the request path.
 
     ``__post_init__`` never reads the process-global
-    :func:`~restgdf._config.get_config`: a plain
+    ``get_config``: a plain
     ``ArcGISTokenSession(session, credentials)`` keeps its dataclass
     defaults (e.g. ``token_refresh_threshold=60``). The
-    :class:`~restgdf._config.AuthConfig` refresh knobs are config
+    ``AuthConfig`` refresh knobs are config
     holders, not auto-applied; opt in explicitly with
     :meth:`from_config` when you want the ``RESTGDF_AUTH_*`` namespace to
     drive a session's refresh timing / transport.
@@ -191,7 +191,7 @@ class ArcGISTokenSession:
         *,
         config: AuthConfig | None = None,
     ) -> ArcGISTokenSession:
-        """Build a token session from an :class:`~restgdf._config.AuthConfig` (opt-in).
+        """Build a token session from an ``AuthConfig`` (opt-in).
 
         W3-3 (CONFIG-02, hybrid decision): this classmethod is the ONLY
         sanctioned path by which an ``AuthConfig`` namespace flows into a

--- a/tests/test_token_4xx_taxonomy.py
+++ b/tests/test_token_4xx_taxonomy.py
@@ -146,10 +146,8 @@ class TestW2_2_FourXXMapsToTaxonomy:
 class TestW2_2_TransientStillRetried:
     @pytest.mark.asyncio
     async def test_timeout_during_refresh_still_hits_retry_ladder(self):
-        import asyncio
-
         async def always_timeout():
-            raise asyncio.TimeoutError("slow")
+            raise TimeoutError("slow")
 
         ctx = AsyncMock()
         ctx.__aenter__ = AsyncMock(side_effect=always_timeout)

--- a/tests/test_token_4xx_taxonomy.py
+++ b/tests/test_token_4xx_taxonomy.py
@@ -1,0 +1,203 @@
+"""W2-2 / W2-3 (AUTH-02, ERRTAX-01, ERRTAX-02): /generateToken error taxonomy.
+
+W2-2 — a true-HTTP 4xx from ``/generateToken`` must surface through the
+``RestgdfError`` umbrella (``InvalidCredentialsError`` for 400/401/403,
+``RestgdfResponseError`` for other non-2xx) instead of escaping as a raw
+``aiohttp.ClientResponseError``. The HTTP-200 JSON-error-envelope path is
+unchanged (still ``RestgdfResponseError`` via the strict ``TokenResponse``
+tier). A transient network error during refresh is still retried, never
+reclassified as a credential failure.
+
+W2-3 — restgdf's own deterministic errors co-inherit ``OSError`` via
+``PermissionError`` (``AuthenticationError`` → ``PermissionError`` →
+``OSError``). Without an ``except RestgdfError: raise`` guard placed *before*
+``except _RETRYABLE_ERRORS`` they are swept into the ``OSError`` retry bucket
+and mislabeled ``TokenRefreshFailedError``. The guard distinguishes error
+classes by real exception instances (MRO), not by name.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from pydantic import SecretStr
+
+from restgdf.errors import (
+    AuthenticationError,
+    InvalidCredentialsError,
+    RestgdfError,
+    RestgdfResponseError,
+    TokenRefreshFailedError,
+)
+from restgdf.utils.token import ArcGISTokenSession
+
+
+def _creds():
+    from restgdf._models.credentials import AGOLUserPass
+
+    return AGOLUserPass(username="u", password=SecretStr("p"))
+
+
+def _session_raise_for_status(status: int, *, message: str = "err") -> MagicMock:
+    """Mock aiohttp session whose ``/generateToken`` POST resp.raise_for_status raises."""
+    resp = AsyncMock()
+    err = aiohttp.ClientResponseError(
+        request_info=MagicMock(),
+        history=(),
+        status=status,
+        message=message,
+    )
+    resp.raise_for_status = MagicMock(side_effect=err)
+    resp.json = AsyncMock(return_value={})
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=resp)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post = MagicMock(return_value=ctx)
+    return session
+
+
+def _session_200_envelope(body: dict) -> MagicMock:
+    """Mock session returning HTTP 200 with an in-body ArcGIS error envelope."""
+    resp = AsyncMock()
+    resp.raise_for_status = MagicMock(return_value=None)
+    resp.json = AsyncMock(return_value=body)
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=resp)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post = MagicMock(return_value=ctx)
+    return session
+
+
+class TestW2_2_FourXXMapsToTaxonomy:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [400, 401, 403])
+    async def test_4xx_credential_status_raises_invalid_credentials(self, status):
+        ts = ArcGISTokenSession(
+            session=_session_raise_for_status(status),
+            credentials=_creds(),
+        )
+        with patch("restgdf.utils.token.asyncio.sleep", new_callable=AsyncMock) as sl:
+            with pytest.raises(InvalidCredentialsError) as exc_info:
+                await ts.update_token()
+        # No raw aiohttp escape: it is under the RestgdfError umbrella and
+        # catchable as AuthenticationError and PermissionError (MRO).
+        assert isinstance(exc_info.value, AuthenticationError)
+        assert isinstance(exc_info.value, RestgdfError)
+        assert isinstance(exc_info.value, PermissionError)
+        # Deterministic: not retried (no backoff sleeps).
+        assert sl.await_count == 0
+        # Original aiohttp error is chained, not swallowed.
+        assert isinstance(exc_info.value.__cause__, aiohttp.ClientResponseError)
+
+    @pytest.mark.asyncio
+    async def test_non_credential_4xx_5xx_raises_response_error_not_invalid_creds(self):
+        ts = ArcGISTokenSession(
+            session=_session_raise_for_status(500),
+            credentials=_creds(),
+        )
+        with patch("restgdf.utils.token.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(RestgdfResponseError) as exc_info:
+                await ts.update_token()
+        assert not isinstance(exc_info.value, InvalidCredentialsError)
+        assert isinstance(exc_info.value.__cause__, aiohttp.ClientResponseError)
+
+    @pytest.mark.asyncio
+    async def test_no_raw_aiohttp_error_escapes(self):
+        """The failure mode this item exists to avoid: raw aiohttp on a 4xx."""
+        ts = ArcGISTokenSession(
+            session=_session_raise_for_status(401),
+            credentials=_creds(),
+        )
+        with patch("restgdf.utils.token.asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(RestgdfError):
+                await ts.update_token()
+        # Prove it is NOT a bare aiohttp error escaping.
+        ts2 = ArcGISTokenSession(
+            session=_session_raise_for_status(401),
+            credentials=_creds(),
+        )
+        with patch("restgdf.utils.token.asyncio.sleep", new_callable=AsyncMock):
+            raised_raw = False
+            try:
+                await ts2.update_token()
+            except aiohttp.ClientResponseError:
+                raised_raw = True
+            except RestgdfError:
+                raised_raw = False
+        assert raised_raw is False
+
+    @pytest.mark.asyncio
+    async def test_http_200_error_envelope_still_response_error(self):
+        """The 200 + {"error": {...}} path is unchanged (strict TokenResponse tier)."""
+        ts = ArcGISTokenSession(
+            session=_session_200_envelope(
+                {"error": {"code": 400, "message": "Invalid username or password."}},
+            ),
+            credentials=_creds(),
+        )
+        with pytest.raises(RestgdfResponseError):
+            await ts.update_token()
+
+
+class TestW2_2_TransientStillRetried:
+    @pytest.mark.asyncio
+    async def test_timeout_during_refresh_still_hits_retry_ladder(self):
+        import asyncio
+
+        async def always_timeout():
+            raise asyncio.TimeoutError("slow")
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(side_effect=always_timeout)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.post = MagicMock(return_value=ctx)
+        ts = ArcGISTokenSession(session=session, credentials=_creds())
+
+        with patch(
+            "restgdf.utils.token.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sl:
+            # A transient error is NEVER reclassified as a credential failure.
+            with pytest.raises(TokenRefreshFailedError):
+                await ts.update_token()
+        assert sl.await_count == 2  # _MAX_TOKEN_RETRIES - 1 backoffs
+
+
+class TestW2_3_DeterministicAuthNotSwallowed:
+    @pytest.mark.asyncio
+    async def test_none_credentials_raises_authentication_error_immediately(self):
+        """None-cred AuthenticationError (an OSError via PermissionError) must not retry."""
+        ts = ArcGISTokenSession(session=MagicMock(), credentials=None)
+        with patch("restgdf.utils.token.asyncio.sleep", new_callable=AsyncMock) as sl:
+            with pytest.raises(AuthenticationError) as exc_info:
+                await ts.update_token()
+        # NOT reclassified as TokenRefreshFailedError, and zero backoff sleeps.
+        assert not isinstance(exc_info.value, TokenRefreshFailedError)
+        assert sl.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_genuine_oserror_still_retries_then_refresh_failed(self):
+        """A real socket-layer OSError is still retryable and ends as TokenRefreshFailedError."""
+
+        async def always_oserror():
+            raise OSError("connection reset")
+
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(side_effect=always_oserror)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        session = MagicMock()
+        session.post = MagicMock(return_value=ctx)
+        ts = ArcGISTokenSession(session=session, credentials=_creds())
+
+        with patch(
+            "restgdf.utils.token.asyncio.sleep",
+            new_callable=AsyncMock,
+        ) as sl:
+            with pytest.raises(TokenRefreshFailedError):
+                await ts.update_token()
+        assert sl.await_count == 2

--- a/tests/test_token_from_config.py
+++ b/tests/test_token_from_config.py
@@ -1,0 +1,108 @@
+"""W2-11 (AUTH-04/CONFIG-02) + W3-3 (CONFIG-02 token half): opt-in AuthConfig wiring.
+
+The hybrid decision (master plan §Decision record): ``AuthConfig`` is wired into a
+token session ONLY via an opt-in factory, never implicitly through
+``ArcGISTokenSession.__post_init__``. Two coordinated surfaces:
+
+* ``TokenSessionConfig.from_auth_config(auth_config, credentials)`` (W2-11) —
+  projects an ``AuthConfig`` namespace onto a validated ``TokenSessionConfig``.
+* ``ArcGISTokenSession.from_config(session, credentials, config=...)`` (W3-3
+  token half) — the opt-in classmethod; ``config`` defaults to
+  ``get_config().auth`` but is only read when the classmethod is invoked, never
+  at import time and never in ``__post_init__``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from pydantic import SecretStr
+
+from restgdf._config import AuthConfig
+from restgdf._models.credentials import AGOLUserPass, TokenSessionConfig
+from restgdf.utils.token import ArcGISTokenSession
+
+
+def _creds():
+    return AGOLUserPass(username="u", password=SecretStr("p"))
+
+
+class TestFromAuthConfigFactory:
+    def test_projects_refresh_knobs_and_transport(self):
+        auth = AuthConfig(
+            token_url="https://enterprise.example.com/portal/sharing/rest/generateToken",
+            transport="body",
+            refresh_leeway_s=300.0,
+            clock_skew_s=45.0,
+        )
+        tsc = TokenSessionConfig.from_auth_config(auth, _creds())
+        assert isinstance(tsc, TokenSessionConfig)
+        assert tsc.refresh_leeway_seconds == 300
+        assert tsc.clock_skew_seconds == 45
+        assert tsc.transport == "body"
+        assert tsc.token_url.endswith("/generateToken")
+        # Effective refresh threshold reflects the AuthConfig values.
+        assert tsc.refresh_leeway_seconds + tsc.clock_skew_seconds == 345
+
+    def test_none_token_url_falls_back_to_default(self):
+        auth = AuthConfig()  # token_url defaults to None
+        tsc = TokenSessionConfig.from_auth_config(auth, _creds())
+        assert tsc.token_url.startswith("https://")
+        assert tsc.token_url.endswith("/generateToken")
+
+    def test_referer_prefers_auth_config_then_credentials(self):
+        auth = AuthConfig(referer="https://portal.example.com")
+        tsc = TokenSessionConfig.from_auth_config(auth, _creds())
+        assert tsc.referer == "https://portal.example.com"
+
+        cred = AGOLUserPass(
+            username="u",
+            password=SecretStr("p"),
+            referer="https://cred.example.com",
+        )
+        tsc2 = TokenSessionConfig.from_auth_config(AuthConfig(), cred)
+        assert tsc2.referer == "https://cred.example.com"
+
+
+class TestFromConfigClassmethod:
+    def test_explicit_config_threads_refresh_window(self):
+        ts = ArcGISTokenSession.from_config(
+            session=MagicMock(),
+            credentials=_creds(),
+            config=AuthConfig(refresh_leeway_s=300.0, clock_skew_s=45.0),
+        )
+        assert isinstance(ts, ArcGISTokenSession)
+        assert isinstance(ts.config, TokenSessionConfig)
+        # threshold = leeway + skew derived from the AuthConfig instance.
+        assert ts.token_refresh_threshold == 345
+
+    def test_config_none_reads_get_config_auth(self):
+        from restgdf._config import reset_config_cache
+
+        reset_config_cache()
+        ts = ArcGISTokenSession.from_config(session=MagicMock(), credentials=_creds())
+        # Default AuthConfig: refresh_leeway_s=120 + clock_skew_s=30 -> 150.
+        assert ts.token_refresh_threshold == 150
+
+    def test_transport_and_header_name_threaded(self):
+        ts = ArcGISTokenSession.from_config(
+            session=MagicMock(),
+            credentials=_creds(),
+            config=AuthConfig(transport="body", header_name="X-Custom-Auth"),
+        )
+        assert ts.config is not None
+        assert ts.config.transport == "body"
+        assert ts.config.header_name == "X-Custom-Auth"
+
+
+class TestPlainConstructionDoesNotConsumeConfig:
+    def test_plain_session_keeps_dataclass_default_threshold(self):
+        """No implicit get_config() read: a plain session keeps the 60s default."""
+        ts = ArcGISTokenSession(session=MagicMock(), credentials=_creds())
+        # A bare ArcGISTokenSession with only credentials derives its window from
+        # the dataclass default (60), NOT from get_config().auth (which would be
+        # 150). Proves __post_init__ never reaches into the process-global config.
+        assert ts.token_refresh_threshold == 60
+
+    def test_from_config_is_a_classmethod(self):
+        assert callable(ArcGISTokenSession.from_config)


### PR DESCRIPTION
M3 lane L2 (wave verifier CONFIRMED). W2-2: /generateToken 400/401/403 → InvalidCredentialsError, other non-2xx → RestgdfResponseError — no raw aiohttp escape (explicit no-escape test); TokenRequiredError demoted per recorded default. W2-3: the retry filter discriminates deterministic auth errors by instance/MRO — immediate raise, zero sleeps; genuine transport errors still retry. W2-11 + W3-3 token-half: opt-in ArcGISTokenSession.from_config/from_auth_config, AuthConfig read lazily at call time (150s effective refresh threshold documented). W2-5 in-body envelope detection: NO-GO per plan recommendation, owner+trigger recorded, ratified. Suite 1289/4/4 (+17) · mypy 0 · pre-commit fixed point · red proofs on disk. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk