### PR TITLE
feat: inert-config warnings, drift attribution, stats correctness, opt-in from_config surface (W2-13, W3-2/4, W5-2/3/6/13/14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- **`FeatureLayer.from_config` / `Directory.from_config`** — opt-in
+  classmethods that build a prepared instance from an explicit
+  `restgdf.Config`, applying `config.auth.token` as the request token before
+  delegating to `from_url` (W5-14 / CONFIG-02). They are deliberately explicit:
+  `config` is a required argument, so nothing implicitly reads the
+  process-global `get_config()` at construction, and no global `Config` is
+  threaded into the request path (CONFIG-03). The forwarded token rides the
+  standard `token=` path (POST-forced by AUTH-01, never URL-serialized); for
+  header-transport secured services prefer building an
+  `ArcGISTokenSession.from_config(...)` and passing it as `session=`.
+
 ### Changed
 
 - **Multi-page offset/count pagination now sends a deterministic
@@ -43,6 +56,25 @@ All notable changes to restgdf are documented here. This project follows
   `RESTGDF_TRANSPORT_USER_AGENT` / `TransportConfig.user_agent`. The
   exported `DEFAULT_METADATA_HEADERS` constant keeps its historical value
   for back-compat but no longer determines the wire `User-Agent`.
+- **Setting a currently-inert `RESTGDF_*` knob now warns.** `Config.from_env`
+  (hence `get_config()`) emits one `restgdf._config.InertConfigWarning`
+  (a `UserWarning`) naming any set-but-unwired `RESTGDF_RETRY_*` /
+  `RESTGDF_LIMITER_*` / `RESTGDF_AUTH_REFRESH_THRESHOLD_S` variable — those
+  validate into `Config` but no live path consumes them (the resilience
+  executor hardcodes its retry/limiter policy; token sessions never read
+  `AuthConfig.refresh_threshold_s`). The knobs and their env aliases stay
+  wired for back-compat; real executor/session wiring is deferred (warn-now,
+  wire-later; W2-13 / TRANSPORT-01 / AUTH-04). Silence with
+  `warnings.filterwarnings("ignore", category=restgdf._config.InertConfigWarning)`.
+- **`nested_count` / `FeatureLayer.get_nested_count` now require exactly two
+  fields.** Passing any other arity raises a clear `ValueError` instead of an
+  `IndexError` deep in post-processing (one field) or leaving a redundant
+  `*_count` column with an incomplete sort (three or more) (W5-3 / API-04).
+- Schema-drift log records now carry the originating service **context** (in
+  the message and a `drift_context` extra field) so the first, non-deduped
+  occurrence is attributable to which service drifted. The dedupe key stays
+  the context-free `(model, field, kind, type)` 4-tuple, preserving the
+  anti-spam guarantee for many-layer servers (W5-13 / TELEMETRY-02).
 
 ### Fixed
 
@@ -127,6 +159,19 @@ All notable changes to restgdf are documented here. This project follows
   — `Config.from_env()` resolves only from the process environment (`os.environ`).
   The docs now show how to opt in explicitly with `python-dotenv` yourself
   (W3-5, CONFIG-04).
+- **`FeatureLayer.get_value_counts` / `get_nested_count` now send a
+  conservative statistics body.** The instance request `data` (carrying
+  `returnGeometry=True` / `outFields="*"` / `returnCountOnly=False`) previously
+  clobbered the stats-only flags, so the server received a geometry+all-fields
+  query instead of the grouped statistics one. The bodies now forward only
+  `where`+`token` from the caller data (matching `get_unique_values`), so the
+  stats flags win while the instance `where` filter is preserved (W5-2 /
+  API-01).
+- `resolve_domains` (used by `FeatureLayer.get_df(resolve_domains=True)`) is
+  now robust to malformed-but-real domain metadata: a non-dict `domain` is
+  skipped instead of raising `AttributeError`, and coded values are mapped
+  only when they carry both `code` and `name`. A name-less code passes through
+  unchanged rather than being silently replaced with `NaN` (W5-6 / ADAPTERS-03).
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -393,7 +393,7 @@ class Config(BaseModel):
     ``Config`` instance somewhere and expecting it to override the process
     global would silently do nothing. To change resolved configuration, set
     the ``RESTGDF_*`` environment variables (then call
-    :func:`reset_config_cache`) -- the single documented precedence is
+    ``reset_config_cache``) -- the single documented precedence is
     constructor/aiohttp kwargs > env vars > model defaults, resolved
     process-globally. The separate, intentionally session-scoped
     ``ArcGISTokenSession(config=...)`` / ``TokenSessionConfig`` injection is

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -144,12 +144,40 @@ class ConcurrencyConfig(BaseModel):
 
 
 class AuthConfig(BaseModel):
-    """ArcGIS token-session defaults.
+    """ArcGIS token-session defaults (validated ``RESTGDF_AUTH_*`` namespace).
 
     .. versionchanged:: 3.0
         Default *transport* flipped from ``"body"`` to ``"header"``; default
         *header_name* is ``"X-Esri-Authorization"``.  Pass
         ``allow_query_transport=True`` to enable ``transport="query"``.
+
+    Not auto-applied to token sessions (AUTH-04 / CONFIG-02)
+    -------------------------------------------------------
+    ``AuthConfig`` is a *validated namespace* for the ``RESTGDF_AUTH_*``
+    environment variables; it is **not** auto-applied to any
+    :class:`~restgdf.utils.token.ArcGISTokenSession`. In particular the three
+    refresh knobs -- ``refresh_threshold_s``, ``refresh_leeway_s`` and
+    ``clock_skew_s`` -- are config *holders*, exactly like the
+    :class:`RetryConfig`/``LimiterConfig`` inert notes above: reading them off
+    ``get_config().auth`` changes nothing about a live session's refresh
+    timing on its own. The library never constructs the token session for
+    you, and ``ArcGISTokenSession.__post_init__`` deliberately never reads
+    ``get_config()`` -- a process-wide singleton flip must not silently change
+    transport/refresh timing for every session in the process.
+
+    To make these values take effect, construct a
+    :class:`~restgdf._models.credentials.TokenSessionConfig` explicitly and
+    pass it to ``ArcGISTokenSession`` -- e.g. via the opt-in
+    ``TokenSessionConfig.from_auth_config(get_config().auth)`` /
+    ``ArcGISTokenSession.from_config(...)`` hand-off (W2-11). Only that
+    explicit hand-off threads ``AuthConfig`` into a running session.
+
+    Default split to be aware of: a bare ``TokenSessionConfig`` derives its
+    refresh window from ``refresh_leeway_seconds (120) + clock_skew_seconds
+    (30) = 150`` s, whereas a bare ``ArcGISTokenSession`` uses the dataclass
+    default ``token_refresh_threshold = 60`` s. A caller migrating from the
+    dataclass argument to a config-driven session should expect ``150`` s,
+    not ``60`` s; the ``from_auth_config`` path is internally consistent.
     """
 
     model_config = _FROZEN
@@ -324,6 +352,23 @@ class Config(BaseModel):
 
     Use :func:`get_config` (process-cached) rather than instantiating directly
     in production code; direct instantiation is useful for tests.
+
+    Not request-path-injectable (CONFIG-03)
+    ---------------------------------------
+    A freshly built ``Config(...)`` instance is **test-only**: it is *not*
+    threaded into the runtime request path. Every library consumer
+    (``utils._http``, ``utils.getgdf``, ``utils.getinfo``, ``utils.crawl``,
+    ``telemetry._spans``) resolves configuration through the no-arg
+    process-global :func:`get_config`; there is no public API that accepts an
+    explicit ``Config`` and honors it below the public constructor. Passing a
+    ``Config`` instance somewhere and expecting it to override the process
+    global would silently do nothing. To change resolved configuration, set
+    the ``RESTGDF_*`` environment variables (then call
+    :func:`reset_config_cache`) -- the single documented precedence is
+    constructor/aiohttp kwargs > env vars > model defaults, resolved
+    process-globally. The separate, intentionally session-scoped
+    ``ArcGISTokenSession(config=...)`` / ``TokenSessionConfig`` injection is
+    *not* a global ``Config`` override -- do not conflate the two.
     """
 
     model_config = _FROZEN

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -59,6 +59,37 @@ from restgdf._models._settings import _VALID_LOG_LEVELS, _default_user_agent
 
 _FROZEN = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
+
+class InertConfigWarning(UserWarning):
+    """A ``RESTGDF_*`` env var is set but does not (yet) affect runtime.
+
+    Emitted once (per :func:`Config.from_env` resolution) when a caller sets
+    a validated-but-currently-inert knob -- the ``RESTGDF_RETRY_*`` /
+    ``RESTGDF_LIMITER_*`` values (the resilience executor hardcodes its retry
+    and rate-limit policy) or ``RESTGDF_AUTH_REFRESH_THRESHOLD_S`` (token
+    sessions do not read ``AuthConfig``; see :class:`AuthConfig`). The value
+    still validates into :class:`Config`, but nothing consumes it yet
+    (warn-now, wire-later per the AUTH-04 / TRANSPORT-01 decision). Silence it
+    with
+    ``warnings.filterwarnings("ignore", category=restgdf._config.InertConfigWarning)``.
+    """
+
+
+# ``RESTGDF_*`` env keys that validate into :class:`Config` but that no live
+# code path reads yet (verified 2026-07-24: the ``@stamina.retry`` executor
+# hardcodes its policy and never reads ``config.retry``/``config.limiter``;
+# ``AuthConfig.refresh_threshold_s`` is surfaced only through the deprecated
+# ``Settings`` shim, never applied to a token session). Kept intact as a
+# back-compat seam (tests pin them); real wiring is deferred (W2-13/AUTH-04).
+_INERT_ENV_KEYS: tuple[str, ...] = (
+    "RESTGDF_RETRY_ENABLED",
+    "RESTGDF_RETRY_MAX_ATTEMPTS",
+    "RESTGDF_RETRY_MAX_DELAY_S",
+    "RESTGDF_LIMITER_ENABLED",
+    "RESTGDF_LIMITER_RATE_PER_HOST",
+    "RESTGDF_AUTH_REFRESH_THRESHOLD_S",
+)
+
 # pydantic HttpUrl-based validator for ``token_url`` strings. We keep the
 # public field type as ``str`` so consumers (e.g. TokenSessionConfig) that
 # expect plain strings do not break, but we reuse pydantic's URL parser for
@@ -464,6 +495,26 @@ class Config(BaseModel):
             )
             _coerce(old_key, dotted, caster)
 
+        # W2-13 (TRANSPORT-01 / AUTH-04): a validated-but-inert knob is a
+        # silent lie -- the caller set it expecting an effect it never has.
+        # Emit ONE consolidated warning naming every inert key that is set.
+        # ``get_config`` is LRU-cached size-1, so in production this resolves
+        # (and warns) at most once per process; the knobs + env aliases stay
+        # wired (tests pin them). Real executor/session wiring is deferred.
+        inert_present = [key for key in _INERT_ENV_KEYS if key in source]
+        if inert_present:
+            warnings.warn(
+                "These RESTGDF_* environment variables are set but currently "
+                "inert -- they validate into Config yet do not affect runtime "
+                "behavior (the resilience executor hardcodes retry/limiter "
+                "policy; token sessions do not read "
+                "AuthConfig.refresh_threshold_s): "
+                f"{', '.join(sorted(inert_present))}. Real wiring is deferred "
+                "(warn-now, wire-later; see AUTH-04 / TRANSPORT-01).",
+                InertConfigWarning,
+                stacklevel=_warn_stacklevel,
+            )
+
         try:
             return cls(
                 transport=TransportConfig(**sub_kwargs["transport"]),
@@ -512,6 +563,7 @@ __all__ = [
     "AuthConfig",
     "ConcurrencyConfig",
     "Config",
+    "InertConfigWarning",
     "LimiterConfig",
     "ResilienceConfig",
     "RetryConfig",

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -182,8 +182,7 @@ class AuthConfig(BaseModel):
         *header_name* is ``"X-Esri-Authorization"``.  Pass
         ``allow_query_transport=True`` to enable ``transport="query"``.
 
-    Not auto-applied to token sessions (AUTH-04 / CONFIG-02)
-    -------------------------------------------------------
+    **Not auto-applied to token sessions (AUTH-04 / CONFIG-02).**
     ``AuthConfig`` is a *validated namespace* for the ``RESTGDF_AUTH_*``
     environment variables; it is **not** auto-applied to any
     :class:`~restgdf.utils.token.ArcGISTokenSession`. In particular the three
@@ -384,8 +383,7 @@ class Config(BaseModel):
     Use :func:`get_config` (process-cached) rather than instantiating directly
     in production code; direct instantiation is useful for tests.
 
-    Not request-path-injectable (CONFIG-03)
-    ---------------------------------------
+    **Not request-path-injectable (CONFIG-03).**
     A freshly built ``Config(...)`` instance is **test-only**: it is *not*
     threaded into the runtime request path. Every library consumer
     (``utils._http``, ``utils.getgdf``, ``utils.getinfo``, ``utils.crawl``,

--- a/restgdf/_models/_drift.py
+++ b/restgdf/_models/_drift.py
@@ -94,6 +94,7 @@ def _log_drift(
     kind: str,
     sample: Any,
     level: int,
+    context: str | None = None,
 ) -> None:
     """Emit a deduped drift log record.
 
@@ -101,6 +102,16 @@ def _log_drift(
     repeated occurrences of the same drift against the same model do not
     spam the log; semantically-distinct drift (different field or
     different observed type) still logs.
+
+    ``context`` (TELEMETRY-02 / W5-13) is threaded into the emitted record --
+    both in the message and as a ``drift_context`` ``extra`` field -- so the
+    first, non-deduped occurrence is attributable to its originating
+    service/URL. It is deliberately **excluded** from the dedupe key: a
+    drifty server exposing 500 distinct layer URLs must still collapse to
+    ONE record per ``(model, field, kind, type)`` tuple, not 500. The
+    trade-off is that a second service producing the identical tuple is
+    silenced (deduped) rather than re-attributed -- message attribution, not
+    per-service dedup, is the chosen scope; see MIGRATION.md (W6-4).
     """
     sample_type = type(sample).__name__
     key: _DriftKey = (model_name, path, kind, sample_type)
@@ -110,12 +121,15 @@ def _log_drift(
     logger = get_drift_logger()
     logger.log(
         level,
-        "schema drift on %s: field=%r kind=%s observed_type=%s sample=%r",
+        "schema drift on %s: field=%r kind=%s observed_type=%s context=%r "
+        "sample=%r",
         model_name,
         path,
         kind,
         sample_type,
+        context,
         sample,
+        extra={"drift_context": context},
     )
 
 
@@ -184,6 +198,18 @@ def _parse_response(
             ) from exc
 
     if _is_arcgis_error_envelope(raw):
+        # W2-5 (ERRTAX-03) status: an in-body ``{"error": {"code": 498|499}}``
+        # envelope currently surfaces here as a generic ``RestgdfResponseError``
+        # -- HTTP-status-only typed 498/499 detection is the documented
+        # contract (CHANGELOG BL-11 / MIGRATION R-14 / ARCHITECTURE). Mapping
+        # in-body code 498 -> TokenExpiredError / 499 -> AuthNotAttachedError
+        # (and firing the 498 auto-refresh on the in-body shape) is DEFERRED:
+        # it is a maintainer go/no-go-gated, documented-scope change whose
+        # auto-refresh half must be lifted above this parse layer into
+        # ``token._call_with_auth_retry`` (W2, L2-owned). Trigger to implement:
+        # maintainer GO + the coordinated token.py refresh-lift landing. Until
+        # then callers catching ``RestgdfResponseError`` already catch this;
+        # no data is silently lost.
         error = raw["error"]
         message = error.get("message") or "ArcGIS error response"
         code = error.get("code")
@@ -204,6 +230,7 @@ def _parse_response(
             kind="not_a_mapping",
             sample=raw,
             level=logging.WARNING,
+            context=context,
         )
 
     try:
@@ -226,6 +253,7 @@ def _parse_response(
                 kind="bad_type",
                 sample=sample,
                 level=logging.DEBUG,
+                context=context,
             )
             if (
                 len(loc) > 1
@@ -258,6 +286,7 @@ def _parse_response(
                 kind="unknown_extra",
                 sample=extra_val,
                 level=logging.DEBUG,
+                context=context,
             )
 
     result: _M = instance
@@ -351,6 +380,7 @@ class FieldSetDriftObserver:
                 kind="field_appeared",
                 sample=appeared,
                 level=logging.INFO,
+                context=self._context,
             )
         for disappeared in self._observed - page_keys:
             _log_drift(
@@ -359,6 +389,7 @@ class FieldSetDriftObserver:
                 kind="field_disappeared",
                 sample=disappeared,
                 level=logging.INFO,
+                context=self._context,
             )
         self._observed.update(page_keys)
         self._pages_seen += 1

--- a/restgdf/_models/_drift.py
+++ b/restgdf/_models/_drift.py
@@ -121,8 +121,7 @@ def _log_drift(
     logger = get_drift_logger()
     logger.log(
         level,
-        "schema drift on %s: field=%r kind=%s observed_type=%s context=%r "
-        "sample=%r",
+        "schema drift on %s: field=%r kind=%s observed_type=%s context=%r sample=%r",
         model_name,
         path,
         kind,

--- a/restgdf/adapters/pandas.py
+++ b/restgdf/adapters/pandas.py
@@ -97,12 +97,26 @@ def resolve_domains(
         domain = field.get("domain")
         if not name or not domain or name not in df.columns:
             continue
+        # W5-6 (ADAPTERS-03): a non-dict ``domain`` (e.g. a bare string from a
+        # malformed-but-real payload) must be skipped, not AttributeError on
+        # ``.get``.
+        if not isinstance(domain, dict):
+            continue
         if domain.get("type") != "codedValue":
             # Range domains (and any unknown variants) are intentionally
             # pass-through; see the docstring.
             continue
         coded_values = domain.get("codedValues") or []
-        mapping = {cv["code"]: cv["name"] for cv in coded_values if "code" in cv}
+        # W5-6: require BOTH ``code`` and ``name`` on a well-formed dict entry.
+        # The ``"name" in cv`` guard is CRITICAL: using ``cv.get("name")`` would
+        # map a name-less code to ``None`` and silently NaN-out the real value
+        # via ``Series.replace`` -- data corruption worse than the loud
+        # KeyError. Unresolvable codes must pass through untouched.
+        mapping = {
+            cv["code"]: cv["name"]
+            for cv in coded_values
+            if isinstance(cv, dict) and "code" in cv and "name" in cv
+        }
         if mapping:
             coded_maps[name] = mapping
 

--- a/restgdf/directory/directory.py
+++ b/restgdf/directory/directory.py
@@ -1,8 +1,13 @@
+from typing import TYPE_CHECKING
+
 from restgdf._client._protocols import AsyncHTTPSession
 from restgdf._models.crawl import CrawlReport, CrawlServiceEntry
 from restgdf._models.responses import LayerMetadata
 from restgdf.utils.getinfo import get_metadata
 from restgdf.utils.crawl import fetch_all_data, safe_crawl  # noqa: F401
+
+if TYPE_CHECKING:
+    from restgdf._config import Config
 
 
 class Directory:
@@ -96,6 +101,39 @@ class Directory:
         self = cls(url, **kwargs)
         await self.prep()
         return self
+
+    @classmethod
+    async def from_config(
+        cls,
+        url: str,
+        config: "Config",
+        **kwargs,
+    ) -> "Directory":
+        """Opt-in constructor applying an explicit ``Config``'s auth token.
+
+        Mirrors :meth:`restgdf.FeatureLayer.from_config` (CONFIG-02 / W5-14):
+        **opt-in and explicit** -- the caller passes ``config``; nothing here
+        or in :meth:`__init__` implicitly reads the process-global
+        :func:`~restgdf.get_config` at construction. ``config.auth.token`` is
+        unwrapped and forwarded as the directory ``token``, then delegated to
+        :meth:`from_url`. Other transport settings still resolve through the
+        process-global config at request time; a directly built ``Config`` is
+        not otherwise threaded into the request path (CONFIG-03).
+
+        Parameters
+        ----------
+        url : str
+            ArcGIS Server directory endpoint URL.
+        config : restgdf.Config
+            An explicit configuration instance (required).
+        **kwargs
+            Forwarded to :meth:`from_url` (``session``). Do not also pass
+            ``token=`` -- it is sourced from ``config.auth.token``.
+        """
+        secret = config.auth.token
+        if secret is not None:
+            kwargs.setdefault("token", secret.get_secret_value())
+        return await cls.from_url(url, **kwargs)
 
     async def crawl(
         self,

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -663,7 +663,7 @@ class FeatureLayer:
         Parameters
         ----------
         fields : tuple of str
-            Two or more field names to cross-tabulate.
+            Exactly two field names to cross-tabulate.
 
         Returns
         -------
@@ -676,9 +676,19 @@ class FeatureLayer:
 
         Raises
         ------
+        ValueError
+            If *fields* does not contain exactly two field names (W5-3).
         FieldDoesNotExistError
             If any field in *fields* is not present in the layer schema.
         """
+        # W5-3 (API-04): the underlying helper cross-tabulates exactly two
+        # fields (it indexes fields[0]/fields[1]); reject other arities with a
+        # clear error instead of a deep IndexError / silently-wrong output.
+        if len(fields) != 2:
+            raise ValueError(
+                "get_nested_count requires exactly two field names; got "
+                f"{len(fields)}: {fields!r}",
+            )
         if fields not in self.nestedcount:
             if any(field not in self.fields for field in fields):
                 raise FieldDoesNotExistError(

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -61,10 +61,24 @@ if TYPE_CHECKING:
     from geopandas import GeoDataFrame
     from pandas import DataFrame
 
+    from restgdf._config import Config
+
 
 def _require_featurelayer_geo_support(feature: str) -> None:
     """Fail fast for FeatureLayer GeoDataFrame helpers on base installs."""
     require_geo_stack(feature)
+
+
+def _auth_token_from_config(config: Config) -> str | None:
+    """Return the plaintext ``config.auth.token`` (unwrapped), or ``None``.
+
+    W5-14: the single ``AuthConfig`` value consumed by the opt-in
+    ``from_config`` construction seam. The credential is unwrapped from its
+    :class:`pydantic.SecretStr` only here, at the point it is threaded into
+    the request token.
+    """
+    secret = config.auth.token
+    return secret.get_secret_value() if secret is not None else None
 
 
 class FeatureLayer:
@@ -243,6 +257,62 @@ class FeatureLayer:
         self = cls(url, **kwargs)
         await self.prep()
         return self
+
+    @classmethod
+    async def from_config(
+        cls,
+        url: str,
+        config: Config,
+        **kwargs: Any,
+    ) -> FeatureLayer:
+        """Opt-in constructor that applies an explicit ``Config``'s auth token.
+
+        This is the FeatureLayer-side consume seam for the config hybrid
+        (CONFIG-02 / W5-14). It is **opt-in and explicit**: the caller passes
+        a ``config`` object; ``from_config`` never reads the process-global
+        :func:`~restgdf.get_config` on its own, and neither this method nor
+        :meth:`__init__` implicitly sources configuration at construction
+        time. Pass ``config=get_config()`` if the process config is wanted.
+
+        The one setting consumed is ``config.auth.token`` -- forwarded as the
+        layer ``token`` (the only ``AuthConfig`` field ``FeatureLayer``
+        natively accepts) -- then delegated to :meth:`from_url`. Every other
+        request/transport setting still resolves through the process-global
+        config at request time (the designated W2-10 seam); a directly built
+        ``Config`` is not otherwise threaded into the request path (CONFIG-03,
+        see :class:`restgdf.Config`).
+
+        Transport note: the forwarded token rides the standard
+        ``FeatureLayer(token=...)`` body/query path (AUTH-01 forces POST so it
+        is never serialized into the URL). For header-transport secured
+        services, prefer building an ``ArcGISTokenSession.from_config(...)``
+        and passing it as ``session=`` instead.
+
+        Parameters
+        ----------
+        url : str
+            ArcGIS REST FeatureLayer endpoint URL (must end with a numeric id).
+        config : restgdf.Config
+            An explicit configuration instance (required -- no implicit
+            process-global default).
+        **kwargs
+            Forwarded to :meth:`from_url` (``session``, ``where``, extra HTTP
+            request args). Do not also pass ``token=`` -- it is sourced from
+            ``config.auth.token``.
+
+        Returns
+        -------
+        FeatureLayer
+            A fully prepared instance.
+
+        See Also
+        --------
+        from_url : The underlying constructor this delegates to.
+        """
+        token = _auth_token_from_config(config)
+        if token is not None:
+            kwargs.setdefault("token", token)
+        return await cls.from_url(url, **kwargs)
 
     async def get_oids(self) -> list[int]:
         """Return all object IDs matching the current WHERE filter.

--- a/restgdf/utils/_stats.py
+++ b/restgdf/utils/_stats.py
@@ -114,16 +114,21 @@ async def get_value_counts(
     """Get the value counts for a field."""
     require_pandas_dataframe("get_value_counts()")
     statstr = f'[{{"statisticType":"count","onStatisticField":"{field}","outStatisticFieldName":"{field}_count"}}]'
-    data = kwargs.pop("data", None) or {}
-    data = {
-        "where": "1=1",
-        "f": "json",
-        "returnGeometry": False,
-        "outFields": field,
-        "outStatistics": statstr,
-        "groupByFieldsForStatistics": field,
-        **data,
-    }
+    # W5-2 (API-01): conservative merge -- forward ONLY ``where``+``token``
+    # from the caller data so the instance ``datadict`` (returnGeometry=True /
+    # outFields="*" / returnCountOnly=False) cannot clobber the stats flags,
+    # while the user's WHERE filter is preserved.
+    data = build_conservative_query_data(
+        {
+            "where": "1=1",
+            "f": "json",
+            "returnGeometry": False,
+            "outFields": field,
+            "outStatistics": statstr,
+            "groupByFieldsForStatistics": field,
+        },
+        kwargs.pop("data", None),
+    )
     kwargs.setdefault("timeout", default_timeout())
     response = await _arcgis_request(
         session,
@@ -150,8 +155,20 @@ async def nested_count(
     session: AsyncHTTPSession,
     **kwargs,
 ) -> DataFrame:
-    """Get the nested value counts for a field."""
+    """Get the nested value counts for exactly two fields."""
     require_pandas_dataframe("nested_count()")
+    # W5-3 (API-04): the post-processing indexes ``fields[0]``/``fields[1]``
+    # unconditionally, so a single field IndexErrors deep in the helper and a
+    # third field leaves a redundant ``*_count`` column with an incomplete
+    # sort. Enforce exactly-two arity here too -- the helper is a public
+    # re-exported name (``restgdf.utils.getinfo.nested_count``), so a direct
+    # caller must get the clear error, not the FeatureLayer method alone.
+    field_list = [fields] if isinstance(fields, str) else list(fields)
+    if len(field_list) != 2:
+        raise ValueError(
+            "nested_count requires exactly two field names; got "
+            f"{len(field_list)}: {field_list!r}",
+        )
     statstr = "".join(
         (
             "[",
@@ -162,16 +179,18 @@ async def nested_count(
             "]",
         ),
     )
-    data = kwargs.pop("data", None) or {}
-    data = {
-        "where": "1=1",
-        "f": "json",
-        "returnGeometry": False,
-        "outFields": ",".join(fields),
-        "outStatistics": statstr,
-        "groupByFieldsForStatistics": ",".join(fields),
-        **data,
-    }
+    # W5-2 (API-01): conservative merge -- see get_value_counts above.
+    data = build_conservative_query_data(
+        {
+            "where": "1=1",
+            "f": "json",
+            "returnGeometry": False,
+            "outFields": ",".join(fields),
+            "outStatistics": statstr,
+            "groupByFieldsForStatistics": ",".join(fields),
+        },
+        kwargs.pop("data", None),
+    )
     kwargs.setdefault("timeout", default_timeout())
     response = await _arcgis_request(
         session,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,6 +12,7 @@ from restgdf._config import (
     AuthConfig,
     ConcurrencyConfig,
     Config,
+    InertConfigWarning,
     LimiterConfig,
     RetryConfig,
     TelemetryConfig,
@@ -302,6 +303,55 @@ def test_from_env_empty_mapping_uses_defaults() -> None:
     cfg = Config.from_env(env={})
     assert cfg.timeout.total_s == 30.0
     assert cfg.concurrency.max_concurrent_requests == 8
+
+
+# ---- W2-13 (TRANSPORT-01 / AUTH-04): warn on set-but-inert knobs ----------
+
+
+def test_inert_retry_env_var_warns() -> None:
+    with pytest.warns(InertConfigWarning, match="RESTGDF_RETRY_MAX_ATTEMPTS"):
+        Config.from_env(env={"RESTGDF_RETRY_MAX_ATTEMPTS": "10"})
+
+
+def test_inert_limiter_env_var_warns() -> None:
+    with pytest.warns(InertConfigWarning, match="RESTGDF_LIMITER_RATE_PER_HOST"):
+        Config.from_env(env={"RESTGDF_LIMITER_RATE_PER_HOST": "5"})
+
+
+def test_inert_auth_refresh_env_var_warns() -> None:
+    with pytest.warns(InertConfigWarning, match="RESTGDF_AUTH_REFRESH_THRESHOLD_S"):
+        Config.from_env(env={"RESTGDF_AUTH_REFRESH_THRESHOLD_S": "120"})
+
+
+def test_inert_warning_lists_all_set_keys_in_one_warning() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Config.from_env(
+            env={
+                "RESTGDF_RETRY_MAX_ATTEMPTS": "10",
+                "RESTGDF_LIMITER_ENABLED": "1",
+            },
+        )
+    inert = [w for w in caught if issubclass(w.category, InertConfigWarning)]
+    assert len(inert) == 1, f"expected one consolidated warning, got {len(inert)}"
+    msg = str(inert[0].message)
+    assert "RESTGDF_RETRY_MAX_ATTEMPTS" in msg
+    assert "RESTGDF_LIMITER_ENABLED" in msg
+
+
+def test_honored_env_var_does_not_warn_inert() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Config.from_env(env={"RESTGDF_TIMEOUT_TOTAL_S": "13.0"})
+    assert not [w for w in caught if issubclass(w.category, InertConfigWarning)]
+
+
+def test_inert_warning_surfaces_through_get_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("RESTGDF_RETRY_MAX_ATTEMPTS", "7")
+    with pytest.warns(InertConfigWarning, match="RESTGDF_RETRY_MAX_ATTEMPTS"):
+        get_config()
 
 
 # ---- gate-2: log_level aliases (WARN/FATAL) -------------------------------

--- a/tests/test_from_config.py
+++ b/tests/test_from_config.py
@@ -1,0 +1,88 @@
+"""W5-14 (CONFIG-02 / CONFIG-03): opt-in ``from_config`` construction seam.
+
+Per the config hybrid decision, ``FeatureLayer.from_config`` /
+``Directory.from_config`` are **opt-in and explicit**: the caller passes a
+``Config``; the only setting consumed is ``config.auth.token`` (forwarded as
+the request token), and NOTHING here implicitly reads the process-global
+``get_config()`` at import or construction time. A directly built ``Config``
+is not otherwise threaded into the request path (CONFIG-03 delete-the-claim).
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from restgdf._config import AuthConfig, Config
+from restgdf.directory.directory import Directory
+from restgdf.featurelayer.featurelayer import FeatureLayer
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_from_config_applies_auth_token(
+    fake_session,
+    feature_layer_metadata,
+) -> None:
+    fake_session.post_responses.extend([feature_layer_metadata, {"count": 5}])
+    cfg = Config(auth=AuthConfig(token="cfg-token"))
+    fl = await FeatureLayer.from_config(
+        "https://example.test/MapServer/0",
+        cfg,
+        session=fake_session,
+    )
+    # The explicit config's token reached the request datadict.
+    assert fl.datadict["token"] == "cfg-token"
+    assert fl.count == 5
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_from_config_no_token_when_config_has_none(
+    fake_session,
+    feature_layer_metadata,
+) -> None:
+    fake_session.post_responses.extend([feature_layer_metadata, {"count": 0}])
+    fl = await FeatureLayer.from_config(
+        "https://example.test/MapServer/0",
+        Config(),  # auth.token is None
+        session=fake_session,
+    )
+    assert fl.datadict.get("token") is None
+
+
+@pytest.mark.asyncio
+async def test_directory_from_config_applies_auth_token(
+    fake_session,
+    feature_layer_metadata,
+) -> None:
+    fake_session.post_responses.append(feature_layer_metadata)
+    cfg = Config(auth=AuthConfig(token="dir-token"))
+    directory = await Directory.from_config(
+        "https://example.test/rest/services",
+        cfg,
+        session=fake_session,
+    )
+    assert directory.token == "dir-token"
+
+
+def test_from_config_requires_explicit_config() -> None:
+    """``config`` is a required positional -- no implicit process-global."""
+    for ctor in (FeatureLayer.from_config, Directory.from_config):
+        params = inspect.signature(ctor).parameters
+        assert "config" in params
+        assert (
+            params["config"].default is inspect.Parameter.empty
+        ), f"{ctor.__qualname__} must require an explicit config"
+
+
+def test_plain_construction_consumes_no_implicit_auth_token() -> None:
+    """A plain (non-from_config) FeatureLayer never sources a global token.
+
+    Guards the failure mode: config must not be consumed implicitly at
+    construction time.
+    """
+    fl = FeatureLayer(
+        "https://example.test/MapServer/0",
+        session=object(),  # type: ignore[arg-type]
+    )
+    assert fl.datadict.get("token") is None

--- a/tests/test_models_primitives.py
+++ b/tests/test_models_primitives.py
@@ -27,6 +27,7 @@ import pytest
 
 from restgdf._models import RestgdfResponseError
 from restgdf._models._drift import (
+    FieldSetDriftObserver,
     PermissiveModel,
     StrictModel,
     _parse_response,
@@ -187,6 +188,68 @@ def test_parse_response_passes_through_valid_permissive_model() -> None:
     result = _parse_response(FieldSpec, raw, context="ctx")
     assert isinstance(result, FieldSpec)
     assert result.name == "X"
+
+
+# --- W5-13 (TELEMETRY-02): per-service drift attribution -------------------
+
+
+def test_drift_record_carries_context_for_attribution(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The first (non-deduped) drift record is attributable to its service.
+
+    The originating ``context`` must appear both in the log message and as a
+    ``drift_context`` extra attribute so an operator can tell WHICH service
+    drifted.
+    """
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    _parse_response(
+        FieldSpec,
+        {"name": "X", "type": "Y", "weirdKey": 1},
+        context="https://example.test/MapServer/7",
+    )
+    records = [
+        r
+        for r in caplog.records
+        if r.name == "restgdf.schema_drift" and "weirdKey" in r.getMessage()
+    ]
+    assert records, "expected a drift record for the unknown extra key"
+    record = records[0]
+    assert "https://example.test/MapServer/7" in record.getMessage()
+    assert record.drift_context == "https://example.test/MapServer/7"
+
+
+def test_drift_dedup_key_stays_context_free(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Two distinct contexts, same drift tuple, still collapse to one record.
+
+    The dedupe key remains the 4-tuple ``(model, field, kind, type)`` -- adding
+    the per-service URL context would let a drifty 500-layer server emit 500
+    identical records. The first context wins attribution; the second is
+    silenced (the accepted anti-spam trade-off).
+    """
+    caplog.set_level(logging.DEBUG, logger="restgdf.schema_drift")
+    payload = {"name": "X", "type": "Y", "weirdKey": 1}
+    _parse_response(FieldSpec, payload, context="service-A")
+    _parse_response(FieldSpec, payload, context="service-B")
+    weird = [r for r in caplog.records if "weirdKey" in r.getMessage()]
+    assert len(weird) == 1, f"dedupe must collapse to one record, got {len(weird)}"
+    assert "service-A" in weird[0].getMessage()
+    assert "service-B" not in weird[0].getMessage()
+
+
+def test_field_set_drift_observer_record_carries_context(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """FieldSetDriftObserver drift records are attributable to their context."""
+    caplog.set_level(logging.INFO, logger="restgdf.schema_drift")
+    observer = FieldSetDriftObserver(context="svc-root/0")
+    observer.observe_page([{"attributes": {"A": 1}}])
+    observer.observe_page([{"attributes": {"A": 1, "B": 2}}])
+    appeared = [r for r in caplog.records if "field_appeared" in r.getMessage()]
+    assert appeared, "expected a field_appeared drift record"
+    assert appeared[0].drift_context == "svc-root/0"
 
 
 def test_tier_base_classes_have_expected_configs() -> None:

--- a/tests/test_resolve_domains.py
+++ b/tests/test_resolve_domains.py
@@ -278,3 +278,62 @@ def test_resolve_domains_helper_with_dict_fields() -> None:
     assert out["NAME"].tolist() == ["a", "b", "c"]
     # Helper must not mutate the input frame.
     assert df["STATUS"].tolist() == [1, 2, 99]
+
+
+# --- W5-6 (ADAPTERS-03): robustness to malformed domain metadata -----------
+
+
+def test_resolve_domains_skips_non_dict_domain() -> None:
+    """A malformed (non-dict) ``domain`` is skipped, not fatal (W5-6)."""
+    from restgdf.adapters.pandas import resolve_domains
+
+    df = pd.DataFrame({"STATUS": [1, 2, 99], "KIND": [1, 2, 3]})
+    fields = [
+        # ``domain`` is a bare string -> pre-fix this AttributeError'd on
+        # ``domain.get("type")``; must now be skipped.
+        {"name": "KIND", "type": "esriFieldTypeSmallInteger", "domain": "bogus"},
+        {
+            "name": "STATUS",
+            "type": "esriFieldTypeSmallInteger",
+            "domain": {
+                "type": "codedValue",
+                "codedValues": [
+                    {"name": "Active", "code": 1},
+                    {"name": "Inactive", "code": 2},
+                ],
+            },
+        },
+    ]
+    out = resolve_domains(df, fields)
+    # The well-formed STATUS domain still resolves.
+    assert out["STATUS"].tolist() == ["Active", "Inactive", 99]
+    # The malformed KIND field passes through untouched.
+    assert out["KIND"].tolist() == [1, 2, 3]
+
+
+def test_resolve_domains_skips_nameless_coded_value() -> None:
+    """A coded value with ``code`` but no ``name`` is left unchanged (W5-6).
+
+    CRITICAL anti-rec: it must NOT be mapped to ``None``/NaN (silent data
+    corruption); the unresolvable code passes through verbatim.
+    """
+    from restgdf.adapters.pandas import resolve_domains
+
+    df = pd.DataFrame({"STATUS": [1, 2, 3]})
+    fields = [
+        {
+            "name": "STATUS",
+            "type": "esriFieldTypeSmallInteger",
+            "domain": {
+                "type": "codedValue",
+                "codedValues": [
+                    {"name": "Active", "code": 1},
+                    {"code": 2},  # name-less -> pre-fix KeyError
+                    "garbage",  # non-dict entry -> skipped
+                ],
+            },
+        },
+    ]
+    out = resolve_domains(df, fields)
+    # Code 1 resolves; code 2 (name-less) and 3 (absent) pass through unchanged.
+    assert out["STATUS"].tolist() == ["Active", 2, 3]

--- a/tests/test_stats_query_body.py
+++ b/tests/test_stats_query_body.py
@@ -1,0 +1,154 @@
+"""W5-2 (API-01) / W5-3 (API-04): stats query-body correctness.
+
+W5-2: ``FeatureLayer.get_value_counts`` / ``get_nested_count`` must send a
+conservative statistics body -- ``returnGeometry=False``, ``outFields=<field>``,
+no ``returnCountOnly`` -- while PRESERVING the instance ``where`` clause. The
+pre-fix code spread the caller ``data`` (the instance ``datadict``, which
+carries ``returnGeometry=True`` / ``outFields="*"`` / ``returnCountOnly=False``)
+LAST, clobbering the stats flags.
+
+W5-3: ``nested_count`` requires EXACTLY two field names; a one-element tuple
+must raise a clear ``ValueError`` at both the FeatureLayer method and the bare
+helper, not an ``IndexError`` deep inside post-processing.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from restgdf.featurelayer.featurelayer import FeatureLayer
+from restgdf.utils.getinfo import nested_count
+
+
+class _FakeResp:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+        self.content_type = "application/json"
+        self.status = 200
+
+    async def json(self, content_type: str | None = None) -> dict[str, Any]:
+        return self._payload
+
+
+class _CapturingSession:
+    """A duck-typed async HTTP session that records the outgoing body.
+
+    A ``token`` in the body forces ``_arcgis_request`` down the POST path
+    (AUTH-01), so the captured ``data`` kwarg is the raw, un-coerced body
+    dict -- exactly what we want to assert against.
+    """
+
+    def __init__(self, features: list[dict[str, Any]]) -> None:
+        self.captured: list[tuple[str, str, dict[str, Any]]] = []
+        self._features = features
+
+    async def post(self, url: str, **kwargs: Any) -> _FakeResp:
+        self.captured.append(("post", url, kwargs))
+        return _FakeResp({"features": self._features})
+
+    async def get(self, url: str, **kwargs: Any) -> _FakeResp:
+        self.captured.append(("get", url, kwargs))
+        return _FakeResp({"features": self._features})
+
+    def body_of(self, index: int = -1) -> dict[str, Any]:
+        _, _, kwargs = self.captured[index]
+        # POST path -> data=; GET path -> params=.
+        return dict(kwargs.get("data") or kwargs.get("params") or {})
+
+
+def _layer(session: _CapturingSession, *, where: str = "1=1") -> FeatureLayer:
+    """Build an un-prepped FeatureLayer with a token (forces the POST path)."""
+    fl = FeatureLayer(
+        "https://example.test/MapServer/0",
+        session=session,  # type: ignore[arg-type]
+        where=where,
+        token="tok-123",
+    )
+    fl.fields = ("City", "Status")
+    return fl
+
+
+# --- W5-2: conservative stats body -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_value_counts_sends_conservative_body() -> None:
+    session = _CapturingSession(
+        [{"attributes": {"City": "A", "City_count": 3}}],
+    )
+    fl = _layer(session, where="CITY = 'DAYTONA'")
+    await fl.get_value_counts("City")
+
+    body = session.body_of()
+    assert body["returnGeometry"] is False
+    assert body["outFields"] == "City"
+    assert "returnCountOnly" not in body
+    assert body["outStatistics"]
+    assert body["groupByFieldsForStatistics"] == "City"
+    # W5-2 anti-rec: the instance WHERE must survive the conservative merge.
+    assert body["where"] == "CITY = 'DAYTONA'"
+    # token forwarded through build_conservative_query_data.
+    assert body["token"] == "tok-123"
+
+
+@pytest.mark.asyncio
+async def test_get_nested_count_sends_conservative_body() -> None:
+    session = _CapturingSession(
+        [
+            {
+                "attributes": {
+                    "City": "A",
+                    "Status": "X",
+                    "City_count": 2,
+                    "Status_count": 2,
+                },
+            },
+        ],
+    )
+    fl = _layer(session, where="STATUS = 'OPEN'")
+    await fl.get_nested_count(("City", "Status"))
+
+    body = session.body_of()
+    assert body["returnGeometry"] is False
+    assert body["outFields"] == "City,Status"
+    assert "returnCountOnly" not in body
+    assert body["groupByFieldsForStatistics"] == "City,Status"
+    assert body["where"] == "STATUS = 'OPEN'"
+    assert body["token"] == "tok-123"
+
+
+# --- W5-3: nested_count arity ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_nested_count_rejects_single_field() -> None:
+    session = _CapturingSession([])
+    fl = _layer(session)
+    with pytest.raises(ValueError, match="exactly two"):
+        await fl.get_nested_count(("City",))
+    # No request should have been issued.
+    assert session.captured == []
+
+
+@pytest.mark.asyncio
+async def test_bare_nested_count_helper_rejects_single_field() -> None:
+    session = _CapturingSession([])
+    with pytest.raises(ValueError, match="exactly two"):
+        await nested_count(
+            "https://example.test/MapServer/0",
+            ("City",),
+            session,  # type: ignore[arg-type]
+        )
+    assert session.captured == []
+
+
+@pytest.mark.asyncio
+async def test_featurelayer_nested_count_rejects_three_fields() -> None:
+    session = _CapturingSession([])
+    fl = _layer(session)
+    fl.fields = ("City", "Status", "Kind")
+    with pytest.raises(ValueError, match="exactly two"):
+        await fl.get_nested_count(("City", "Status", "Kind"))
+    assert session.captured == []


### PR DESCRIPTION
M3 lane L35 (wave verifier CONFIRMED). W2-13: one-time InertConfigWarning (UserWarning, deliberately not DeprecationWarning) when set-but-inert RESTGDF_RETRY_*/LIMITER_*/AUTH_REFRESH_* vars are present — warn-now/wire-later per the recorded decision. W5-13: drift records attributed with service context (message + extra; dedup key deliberately kept context-free for anti-spam, decision recorded). W5-2/W5-3: stats calls send a conservative body (no clobbered returnGeometry/outFields) and nested_count enforces two-field arity. W5-6: resolve_domains tolerates malformed-but-real domain metadata. W5-14: opt-in FeatureLayer/Directory.from_config (config required, no implicit global; token rides the AUTH-01 POST-forced path). W3-2/W3-4 doc-downs recorded. Suite 1293/4/4 · cov 98% · mypy 0 · pre-commit fixed point. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk