### PR TITLE
docs: reconcile all prose to 3.x reality (W6-3/4/6/7, W2-9, W5-5, W4-4)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -68,9 +68,9 @@ RestgdfError
 │   ├── ArcGISServiceError
 │   │   └── PaginationError(ArcGISServiceError, IndexError)
 │   └── AuthenticationError(RestgdfResponseError, PermissionError)
-│       ├── InvalidCredentialsError      # HTTP 401
+│       ├── InvalidCredentialsError      # /generateToken HTTP 4xx (400/401/403)
 │       ├── TokenExpiredError            # HTTP 498 after refresh
-│       ├── TokenRequiredError
+│       ├── TokenRequiredError           # reserved — not currently raised
 │       ├── TokenRefreshFailedError      # /generateToken retries exhausted
 │       └── AuthNotAttachedError         # HTTP 499
 ├── TransportError
@@ -85,9 +85,10 @@ Several classes co-inherit from stdlib exceptions (`ValueError`,
 so existing `except ValueError:` / `except TimeoutError:` code keeps
 working — see [MIGRATION.md](MIGRATION.md) for the full story.
 
-Detail types in `restgdf.errors` (e.g. `ErrorPayload`,
-`RateLimitError.retry_after`, `PaginationError.batch_index`) expose
-structured metadata for programmatic recovery.
+Exceptions in `restgdf.errors` carry structured attributes for
+programmatic recovery — for example `RestgdfResponseError.raw` /
+`RestgdfResponseError.model_name`, `RateLimitError.retry_after`, and
+`PaginationError.batch_index`.
 
 ## Logger hierarchy
 
@@ -95,14 +96,24 @@ restgdf uses namespaced loggers under the `restgdf.` prefix so
 applications can configure verbosity per subsystem.
 
 ```
-restgdf
+restgdf                       # root logger (NullHandler; get_logger(""))
+├── restgdf.transport         # aiohttp requests, verb selection (HTTP)
+├── restgdf.retry             # stamina retry attempts (restgdf[resilience])
+├── restgdf.limiter           # rate limiting (restgdf[resilience])
+├── restgdf.concurrency       # page-fetch concurrency gating
 ├── restgdf.auth              # token lifecycle, refresh attempts
-├── restgdf.transport         # aiohttp requests, retries
-├── restgdf.featurelayer      # prep / query / streaming
-├── restgdf.streaming         # pagination, split-on-truncation decisions
-├── restgdf.directory         # service enumeration
-└── restgdf.telemetry         # OpenTelemetry hooks (only when `telemetry` extra installed)
+├── restgdf.pagination        # streaming + split-on-truncation decisions
+├── restgdf.normalization     # attribute / row normalization
+└── restgdf.schema_drift      # permissive-tier schema-drift warnings
 ```
+
+These eight suffixes are the *only* names `get_logger()` accepts (see
+`LOGGER_SUFFIXES` in `restgdf/_logging.py`); any other suffix raises
+`ValueError`, so there are no `restgdf.featurelayer` / `restgdf.streaming`
+/ `restgdf.directory` / `restgdf.telemetry` loggers. Subsystem → logger:
+HTTP transport → `restgdf.transport` (retries → `restgdf.retry`),
+streaming/pagination → `restgdf.pagination`, schema drift →
+`restgdf.schema_drift`, normalization → `restgdf.normalization`.
 
 Loggers never emit at `DEBUG` with secrets; tokens and password-bearing
 request bodies are redacted at the transport layer.
@@ -112,31 +123,44 @@ request bodies are redacted at the transport layer.
 `restgdf.Config` (Pydantic v2, defined in `restgdf/_config.py`) resolves
 values in this order, highest precedence first:
 
-1. **Explicit constructor arguments** (`FeatureLayer.from_url(timeout=…)`).
-2. **`Config(...)` instance passed explicitly**.
-3. **Process environment variables** (`RESTGDF_*`).
-4. **`.env` file** in the working directory, if present.
-5. **Library defaults** (see `Config.model_fields`).
+1. **Explicit constructor / aiohttp keyword arguments**
+   (`FeatureLayer.from_url(timeout=…)`), applied per call.
+2. **Process environment variables** (`RESTGDF_*`), read by
+   `Config.from_env` and exposed process-globally through the size-1
+   LRU-cached `restgdf.get_config()` (reset with `reset_config_cache()`).
+3. **Library defaults** (see `Config.model_fields`).
+
+restgdf does **not** read a `.env` file — only the process environment,
+or a mapping you pass to `Config.from_env(env=…)`; `python-dotenv` is not
+a dependency. A directly built `Config(...)` instance is **not**
+injectable into the `FeatureLayer` / `Directory` request path (there is
+no `config=` parameter on either), so it does not sit in the precedence
+chain above; it is used in tests and to construct a session-scoped
+`ArcGISTokenSession(config=…)`, which is separate from the process-global
+`get_config()`.
 
 The legacy `restgdf.Settings` name is retained as a deprecation alias
 over `Config`; both resolve to the same cached instance via
 `restgdf.get_config()` / `restgdf.get_settings()`.
 
 Token-session settings (`TokenSessionConfig` in
-`restgdf/_models/credentials.py`) follow the same precedence but are
-stored on the session object, not globally.
+`restgdf/_models/credentials.py`) are stored on the session object, not
+globally.
 
 ## Session ownership
 
-`aiohttp.ClientSession` ownership is explicit and documented on every
-public API:
+`aiohttp.ClientSession` ownership is explicit and caller-driven:
 
-- **Caller-provided session** — passed to `FeatureLayer.from_url(...,
-  session=...)` or `Directory(..., session=...)`. restgdf does **not**
-  close it; the caller's `async with session:` block owns lifecycle.
-- **Library-owned session** — if no session is provided, restgdf
-  lazily constructs one and closes it when the owning object is
-  `close()`d or used as an async context manager.
+- **Caller-owned session (the only model for `FeatureLayer` /
+  `Directory`)** — both require a `session` argument
+  (`FeatureLayer.from_url(..., session=...)`, `Directory(...,
+  session=...)`). restgdf never closes a caller-supplied session, and
+  neither class defines `close()` / `__aenter__` / `__aexit__`; the
+  caller's `async with session:` block owns lifecycle.
+- **The one lazy-owning helper** — `restgdf.utils.getgdf.get_gdf(url,
+  session=None, ...)` builds a temporary `ClientSession` when none is
+  passed and closes it in a `finally` block. A caller-supplied session is
+  used as-is and left open.
 
 Token sessions wrap an inner `ClientSession` and propagate the same
 rule: the token session only closes what it created.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,10 +481,10 @@ tranche.
 
 #### Configuration
 
-- `restgdf.Config` — frozen pydantic 2.x aggregate of seven frozen
+- `restgdf.Config` — frozen pydantic 2.x aggregate of eight frozen
   sub-configs (`TransportConfig`, `TimeoutConfig`, `RetryConfig`,
   `LimiterConfig`, `ConcurrencyConfig`, `AuthConfig`,
-  `TelemetryConfig`) plus `Config.from_env(env=None)` classmethod.
+  `TelemetryConfig`, `ResilienceConfig`) plus `Config.from_env(env=None)` classmethod.
   Sub-configs and the aggregate are immutable at both slot and
   nested-field level.
 - `restgdf.get_config()` — process-wide cached `Config` accessor
@@ -898,5 +898,7 @@ Earlier releases were not formally tracked here. See the
 [PyPI release notes](https://pypi.org/project/restgdf/#history) for pre-2.0
 changes.
 
-[Unreleased]: https://github.com/joshuasundance-swca/restgdf/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/joshuasundance-swca/restgdf/compare/v3.1.0...HEAD
+[3.1.0]: https://github.com/joshuasundance-swca/restgdf/compare/v3.0.0...v3.1.0
+[3.0.0]: https://github.com/joshuasundance-swca/restgdf/compare/v2.0.0...v3.0.0
 [2.0.0]: https://github.com/joshuasundance-swca/restgdf/releases/tag/v2.0.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## What this is
 
 `restgdf` is a **lightweight async Esri/ArcGIS REST client** for Python ≥ 3.11, published to
-PyPI as a Production/Stable library (currently v3.0.0; a 3.1.0 release carrying the Python
-floor bump and other `## [Unreleased]` CHANGELOG entries is pending). The light core depends only on
+PyPI as a Production/Stable library (currently v3.1.0; a 3.2.0 release carrying the
+`## [Unreleased]` CHANGELOG entries is pending). The light core depends only on
 `aiohttp` + `pydantic` v2; GeoPandas/pandas, retry/rate-limiting, and OpenTelemetry are
 **optional extras** (`geo`, `resilience`, `telemetry`). The two public entry points are
 `FeatureLayer` (one ArcGIS feature layer) and `Directory` (service discovery / crawl).
@@ -125,24 +125,29 @@ on its own (so `git bisect` stays useful).
     `RestgdfResponseError(context='exceededTransferLimit')`. `get_df` always raises (it does not
     expose the knob).
   - *GeoDataFrame path* — `get_gdf` and `stream_gdf_chunks` (via `chunk_generator`→`get_sub_gdf`)
-    perform **no** `exceededTransferLimit` check and can **silently return truncated data**.
+    now inspect each page's parsed JSON and **raise `PaginationError`** on `exceededTransferLimit`
+    (W4-1/PAGINATION-01) instead of silently returning truncated data; this legacy path still
+    exposes no `ignore`/`split` knob.
   - *Legacy feature path* — `row_dict_generator` and `adapters.stream.iter_rows`/
     `iter_feature_batches` (via `_get_sub_features`) **raise `PaginationError`**, with no
     `ignore`/`split` option.
 - **WHERE building does not escape quotes:** `where_var_in_list` (`restgdf/utils/utils.py`)
   wraps string values in single quotes with no escaping; it backs OID-chunk pagination,
   `sample_gdf`/`head_gdf`, and `on_truncation="split"`. Quote-bearing values make malformed SQL.
-- **Per-instance caches are not concurrency-safe:** `FeatureLayer.uniquevalues/valuecounts/`
-  `nestedcount/gdf` are plain dicts with no lock; concurrent awaiters double-fetch, and
-  multi-field results are returned by reference (mutating the result mutates the cache).
+- **Per-instance caches are not concurrency-safe on the *write* side:**
+  `FeatureLayer.uniquevalues/valuecounts/nestedcount/gdf` are plain dicts with no lock, so
+  concurrent awaiters still double-fetch (cache *population* is racy). Cache *reads* are now
+  safe: `get_gdf`/`get_unique_values`/`get_value_counts`/`get_nested_count` return an independent
+  `.copy()` / `list(...)` of the cached frame (W5-1), so mutating a result no longer corrupts
+  the cache.
 - **Token transport (fixed in 3.1, AUTH-01):** a token in the `data` dict on a *plain*
   `aiohttp` session used to be GET-serializable into the URL when the encoded request was
   < 8192 bytes (the credential-leak guard previously only triggered for body/query transport
   on an `ArcGISTokenSession`). `restgdf/utils/_http.py` now forces `POST` whenever the
   outgoing body carries a token, regardless of session type or encoded length. Prefer header
   transport regardless — it never touches this length-based routing at all.
-- **CI surprises:** the PR-gating `pytest.yml` does **not** run coverage (the 97% floor is only
-  checked post-merge in `coverage.yml` — this gap closes once W1-3 lands). `ci-offline` (a
-  `pytest.yml` job) IS now a required GitHub branch-protection status check on `main`, so a PR
-  cannot merge until it is green; `pytest.yml` itself still only triggers on `pull_request`
-  (no separate workflow re-runs it on a direct push). Run the local gate before merging.
+- **CI surprises:** `pytest.yml` now runs the 97% coverage floor as a PR gate (the
+  `coverage (>=97%)` job, W1-3 landed — the floor no longer waits for post-merge `coverage.yml`).
+  `ci-offline` (a `pytest.yml` job) is a required GitHub branch-protection status check on `main`,
+  so a PR cannot merge until it is green; `pytest.yml` triggers on `pull_request` only (no separate
+  workflow re-runs it on a direct push). Run the local gate before merging.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,12 +38,12 @@ The token-mint payload also now carries an explicit `expiration` field
 synchronous `get_token` helper sends `expiration=60`). This matches the
 ArcGIS server-side default and is not a behaviour change in practice.
 
-## 2.0.0 migration notes
+## 2.x → 3.0 migration notes
 
-restgdf 2.0.0 reshapes install surface, error taxonomy, configuration,
+restgdf 3.0 reshapes install surface, error taxonomy, configuration,
 authentication, observability, and streaming on top of the typed
-pydantic models that now ship in the release. The preserved 1.x → 2.0
-guide follows below.
+pydantic models introduced in 2.0. The preserved 1.x → 2.0 guide
+follows below.
 
 ### Summary
 
@@ -144,8 +144,12 @@ guide follows below.
 
 - `ArcGISTokenSession` now defaults to sending the token via the
   `X-Esri-Authorization` header. If your server requires the legacy
-  body/query transport, set `AuthConfig(transport="body")` or
-  `TokenSessionConfig(transport="body")`.
+  body/query transport, construct the session with
+  `TokenSessionConfig(transport="body")` — that is the value the session
+  actually reads. A bare `AuthConfig(transport="body")` is a config
+  *holder* that is never auto-applied to a session; opt in explicitly via
+  `ArcGISTokenSession.from_config(...)` /
+  `TokenSessionConfig.from_auth_config(...)`.
 - `refresh_leeway_seconds` default raised from **60 → 120** — proactive
   token refresh now fires two minutes before expiry instead of one.
 - `refresh_threshold_seconds` on `TokenSessionConfig` is retained as a
@@ -180,9 +184,9 @@ RestgdfError
 │   ├── ArcGISServiceError
 │   │   └── PaginationError(ArcGISServiceError, IndexError)  # .batch_index, .page_size
 │   └── AuthenticationError(RestgdfResponseError, PermissionError)
-│       ├── InvalidCredentialsError        # HTTP 401
+│       ├── InvalidCredentialsError        # /generateToken HTTP 4xx (400/401/403)
 │       ├── TokenExpiredError              # HTTP 498 after refresh
-│       ├── TokenRequiredError
+│       ├── TokenRequiredError             # reserved — not currently raised
 │       ├── TokenRefreshFailedError        # /generateToken retries exhausted
 │       └── AuthNotAttachedError           # HTTP 499
 ├── TransportError
@@ -249,8 +253,10 @@ See `docs/recipes/streaming.md` for copy-pasteable examples.
 **Tabular output** (`FeatureLayer.get_df`)
 
 Pandas-first sibling to `get_gdf()`. Returns a `pandas.DataFrame` built
-from the same row stream; raises `OptionalDependencyError`
-(`extra="pandas"`) if pandas is missing. Geopandas is **not** required.
+from the same row stream; raises `OptionalDependencyError` naming
+`restgdf[geo]` if pandas is missing (pandas ships in the `geo` extra —
+there is no separate `pandas` extra). Geopandas itself is **not**
+required to materialize the frame.
 
 **Response normalization** (`restgdf._models.responses`)
 
@@ -287,7 +293,7 @@ from the same row stream; raises `OptionalDependencyError`
   `(resultOffset, resultRecordCount)` tuples byte-identical to the
   previous inline arithmetic. When `factor` exceeds
   `advertised_factor` the planner clamps to the advertised value and
-  logs a warning via `restgdf.pagination`. In 2.0.0,
+  logs a warning via `restgdf.pagination`. In 3.0,
   `get_query_data_batches` now forwards live
   `advancedQueryCapabilities.maxRecordCountFactor` values into
   `build_pagination_plan(advertised_factor=...)` when the server
@@ -500,9 +506,14 @@ Resilience / telemetry toggles:
   Exhausted timeouts raise `RestgdfTimeoutError` with the original
   exception chained as `__cause__`. Inline-only; no soft-dep on the
   resilience extra.
-- **`verify_ssl` plumbed through.** `ArcGISTokenSession.update_token`
-  now forwards `ssl=self.verify_ssl` to aiohttp, matching the existing
-  behavior of other library-maintained request sites.
+- **`verify_ssl` plumbed through end-to-end.**
+  `ArcGISTokenSession.update_token` forwards `ssl=self.verify_ssl` on the
+  `/generateToken` POST, and `_call_with_auth_retry` forwards
+  `ssl=self.verify_ssl` (via `setdefault`, so a caller-supplied `ssl=`
+  still wins) on token-attached data requests. The bare-session path,
+  `get_gdf(session=None)`, builds its temporary `ClientSession` with
+  `TCPConnector(ssl=get_config().transport.verify_ssl)`. A caller-supplied
+  session's own connector continues to own TLS policy for its requests.
 - **Safe-crawl concurrency bound.** `Directory.safe_crawl` routes the
   per-layer `feature_count` probe through a `BoundedSemaphore` sized
   from `ConcurrencyConfig.max_concurrent_requests`.
@@ -827,7 +838,12 @@ Log levels:
 
 Drift events are deduped per process via `(model_name, path, kind,
 value_type)` so repeated calls against the same drifty server don't
-spam the log.
+spam the log. The originating service/URL is threaded into the first
+(non-deduped) record — both in the log message and as a `drift_context`
+`extra` field — so that emission is attributable, but `drift_context` is
+deliberately **excluded** from the dedupe key: a second service that
+drifts on the same tuple is silenced rather than re-attributed (message
+attribution, not per-service dedup).
 
 ## `Settings` usage
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ asyncio.run(main())
 ```
 
 <details>
-<summary><strong>2.0 release highlights and migration summary</strong> (click to expand)</summary>
+<summary><strong>3.0 release highlights and migration summary</strong> (click to expand)</summary>
 
 ## Release highlights
 
-restgdf 2.0.0 includes the following major additions alongside the core
+restgdf 3.0 added the following major capabilities alongside the 2.0
 typed-model migration described below.
 
 - **Streaming APIs.** `FeatureLayer.stream_features`,
@@ -85,8 +85,10 @@ typed-model migration described below.
   [tracing recipe](https://restgdf.readthedocs.io/en/latest/recipes/tracing.html)
   and [streaming recipe](https://restgdf.readthedocs.io/en/latest/recipes/streaming.html).
 - **Header-token default.** Tokens now ride the
-  `X-Esri-Authorization` header by default; set
-  `AuthConfig.transport="body"` to restore the old behavior.
+  `X-Esri-Authorization` header by default; construct the session with
+  `TokenSessionConfig(transport="body")` to restore the old body
+  transport (a bare `AuthConfig(transport="body")` is a config holder
+  that is not auto-applied to a session).
 
 See [`CHANGELOG.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/CHANGELOG.md)
 and [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md)
@@ -184,7 +186,7 @@ pip install "restgdf[geo]"
 Treat the split above as the stable dependency boundary: geo-enabled
 environments should depend on `restgdf[geo]` explicitly. See
 [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md)
-for the full 1.x → 2.0 rewrite table and upgrade recipes.
+for the 1.x → 2.0 and 2.x → 3.0 upgrade guides.
 
 ## Light-core usage
 
@@ -329,6 +331,15 @@ Keyword arguments to `FeatureLayer.get_gdf()` are passed on to
 `aiohttp.ClientSession.post`; include query parameters like `where` and `token`
 in the `data` dict when needed.
 
+**Truncation now raises (PAGINATION-01).** `get_gdf()` and
+`stream_gdf_chunks()` — the GeoDataFrame path — now inspect each page for
+`exceededTransferLimit=true` and raise `restgdf.errors.PaginationError`,
+mirroring the raw-feature streaming engine, instead of silently returning
+a GeoDataFrame that is missing rows. If a very large layer trips this,
+read it through the `iter_pages`-based `stream_features` / `stream_rows`
+shapes, which expose `on_truncation="ignore" | "split"` (the legacy geo
+chunk path does not take that knob).
+
 ## Token authentication
 
 Token helpers are available in the base install. The GeoDataFrame example below
@@ -361,7 +372,13 @@ async def main():
 secured_gdf = asyncio.run(main())
 ```
 
-If you already have a token, you can pass it with `token="..."` or `data={"token": "..."}`.
+If you already have a token, you can pass it with `token="..."` or
+`data={"token": "..."}`. restgdf sends a token-bearing request as a **POST
+with the token in the request body** (never serialized into the URL query
+string), so the token does not leak into server or proxy access logs —
+this holds even for short requests that would otherwise use GET (AUTH-01).
+For fully header-based auth, use an `ArcGISTokenSession`, which sends the
+token via the `X-Esri-Authorization` header instead.
 
 ## Typed responses
 
@@ -391,7 +408,7 @@ name, max_record_count, arcgis_dict = asyncio.run(main())
 
 Need a plain dict during a transitional migration? Use
 `restgdf.compat.as_dict(md)`. See [`MIGRATION.md`](https://github.com/joshuasundance-swca/restgdf/blob/main/MIGRATION.md) for
-the full 1.x → 2.0 rewrite table.
+the 1.x → 2.0 and 2.x → 3.0 upgrade guides.
 
 ### ArcGIS drift guarantees and limitations
 
@@ -441,7 +458,8 @@ contents.
   taxonomy, logger hierarchy, config precedence, session ownership,
   streaming shapes, extras matrix.
 - [CHANGELOG.md](CHANGELOG.md) — every user-visible change.
-- [MIGRATION.md](MIGRATION.md) — upgrading from 1.x to 2.0.
+- [MIGRATION.md](MIGRATION.md) — upgrading across 1.x → 2.0, 2.x → 3.0,
+  and 3.0.x → 3.1.
 
 # Uses
 

--- a/audit-recommendations/plan/99-traceability.md
+++ b/audit-recommendations/plan/99-traceability.md
@@ -182,4 +182,23 @@ Findings mapped to more than one item are **split-ownership**: each owning item 
 
 ## Deliberate deferrals
 
-None. All 61 confirmed findings are allocated to at least one work item. (Decision-required items may, at the maintainer's choice, resolve to *doc-only* fixes — e.g. CONFIG-03/04 — but the finding is still addressed, not dropped; see the master plan's decision record.)
+All 61 confirmed findings are allocated to at least one work item, and one item is a recorded
+deferral (updated 2026-07-24 at M4 close; originally this section said "None"):
+
+- **`ERRTAX-03` / `W2-5` — DEFERRED (NO-GO), M3 2026-07-24.** In-body 498/499 envelope
+  detection was closed as NO-GO per plan/02's own recommendation: HTTP-200-wrapped auth
+  envelopes already surface as typed `RestgdfResponseError`, so the added mapping buys little
+  against its cross-layer cost. Owner: a future reactive-auth design pass (jointly with the
+  `_drift.py` owner). Trigger: maintainer GO, or field reports of HTTP-200 498/499 envelopes.
+  Rationale recorded in the W2-5 docstring note and PR #209.
+
+Two disposition clarifications for the record (surfaced by `scripts/audit_disposition.py`):
+- **`W3-6` was not dropped** — it resolved as *confirm-only* (Path a) in M2/PR #203: the
+  timeout/concurrency env vars were verified wired and the three `RESTGDF_AUTH_*` vars
+  verified absent from the resolver; the documentation rows were corrected under W6-7 (M4).
+- **`W4-6`/`W5-9`/`W5-10`/`W5-11`** carry an M2 milestone label below but landed in the M1
+  typing-transition stack (PR #196) per the runbook's recorded milestone override.
+
+(Decision-required items may, at the maintainer's choice, resolve to *doc-only* fixes — e.g.
+CONFIG-03/04, both landed as doc-downs — the finding is addressed, not dropped; see the master
+plan's decision record.)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,14 +1,15 @@
 Configuration
 =============
 
-``restgdf`` uses a layered configuration system based on
-`Pydantic Settings <https://docs.pydantic.dev/latest/concepts/pydantic_settings/>`_.
-Values resolve in this order (highest precedence first):
+``restgdf`` uses a layered, environment-variable + explicit-argument
+configuration system. Values resolve in this order (highest precedence first):
 
-1. **Explicit constructor arguments** — e.g. ``FeatureLayer.from_url(timeout=…)``
-2. **``Config(...)`` instance** passed explicitly
-3. **Process environment variables** (``RESTGDF_*``)
-4. **Library defaults**
+1. **Explicit constructor / aiohttp keyword arguments** — e.g.
+   ``FeatureLayer.from_url(timeout=…)``, applied per call
+2. **Process environment variables** (``RESTGDF_*``), read by
+   ``Config.from_env`` and exposed process-globally through the
+   size-1-cached ``get_config()``
+3. **Library defaults**
 
 ``restgdf`` does not read a ``.env`` file itself — ``Config.from_env()`` resolves values
 from the process environment (``os.environ``) only, and ``python-dotenv`` is not a
@@ -30,12 +31,15 @@ Quick start
 
    from restgdf import Config, get_config
 
-   # Read from environment + defaults
+   # Resolve from the environment + defaults — this is the instance the
+   # request path reads.
    cfg = get_config()
 
-   # Override explicitly
+   # Build an explicit Config object (for tests, or an
+   # ``ArcGISTokenSession(config=...)``); a directly built Config is not
+   # injected into the FeatureLayer/Directory request path.
    cfg = Config(
-       transport={"timeout_total": 120},
+       timeout={"total_s": 120},
        concurrency={"max_concurrent_requests": 8},
    )
 
@@ -53,24 +57,15 @@ are supported with a ``DeprecationWarning``.
    * - Variable
      - Default
      - Description
-   * - ``RESTGDF_TRANSPORT_TIMEOUT_TOTAL``
-     - ``300``
+   * - ``RESTGDF_TIMEOUT_TOTAL_S``
+     - ``30``
      - Total HTTP timeout in seconds
    * - ``RESTGDF_TRANSPORT_USER_AGENT``
      - ``"restgdf/<version>"``
      - User-Agent header value
    * - ``RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS``
-     - ``10``
+     - ``8``
      - Global concurrency cap for parallel page fetches
-   * - ``RESTGDF_AUTH_TRANSPORT``
-     - ``"header"``
-     - Token delivery method: ``"header"`` or ``"body"``
-   * - ``RESTGDF_AUTH_REFRESH_LEEWAY_SECONDS``
-     - ``120``
-     - Seconds before expiry to trigger proactive refresh
-   * - ``RESTGDF_AUTH_CLOCK_SKEW_SECONDS``
-     - ``30``
-     - Clock skew tolerance for token expiry comparison
    * - ``RESTGDF_RESILIENCE_ENABLED``
      - ``false``
      - Enable retry + rate limiting (requires ``restgdf[resilience]``)
@@ -86,6 +81,11 @@ are supported with a ``DeprecationWarning``.
    * - ``RESTGDF_TELEMETRY_SERVICE_NAME``
      - ``"restgdf"``
      - OTel service name for emitted spans
+
+The token-session knobs ``AuthConfig.transport``, ``refresh_leeway_s``, and
+``clock_skew_s`` are **not** driven by dedicated ``RESTGDF_AUTH_*`` environment
+variables. Set them on an explicit ``Config`` instead — for example
+``Config(auth=AuthConfig(transport="body", refresh_leeway_s=180, clock_skew_s=45))``.
 
 Config model reference
 ----------------------

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -116,7 +116,7 @@ Many exceptions carry structured metadata for programmatic recovery:
    * - ``PaginationError``
      - ``batch_index``, ``page_size``
    * - ``FieldDoesNotExistError``
-     - ``field``, ``context``
+     - ``field_name``, ``context``
 
 See also
 --------

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -33,7 +33,7 @@ async def main():
         cities = await beaches.get_unique_values("CITY")
 
         first_rows = []
-        async for row in beaches.row_dict_generator(data={"outFields": "CITY,STATE"}):
+        async for row in beaches.stream_rows(data={"outFields": "CITY,STATE"}):
             first_rows.append(row)
             if len(first_rows) == 2:
                 break

--- a/docs/recipes/observability.md
+++ b/docs/recipes/observability.md
@@ -62,8 +62,11 @@ Custom attributes use the `restgdf.*` namespace:
 ## Log correlation
 
 `restgdf` automatically attaches a `_SpanContextFilter` to the root
-`restgdf` logger. When an OTel span is active, every log record gains
-`trace_id` and `span_id` attributes:
+`restgdf` logger. The filter **always** stamps `trace_id` and `span_id`
+on every `restgdf` log record — the active span's IDs when a span is
+current, and empty strings (`""`) otherwise — so a `%(trace_id)s` /
+`%(span_id)s` format string never raises on a record emitted outside a
+span:
 
 ```python
 import logging

--- a/docs/recipes/streaming.md
+++ b/docs/recipes/streaming.md
@@ -86,6 +86,14 @@ order** and does not accept `on_truncation`, `order`, or
 output, compose `stream_rows` or `stream_features` with your own
 geometry assembly, or call `get_gdf` / `get_gdf_list` for a single-
 shot batch.
+
+Even without the `on_truncation` knob it is **not** silent about
+truncation: if a page reports `exceededTransferLimit=true`, the geo path
+(`stream_gdf_chunks` and `get_gdf`) now raises
+{class}`~restgdf.errors.PaginationError`, mirroring the `iter_pages`
+engine's default, instead of returning a chunk that is missing rows. For
+ignore/split behavior, read the layer through the `iter_pages`-based
+shapes above.
 :::
 
 `stream_rows` is the row-shaped sibling of `stream_features`: each item
@@ -143,11 +151,13 @@ stick with `"request"`.
 ## Throughput: `max_concurrent_pages`
 
 ```python
-# Unbounded (default). Easy to overwhelm slow services.
+# Unbounded (default: None). Every page in the plan is scheduled up
+# front and each fetched page is buffered — concurrency AND memory grow
+# with the page count. `order` alone does not bound this.
 async for feat in layer.stream_features():
     ...
 
-# Cap concurrent in-flight page fetches.
+# Cap concurrent in-flight page fetches (and peak memory).
 async for feat in layer.stream_features(max_concurrent_pages=4):
     ...
 ```
@@ -156,6 +166,14 @@ async for feat in layer.stream_features(max_concurrent_pages=4):
 `ConcurrencyConfig.max_concurrent_requests` (which caps fan-out at
 the top-level orchestration layer) — the more restrictive of the two
 wins.
+
+:::{note}
+`max_concurrent_pages` bounds only the top-level page-plan fetches. When
+`on_truncation="split"`, each truncated page issues its own serial,
+**uncounted** sub-fetches (one `get_object_ids` plus a `_fetch_page_dict`
+per bisected half), so with a cap of `K` the worst-case in-flight count
+is roughly `K + 1`, not a hard `K`.
+:::
 
 ## What about `iter_pages`?
 

--- a/restgdf/adapters/geopandas.py
+++ b/restgdf/adapters/geopandas.py
@@ -45,11 +45,15 @@ def rows_to_geodataframe(
     Parameters
     ----------
     rows:
-        Iterable of row-shaped dicts, typically produced by
-        :func:`restgdf.adapters.stream.iter_rows` or
-        :func:`restgdf.adapters.dict.features_to_rows`. Each row's
-        ``geometry_field`` entry must be shapely-compatible (or a
-        ``GeoSeries`` element).
+        Iterable of row-shaped dicts. Each row's ``geometry_field`` entry
+        must already be **shapely-compatible** (a shapely geometry or a
+        ``GeoSeries`` element). Note that ``iter_rows`` /
+        ``features_to_rows`` yield the *raw ArcGIS geometry dict*, which is
+        not shapely-compatible and must be converted first; for a
+        batteries-included ArcGIS-to-GeoDataFrame path use
+        :meth:`restgdf.FeatureLayer.get_gdf` /
+        :meth:`restgdf.FeatureLayer.stream_gdf_chunks` (or
+        ``restgdf.adapters.stream.iter_gdf_chunks``) instead.
     geometry_field:
         Column name holding the geometry values. Defaults to ``"geometry"``.
     crs:
@@ -104,9 +108,13 @@ async def arows_to_geodataframe(
     Parameters
     ----------
     rows:
-        Async iterable of row-shaped dicts — typically
-        :meth:`restgdf.FeatureLayer.stream_rows` or
-        :func:`restgdf.adapters.stream.iter_rows`.
+        Async iterable of row-shaped dicts whose ``geometry_field`` entry
+        is already **shapely-compatible**. Note that
+        :meth:`restgdf.FeatureLayer.stream_rows` /
+        :func:`restgdf.adapters.stream.iter_rows` yield the *raw ArcGIS
+        geometry dict*, which must be converted to shapely first; for the
+        batteries-included path use :meth:`restgdf.FeatureLayer.get_gdf` /
+        :meth:`restgdf.FeatureLayer.stream_gdf_chunks` instead.
     geometry_field:
         Column name for the geometry column. Defaults to ``"geometry"``.
     crs:
@@ -124,8 +132,8 @@ async def arows_to_geodataframe(
     See Also
     --------
     :meth:`restgdf.FeatureLayer.get_gdf`
-        Equivalent to ``await arows_to_geodataframe(layer.stream_rows())``
-        with geometry normalization and CRS propagation handled for you.
+        High-level accessor that returns the full layer as a single
+        ``GeoDataFrame``.
     """
     materialized: list[dict[str, Any]] = [row async for row in rows]
     return rows_to_geodataframe(

--- a/restgdf/errors.py
+++ b/restgdf/errors.py
@@ -61,7 +61,8 @@ class ConfigurationError(RestgdfError, ValueError):
 
     Multi-inherits :class:`ValueError` through 3.x so existing
     ``except ValueError`` callers continue to catch misconfiguration. The
-    ``ValueError`` base will be dropped in 3.1+.
+    ``ValueError`` base is a back-compat shim and will only be removed in
+    a future major release (>=4.0), preceded by a ``DeprecationWarning``.
     """
 
 

--- a/restgdf/featurelayer/featurelayer.py
+++ b/restgdf/featurelayer/featurelayer.py
@@ -405,8 +405,15 @@ class FeatureLayer:
             ``"completion"`` yields pages as the underlying fetches
             complete (may reorder relative to the pagination plan).
         max_concurrent_pages
-            Upper bound on concurrent in-flight page fetches.
-            ``None`` (default) leaves concurrency unbounded.
+            Upper bound on concurrent in-flight page fetches. Pass a
+            positive ``int`` to bound both concurrency and peak memory.
+            ``None`` (the default) does **not** bound them: every page in
+            the pagination plan is scheduled up front and each fetched
+            page is buffered, so both grow with the page count. ``order``
+            alone does not bound anything — only ``max_concurrent_pages``
+            does. Note that ``on_truncation="split"`` issues additional
+            uncounted sub-fetches per truncated page, so even with a bound
+            of ``K`` the worst-case in-flight count is roughly ``K + 1``.
         on_truncation
             Behavior when a page reports ``exceededTransferLimit=true``:
 


### PR DESCRIPTION
## Summary
The M4 documentation reconciliation — every companion doc now matches the code (adversarially verified: **CONFIRMED**; the verifier sampled 21 changed claims against the tree — zero invented, zero stale — re-ran strict Sphinx from a verified worktree env, and word-diffed CLAUDE.md):

- **W6-3** ARCHITECTURE.md: `ErrorPayload`/`.env`/logger-name/session-ownership claims corrected to the real 3.x contracts.
- **W6-4** MIGRATION.md: verify_ssl end-to-end narrative, refresh-knob consumption (150s split), `extra="pandas"` falsehood removed, telemetry notes.
- **W6-6** README: 3.x refresh, token-in-body (AUTH-01) and truncation-now-raises (W4-1) notes.
- **W6-7** Sphinx docs: env-var table corrected (dropped the 3 unwired `RESTGDF_AUTH_*` rows, fixed names/defaults), errors.rst attribute fix, quickstart deprecated-helper fix, streaming/observability recipe updates.
- **W2-9** errors.py docstring (co-inheritance removal policy: future major ≥4.0 with DeprecationWarning), **W5-5** adapter docstrings, **W4-4** iter_pages docstring (the twice-dropped handoff, landed).
- **CLAUDE.md** pitfalls refresh (only the four enumerated paragraphs) + link/terminology scan.
- **Traceability**: the W2-5/ERRTAX-03 deferral recorded with owner+trigger; W3-6 confirm-only and typing-stack milestone-override clarifications (surfaced by the new census oracle).

Gates re-derived post-interruption: sphinx `-n -W` green (editable target verified), suite 1313/4/4, pre-commit fixed point. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk