### PR TITLE
fix: bound split OID lists; restore verb-true characterization tests (W4-3, W4-4, W1-9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,14 @@ All notable changes to restgdf are documented here. This project follows
   — `Config.from_env()` resolves only from the process environment (`os.environ`).
   The docs now show how to opt in explicitly with `python-dotenv` yourself
   (W3-5, CONFIG-04).
+- `iter_pages`/`stream_*`'s `on_truncation='split'` path no longer re-fetches
+  the OID list at every recursion node (each bisected half now reuses the
+  parent's already-materialized slice) and no longer emits an unbounded
+  `IN (...)` literal for a single oversized half — a half exceeding a new
+  1000-element cap (the common ArcGIS backing-store IN-predicate limit) is
+  bisected further before being fetched, instead of being sent as one
+  arbitrarily large literal list (W4-3, PAGINATION-03). No caller-visible
+  contract change (same pages yielded, same `on_truncation` semantics).
 
 ## [3.1.0] - 2026-07-24
 ### Added

--- a/audit-recommendations/plan/PROGRAM-LEDGER.md
+++ b/audit-recommendations/plan/PROGRAM-LEDGER.md
@@ -15,7 +15,7 @@
 | V0 Establish baseline | **COMPLETE** 2026-07-23 (fresh clone @ `70ebe00` + fresh 3.11 venv: all gates green — pytest 1169/4/2, cov 98%, 34/34 hooks, sphinx, base_install 15, compat 50, build+twine; report `scratch/v0/`) | fresh main clone passes the complete gate |
 | M1 Validation/security | **COMPLETE** 2026-07-24 (items: PRs #193 #194 #195 #196 #197 #198 #199 #200 — see log; 3.1.0 release evidence added on publish) | M1 exit gate plus 3.1.0 release evidence |
 | M2 High correctness | **COMPLETE** 2026-07-24 (PRs #203–#207 + this PR; all five high findings closed with regression evidence — verifier-run census: AUTH-01 ×3, PAGINATION-01 ×7, PAGINATION-02 ×4, CONFIG-01/AUTH-03 ×8 test nodes green; CICD-01 = the structural release gate. verify_ssl proven end-to-end via real-connector introspection) | all five high findings closed with regression evidence |
-| M3 Medium correctness | not started | M3 item/decision gates green |
+| M3 Medium correctness | **COMPLETE** 2026-07-24 (3 batched PRs; W2-2/3/11, W3-2/3/4, W2-13 warn-now, W4-3/4, W1-9, W5-2/3/6/13/14; decision-closes with recorded owner+trigger: W2-5 NO-GO per plan recommendation, W5-13 dedup-key kept context-free per anti-spam decision; wave verifier CONFIRMED, deferral ratified by coordinator) | M3 item/decision gates green |
 | M4 Docs/polish | not started | 61/61 findings closed or explicitly dispositioned |
 | R32 Release 3.2.0 | not started | clean tag-to-PyPI-to-install verification |
 

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -878,6 +878,22 @@ async def _iter_pages_raw(
     attributes for the R-61 INTERNAL parent span so the caller does not
     need to import telemetry helpers from ``restgdf.featurelayer`` (see
     ``tests/test_telemetry_no_dangling_imports_from_featurelayer.py``).
+
+    W4-4 (ASYNC-03): ``max_concurrent_pages`` only bounds the top-level
+    page-plan fetches submitted by the windowing loop below. When
+    ``on_truncation="split"``, each truncated page's ``_resolve_page``
+    call issues its own serial, uncounted sub-fetches (``get_object_ids``
+    plus one ``_fetch_page_dict`` per bisected half/cap-chunk) *in
+    addition to* the ``max_concurrent_pages`` window -- worst-case
+    in-flight is therefore roughly K+1, not a hard K cap. There is no
+    semaphore in this windowing loop (it is a manual
+    ``pending_in_order``/``_submit_next()`` task window), so threading a
+    slot-acquire into ``_resolve_page`` would have the split fetch block
+    on a slot the suspended top-level consumer cannot free -- a
+    re-entrancy deadlock. Do not add one. The public-facing correction
+    (:meth:`FeatureLayer.iter_pages`'s docstring, ``docs/recipes/streaming.md``)
+    is out of this file's ownership -- see the W4-4 report for the
+    handoff.
     """
     if order not in ("request", "completion"):
         raise ValueError(

--- a/restgdf/utils/getgdf.py
+++ b/restgdf/utils/getgdf.py
@@ -699,6 +699,33 @@ async def _fetch_page_dict(
     return raw
 
 
+# W4-3 (PAGINATION-03): common ArcGIS backing-store IN-predicate element
+# cap. A single-node IN-list larger than this is bisected one more level
+# (via ``_cap_oid_chunks``) instead of being emitted as one oversized
+# literal list -- see ``_resolve_page``'s split branch.
+_SPLIT_OID_INLIST_CAP: int = 1000
+
+
+def _cap_oid_chunks(
+    oids: list[int],
+    cap: int = _SPLIT_OID_INLIST_CAP,
+) -> list[list[int]]:
+    """Recursively bisect ``oids`` until every chunk has at most ``cap`` elements.
+
+    Pure/sync -- no HTTP call, no truncation check. The per-node OID list
+    already shrinks geometrically as ``_resolve_page`` bisects on
+    ``exceededTransferLimit`` (N/2, N/4, ...); this helper applies the same
+    midpoint bisection *ahead of* the network round-trip whenever a single
+    half would still exceed the cap, so restgdf never emits one oversized
+    ``IN (...)`` literal. A list already at or under the cap (the common
+    case) returns as a single-element list unchanged.
+    """
+    if len(oids) <= cap:
+        return [oids]
+    mid = len(oids) // 2
+    return _cap_oid_chunks(oids[:mid], cap) + _cap_oid_chunks(oids[mid:], cap)
+
+
 async def _resolve_page(
     url: str,
     session: AsyncHTTPSession,
@@ -709,8 +736,18 @@ async def _resolve_page(
     depth: int,
     max_depth: int,
     request_kwargs: dict[str, Any],
+    oid_hint: tuple[str, list[int]] | None = None,
 ) -> AsyncGenerator[dict[str, Any]]:
-    """Yield ``page`` (and any sub-pages) honoring ``on_truncation``."""
+    """Yield ``page`` (and any sub-pages) honoring ``on_truncation``.
+
+    ``oid_hint`` (W4-3, PAGINATION-03): when the caller already holds the
+    materialized ``(oid_field, oids)`` pair backing this page's predicate
+    (a child node bisecting a parent's split half), pass it here to skip
+    the redundant ``get_object_ids`` round-trip -- the parent already
+    fetched the full OID list under the pre-bisection predicate, and each
+    half is a slice of it. ``None`` (the root call from ``_iter_pages_raw``,
+    which has no parent slice to reuse) falls back to fetching fresh.
+    """
     envelope = _parse_response(
         FeaturesResponse,
         page,
@@ -762,12 +799,17 @@ async def _resolve_page(
             url=f"{url}/query",
         )
     current_where = query_data.get("where", "1=1") or "1=1"
-    split_kwargs = {k: v for k, v in request_kwargs.items() if k != "data"}
-    split_kwargs["data"] = {
-        **(request_kwargs.get("data") or {}),
-        "where": current_where,
-    }
-    oid_field, oids = await get_object_ids(url, session, **split_kwargs)
+    if oid_hint:
+        # W4-3: reuse the parent's materialized slice -- no get_object_ids
+        # round-trip for this node.
+        oid_field, oids = oid_hint
+    else:
+        split_kwargs = {k: v for k, v in request_kwargs.items() if k != "data"}
+        split_kwargs["data"] = {
+            **(request_kwargs.get("data") or {}),
+            "where": current_where,
+        }
+        oid_field, oids = await get_object_ids(url, session, **split_kwargs)
     if len(oids) <= 1:
         raise RestgdfResponseError(
             f"{url}/query: on_truncation='split' could not bisect "
@@ -779,32 +821,38 @@ async def _resolve_page(
     mid = len(oids) // 2
     halves = (oids[:mid], oids[mid:])
     for half in halves:
-        half_where = combine_where_clauses(
-            current_where,
-            where_var_in_list(oid_field, half),
-        )
-        sub_qd = dict(query_data)
-        sub_qd["where"] = half_where
-        # Bisection changes the partitioning scheme; offset/count no longer apply.
-        sub_qd.pop("resultOffset", None)
-        sub_qd.pop("resultRecordCount", None)
-        sub_page = await _fetch_page_dict(
-            url,
-            session,
-            sub_qd,
-            **{k: v for k, v in request_kwargs.items() if k != "data"},
-        )
-        async for resolved in _resolve_page(
-            url,
-            session,
-            sub_page,
-            sub_qd,
-            on_truncation=on_truncation,
-            depth=depth + 1,
-            max_depth=max_depth,
-            request_kwargs=request_kwargs,
-        ):
-            yield resolved
+        # W4-3: cap each half's IN-list element count; a half that still
+        # exceeds the cap is bisected further (no network call) rather
+        # than emitted as one oversized literal list.
+        for capped_half in _cap_oid_chunks(half):
+            half_where = combine_where_clauses(
+                current_where,
+                where_var_in_list(oid_field, capped_half),
+            )
+            sub_qd = dict(query_data)
+            sub_qd["where"] = half_where
+            # Bisection changes the partitioning scheme; offset/count no
+            # longer apply.
+            sub_qd.pop("resultOffset", None)
+            sub_qd.pop("resultRecordCount", None)
+            sub_page = await _fetch_page_dict(
+                url,
+                session,
+                sub_qd,
+                **{k: v for k, v in request_kwargs.items() if k != "data"},
+            )
+            async for resolved in _resolve_page(
+                url,
+                session,
+                sub_page,
+                sub_qd,
+                on_truncation=on_truncation,
+                depth=depth + 1,
+                max_depth=max_depth,
+                request_kwargs=request_kwargs,
+                oid_hint=(oid_field, capped_half),
+            ):
+                yield resolved
 
 
 async def _iter_pages_raw(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,8 +196,27 @@ class FakeSession:
     """Record every get/post call and serve a scripted response per call.
 
     Tests push payloads onto ``post_responses`` / ``get_responses`` queues
-    (falling back to the ``default_*`` payload when empty). All call args
-    are captured on ``post_calls`` / ``get_calls`` for assertions.
+    (falling back to the ``default_*`` payload when empty; the queue is
+    shared, since a scripted response is verb-agnostic). Call args are
+    captured on ``post_calls`` / ``get_calls`` -- each list is populated
+    ONLY by the correspondingly-named session method.
+
+    W1-9 (TESTS-02): earlier this class aliased ``post_calls``/``get_calls``
+    onto one shared list and mirrored the recorded body under BOTH ``data``
+    and ``params`` keys, "so tests written against either verb's contract
+    kept working" after the T8 (R-74) length-based GET/POST router landed.
+    That mirroring is exactly what let a real GET<->POST regression slip
+    past a "verb-correct" assertion: because the mirror copied whichever
+    key WAS populated onto the other key too, a test reading either
+    ``kwargs["data"]`` or ``kwargs["params"]`` got the same value
+    regardless of which physical method restgdf actually called, and
+    ``post_calls``/``get_calls`` were literally the same list, so a call
+    that flipped verbs still showed up under the "wrong" name. There is
+    no mirroring now: a body recorded on ``get_calls`` carries only
+    ``params``; a body recorded on ``post_calls`` carries only ``data``.
+    A verb flip now means the call lands in the OTHER list -- an empty
+    list / index error on the list a test asserts against, not stale
+    mirrored data.
     """
 
     def __init__(
@@ -208,42 +227,28 @@ class FakeSession:
     ):
         self.default_post = default_post if default_post is not None else {"ok": True}
         self.default_get = default_get if default_get is not None else {"ok": True}
-        # T8 (R-74): after the GET/POST length-based routing change, the
-        # same logical ArcGIS request may flip between ``session.post`` and
-        # ``session.get`` depending on the encoded body size. We unify the
-        # recorded-call and scripted-response queues here so pre-existing
-        # tests that assert on ``post_calls`` / ``post_responses`` keep
-        # working without having to rewrite each call site individually.
+        # The scripted-response queue stays shared across verbs (a pushed
+        # payload doesn't know in advance which verb will consume it).
         self._responses: list[Any] = []
         self.post_responses = self._responses
         self.get_responses = self._responses
-        self._calls: list[tuple[str, dict]] = []
-        self.post_calls = self._calls
-        self.get_calls = self._calls
+        self.post_calls: list[tuple[str, dict]] = []
+        self.get_calls: list[tuple[str, dict]] = []
 
-    def _snapshot_kwargs(self, kwargs: dict, *, body_key: str) -> dict:
+    @staticmethod
+    def _snapshot_kwargs(kwargs: dict) -> dict:
         snapshot: dict = {}
         for key, value in kwargs.items():
-            if isinstance(value, dict):
-                snapshot[key] = dict(value)
-            else:
-                snapshot[key] = value
-        # Mirror the body under both ``data`` (POST) and ``params`` (GET)
-        # so tests written against the legacy POST-only contract keep
-        # resolving ``kwargs["data"]`` when a short request now flips to
-        # GET (and vice-versa).
-        mirror_key = "params" if body_key == "data" else "data"
-        if body_key in snapshot and mirror_key not in snapshot:
-            snapshot[mirror_key] = snapshot[body_key]
+            snapshot[key] = dict(value) if isinstance(value, dict) else value
         return snapshot
 
     def post(self, url: str, **kwargs) -> FakeResponse:
-        self._calls.append((url, self._snapshot_kwargs(kwargs, body_key="data")))
+        self.post_calls.append((url, self._snapshot_kwargs(kwargs)))
         payload = self._responses.pop(0) if self._responses else self.default_post
         return FakeResponse(payload)
 
     def get(self, url: str, **kwargs) -> FakeResponse:
-        self._calls.append((url, self._snapshot_kwargs(kwargs, body_key="params")))
+        self.get_calls.append((url, self._snapshot_kwargs(kwargs)))
         payload = self._responses.pop(0) if self._responses else self.default_get
         return FakeResponse(payload)
 

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -9,6 +9,33 @@ guarded against silent regressions.
 If one of these tests fails during a refactor, treat it as a deliberate
 decision point: either update the test (documenting the intended behavior
 change) or fix the regression.
+
+W1-9 (TESTS-02) verb separation
+--------------------------------
+The GET-vs-POST choice for every ArcGIS call in this module is made by
+``restgdf.utils._http._arcgis_request``/``_choose_verb``: short, tokenless
+bodies ride a length-based ``GET`` (params coerced to ArcGIS wire strings
+by ``_coerce_params_for_get`` -- booleans become ``"true"``/``"false"``,
+``None`` becomes ``""``); a body carrying a ``token`` key is ALWAYS forced
+onto ``POST`` regardless of length (AUTH-01/W2-1), and ``POST`` forwards
+the body untouched -- raw ``bool``/``None`` values ride through as-is. This
+is a COORDINATOR-PINNED invariant for M3: raw-bool POST bodies are the
+correct, permanent behavior (the ``_arcgis_request`` body-untouched
+contract) -- do NOT add coercion on the POST path to make it match GET's
+stringified booleans.
+
+Each test below is named for, and asserts against, the verb it ACTUALLY
+exercises (``get_calls``/``kwargs["params"]`` for the GET helpers,
+``post_calls``/``kwargs["data"]`` for the genuinely-POST cases), and
+additionally asserts the OTHER call list stayed empty. Before W1-9,
+``FakeSession`` aliased ``post_calls``/``get_calls`` onto one shared list
+and mirrored the recorded body under both ``data`` and ``params`` keys, so
+a test that read the "wrong" key for the request's actual verb still
+passed silently (e.g. ``test_get_metadata_uses_get_with_params_and_token``
+asserted on ``get_calls``/``params`` for a call the AUTH-01 fix had
+already flipped to POST). ``tests/conftest.py``'s ``FakeSession`` no
+longer mirrors across verbs, so a real GET<->POST regression now empties
+the list a renamed test asserts against instead of silently matching.
 """
 
 from __future__ import annotations
@@ -33,10 +60,16 @@ pytestmark = pytest.mark.characterization
 
 
 @pytest.mark.asyncio
-async def test_get_feature_count_sends_minimal_count_payload(fake_session):
-    """get_feature_count posts only where / returnCountOnly / f=json by default."""
+async def test_get_feature_count_sends_minimal_count_query_payload(fake_session):
+    """get_feature_count GETs only where / returnCountOnly / f=json by default.
 
-    fake_session.post_responses.append({"count": 42})
+    W1-9: renamed from ``*_sends_minimal_count_payload`` -- the call has no
+    token and is short, so it rides GET, not POST; this was the "GET-named
+    token test now riding POST" family's mirror image (a GET call read
+    through the wrong ``post_calls``/``data`` key).
+    """
+
+    fake_session.get_responses.append({"count": 42})
 
     count = await getinfo_mod.get_feature_count(
         "https://example.com/service/0",
@@ -44,13 +77,14 @@ async def test_get_feature_count_sends_minimal_count_payload(fake_session):
     )
 
     assert count == 42
-    assert len(fake_session.post_calls) == 1
-    url, kwargs = fake_session.post_calls[0]
+    assert len(fake_session.get_calls) == 1
+    assert fake_session.post_calls == []
+    url, kwargs = fake_session.get_calls[0]
     assert url == "https://example.com/service/0/query"
     # T8 (R-74): short count queries ride on GET, and bool/None values
     # are coerced to ArcGIS wire strings ("true"/"false") so yarl/aiohttp
     # will accept them as query-string parameters.
-    assert kwargs["data"] == {
+    assert kwargs["params"] == {
         "where": "1=1",
         "returnCountOnly": "true",
         "f": "json",
@@ -79,6 +113,7 @@ async def test_get_feature_count_propagates_where_and_token_from_data(fake_sessi
         },
     )
 
+    assert fake_session.get_calls == []
     _, kwargs = fake_session.post_calls[0]
     # AUTH-01 (W2-1): token-bearing bodies are now forced onto POST, which
     # forwards the body untouched -- the raw bool rides through instead of
@@ -93,10 +128,20 @@ async def test_get_feature_count_propagates_where_and_token_from_data(fake_sessi
 
 
 @pytest.mark.asyncio
-async def test_get_metadata_uses_get_with_params_and_token(fake_session):
-    """get_metadata issues a GET with params={'f':'json', 'token': ...}."""
+async def test_get_metadata_with_token_forces_post_body_untouched(fake_session):
+    """get_metadata with a token issues a POST with the body untouched.
 
-    fake_session.get_responses.append({"name": "L", "fields": []})
+    W1-9: renamed from ``test_get_metadata_uses_get_with_params_and_token``
+    -- AUTH-01 (W2-1) forces POST whenever the outgoing body carries a
+    ``token`` key, and ``get_metadata(..., token=...)`` always puts the
+    token in the body, so this call has ridden POST since AUTH-01 landed.
+    The old name/assertions (``get_calls``/``kwargs["params"]``) were the
+    exact case this item exists to fix: the FakeSession mirror let a POST
+    call satisfy a "GET" assertion because ``get_calls`` was the same list
+    as ``post_calls`` and the body was copied onto ``params`` too.
+    """
+
+    fake_session.post_responses.append({"name": "L", "fields": []})
 
     await getinfo_mod.get_metadata(
         "https://example.com/service/0",
@@ -104,10 +149,34 @@ async def test_get_metadata_uses_get_with_params_and_token(fake_session):
         token="tok",
     )
 
+    assert len(fake_session.post_calls) == 1
+    assert fake_session.get_calls == []
+    url, kwargs = fake_session.post_calls[0]
+    assert url == "https://example.com/service/0"
+    assert kwargs["data"] == {"f": "json", "token": "tok"}
+
+
+@pytest.mark.asyncio
+async def test_get_metadata_without_token_uses_get_with_params(fake_session):
+    """get_metadata with NO token still rides GET -- verb separation intact.
+
+    W1-9: companion to the token-forces-POST case above, proving the two
+    verbs are genuinely distinguishable through this fixture (not just
+    incidentally identical because of a mirror).
+    """
+
+    fake_session.get_responses.append({"name": "L", "fields": []})
+
+    await getinfo_mod.get_metadata(
+        "https://example.com/service/0",
+        fake_session,
+    )
+
     assert len(fake_session.get_calls) == 1
+    assert fake_session.post_calls == []
     url, kwargs = fake_session.get_calls[0]
     assert url == "https://example.com/service/0"
-    assert kwargs["params"] == {"f": "json", "token": "tok"}
+    assert kwargs["params"] == {"f": "json"}
 
 
 @pytest.mark.asyncio
@@ -125,6 +194,7 @@ async def test_get_object_ids_preserves_where_and_returns_tuple(fake_session):
     )
 
     assert (field, ids) == ("OBJECTID", [1, 2, 3])
+    assert fake_session.get_calls == []
     _, kwargs = fake_session.post_calls[0]
     # AUTH-01 (W2-1): token-bearing bodies are now forced onto POST, which
     # forwards the body untouched (raw bool, not the GET-coerced "true").
@@ -137,8 +207,12 @@ async def test_get_object_ids_preserves_where_and_returns_tuple(fake_session):
 
 
 @pytest.mark.asyncio
-async def test_getuniquevalues_sends_distinct_payload_string_field(fake_session):
-    fake_session.post_responses.append(
+async def test_getuniquevalues_sends_distinct_query_payload_string_field(fake_session):
+    """W1-9: renamed from ``*_sends_distinct_payload_string_field`` -- no
+    token, short body -> GET, not POST (the coerced "true"/"false" string
+    values below are themselves only correct for the GET path)."""
+
+    fake_session.get_responses.append(
         {"features": [{"attributes": {"CITY": "A"}}, {"attributes": {"CITY": "B"}}]},
     )
 
@@ -149,8 +223,9 @@ async def test_getuniquevalues_sends_distinct_payload_string_field(fake_session)
     )
 
     assert result == ["A", "B"]
-    _, kwargs = fake_session.post_calls[0]
-    assert kwargs["data"] == {
+    assert fake_session.post_calls == []
+    _, kwargs = fake_session.get_calls[0]
+    assert kwargs["params"] == {
         "where": "1=1",
         "f": "json",
         "returnGeometry": "false",
@@ -160,8 +235,11 @@ async def test_getuniquevalues_sends_distinct_payload_string_field(fake_session)
 
 
 @pytest.mark.asyncio
-async def test_getvaluecounts_builds_statistics_payload(fake_session):
-    fake_session.post_responses.append(
+async def test_getvaluecounts_builds_statistics_query_payload(fake_session):
+    """W1-9: renamed from ``*_builds_statistics_payload`` -- no token, short
+    body -> GET, not POST."""
+
+    fake_session.get_responses.append(
         {
             "features": [
                 {"attributes": {"CITY": "A", "CITY_count": 5}},
@@ -179,8 +257,9 @@ async def test_getvaluecounts_builds_statistics_payload(fake_session):
     assert isinstance(df, DataFrame)
     # Result is sorted by CITY_count desc.
     assert list(df["CITY"]) == ["A", "B"]
-    _, kwargs = fake_session.post_calls[0]
-    data = kwargs["data"]
+    assert fake_session.post_calls == []
+    _, kwargs = fake_session.get_calls[0]
+    data = kwargs["params"]
     assert data["groupByFieldsForStatistics"] == "CITY"
     assert data["outFields"] == "CITY"
     assert data["f"] == "json"

--- a/tests/test_iter_pages_edge_cases.py
+++ b/tests/test_iter_pages_edge_cases.py
@@ -147,3 +147,91 @@ async def test_iter_pages_raw_rejects_non_mapping_page_payload() -> None:
     with patch.object(getgdf_mod, "_arcgis_request", AsyncMock(return_value=response)):
         with pytest.raises(RestgdfResponseError, match="non-object JSON payload"):
             await _fetch_page_dict(url, object(), {"where": "1=1"})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# W4-3 (PAGINATION-03): bound the split path's OID IN-lists and reuse the
+# parent's materialized slice instead of re-calling get_object_ids per node.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_page_split_reuses_parent_oid_slice_across_two_levels() -> None:
+    """A 2-level split calls get_object_ids only once (at the root)."""
+    url = "https://x/FeatureServer/0"
+    truncated = {"features": [], "exceededTransferLimit": True}
+    resolved_page = {"features": [{"attributes": {}}], "exceededTransferLimit": False}
+    fetch_calls: list[dict] = []
+
+    async def fake_fetch(_url, _session, query_data, **_kw):
+        fetch_calls.append(dict(query_data))
+        # Root fetch (#1) and the first-half sub-fetch (#2) both still
+        # report truncation, forcing a second bisection level; every
+        # fetch after that resolves cleanly.
+        if len(fetch_calls) in (1, 2):
+            return truncated
+        return resolved_page
+
+    with (
+        patch.object(
+            getgdf_mod,
+            "get_query_data_batches",
+            AsyncMock(return_value=[{"where": "1=1"}]),
+        ),
+        patch.object(getgdf_mod, "_fetch_page_dict", side_effect=fake_fetch),
+        patch.object(
+            getgdf_mod,
+            "get_object_ids",
+            AsyncMock(return_value=("OBJECTID", [1, 2, 3, 4, 5, 6, 7, 8])),
+        ) as mock_get_object_ids,
+    ):
+        agen = _iter_pages_raw(url, object(), on_truncation="split")  # type: ignore[arg-type]
+        results = [page async for page in agen]
+
+    # root fetch + half([1,2,3,4]) fetch + its two sub-halves + half([5..8]).
+    assert len(fetch_calls) == 5
+    assert len(results) == 3
+    # The child nodes reused the parent's held OID slice -- no re-fetch.
+    mock_get_object_ids.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_page_split_caps_oversized_inlist_and_recurses() -> None:
+    """A half exceeding the IN-list cap is bisected further, not emitted whole."""
+    url = "https://x/FeatureServer/0"
+    big_oid_list = list(range(1, 3001))  # 3000 OIDs -> each 1500-element half > cap
+    truncated = {"features": [], "exceededTransferLimit": True}
+    resolved_page = {"features": [{"attributes": {}}], "exceededTransferLimit": False}
+    fetch_calls: list[dict] = []
+
+    async def fake_fetch(_url, _session, query_data, **_kw):
+        fetch_calls.append(dict(query_data))
+        if len(fetch_calls) == 1:
+            return truncated
+        return resolved_page
+
+    with (
+        patch.object(
+            getgdf_mod,
+            "get_query_data_batches",
+            AsyncMock(return_value=[{"where": "1=1"}]),
+        ),
+        patch.object(getgdf_mod, "_fetch_page_dict", side_effect=fake_fetch),
+        patch.object(
+            getgdf_mod,
+            "get_object_ids",
+            AsyncMock(return_value=("OBJECTID", big_oid_list)),
+        ),
+    ):
+        agen = _iter_pages_raw(url, object(), on_truncation="split")  # type: ignore[arg-type]
+        results = [page async for page in agen]
+
+    sub_fetches = fetch_calls[1:]
+    # Each 1500-element half is bisected once more into two 750-element
+    # chunks (1000-element cap) instead of one 1500-element IN-list.
+    assert len(sub_fetches) == 4
+    assert len(results) == 4
+    for query_data in sub_fetches:
+        element_count = query_data["where"].count(",") + 1
+        assert element_count == 750
+        assert element_count <= 1000


### PR DESCRIPTION
M3 lane L4 (wave verifier CONFIRMED). W4-3: on_truncation='split' OID IN-lists bounded, parent slice reused (PAGINATION-03). W4-4: reduced to the sanctioned comment-check; doc handoffs recorded. W1-9 (TESTS-02): FakeSession no longer mirrors data↔params or aliases the call queues — a GET↔POST flip now FAILS the characterization tests (verb-flip proof both directions on disk); coordinator decision documented in-module: raw-bool POST bodies are pinned behavior (the body-untouched invariant), no coercion. Compat fakes untouched. Includes the M3 ledger row. Suite 1275/4/4 · cov 98% · mypy 0 · pre-commit fixed point. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk