### PR TITLE
fix: census evidence corrections — verified files, decision-close parsing, squash-proof exclusion

### DIFF
--- a/audit-recommendations/findings.json
+++ b/audit-recommendations/findings.json
@@ -81,7 +81,9 @@
   "files": [
    "restgdf/utils/token.py",
    "restgdf/utils/getgdf.py",
-   "MIGRATION.md"
+   "MIGRATION.md",
+   "restgdf/_config.py",
+   "restgdf/_models/_settings.py"
   ]
  },
  {
@@ -154,7 +156,9 @@
   "location": "ARCHITECTURE.md:118, restgdf/_config.py:344, restgdf/_models/_settings.py:197",
   "files": [
    "ARCHITECTURE.md",
-   "restgdf/_config.py"
+   "restgdf/_config.py",
+   "docs/configuration.rst",
+   "docs/authentication.rst"
   ]
  },
  {

--- a/scripts/audit_disposition.py
+++ b/scripts/audit_disposition.py
@@ -59,11 +59,28 @@ lie" / "a LANDED claim whose commit doesn't contain the change = REFUTED"):
   deliberately NOT scanned for this either — see ``build_prose_signals``'s
   docstring for the cross-contamination it produces at paragraph
   granularity.
-* This program's OWN dev-tooling commits (Conventional-Commits scope
-  ``(dev-tooling)``, e.g. this module's genesis commit) are excluded from
-  every evidence scan above — see ``is_dev_tooling_commit``. The oracle's
-  own commit messages narrate its bugfix history in prose; they are never
-  themselves evidence about a finding's disposition.
+* This program's OWN construction commits are excluded from every evidence
+  scan above — see ``is_self_referential_commit``. That is EITHER a subject
+  line using the Conventional-Commits scope ``(dev-tooling)`` (checked by
+  ``is_dev_tooling_commit``), OR a commit whose ENTIRE diff is confined to
+  the oracle's own files (``scripts/audit_disposition.py`` /
+  ``tests/test_audit_disposition.py``) — the file-based check is the one
+  that actually holds: a GitHub squash merge (PR #213) renamed this
+  program's genesis commit's subject to "feat: audit disposition census
+  oracle (M4 exit gate) (#213)", so no "(dev-tooling)" scope survived the
+  squash, and the squashed body still narrates the oracle's own bugfix
+  history in the exact self-contaminating shape — see
+  ``is_self_referential_commit``'s docstring for the two false DEFERREDs
+  (AUTH-01/W2-1, PAGINATION-03/W4-3) the squash commit itself re-triggered.
+  The oracle's own commit messages narrate its bugfix history in prose;
+  they are never themselves evidence about a finding's disposition.
+* A finding's owning item can ALSO resolve DECISION-CLOSED via
+  ``audit-recommendations/plan/99-traceability.md``'s "## Deliberate
+  deferrals" section, for an item explicitly recorded there as
+  *confirm-only* (Path a) — see ``parse_decision_closed_clarifications``.
+  This covers a real terminal disposition with ZERO commits by design
+  (W3-6/DOCS-02 resolved by verifying existing behavior, not by shipping
+  a change), which no commit-based evidence source can ever see.
 
 Disposition per finding, in this precedence order (this is aggregated across
 every work item the traceability map assigns to the finding — split-ownership
@@ -108,6 +125,19 @@ from typing import Any
 _FINDINGS_REL = Path("audit-recommendations/findings.json")
 _TRACEABILITY_REL = Path("audit-recommendations/plan/99-traceability.md")
 _LEDGER_REL = Path("audit-recommendations/plan/PROGRAM-LEDGER.md")
+
+# The traceability doc's own clarifications section, where a terminal
+# disposition can be recorded WITHOUT any commit at all (e.g. W3-6 resolved
+# confirm-only by verifying existing behavior, never by shipping a change).
+_DELIBERATE_DEFERRALS_HEADING = "## Deliberate deferrals"
+
+# "confirm-only" / "decision-closed" — the traceability doc's own wording
+# for a terminal, non-landing, non-deferred disposition. Deliberately
+# narrower than `_MARKER_RE` (no bare "defer*"/"no-go" match here): this
+# section's DEFERRED items (e.g. ERRTAX-03) are already covered by
+# `build_prose_signals` from the real commit history, and re-matching them
+# here via a looser marker would be redundant at best.
+_DECISION_CLOSED_MARKER_RE = re.compile(r"confirm-only|decision-closed", re.IGNORECASE)
 
 # Same-major shorthand ("W3-2/4" == W3-2, W3-4) AND plain IDs ("W2-2"). Cross-
 # major chains ("W4-6/W5-9") fall out naturally: the continuation only grabs
@@ -202,7 +232,7 @@ class CommitRecord:
 
 @dataclass
 class Evidence:
-    kind: str  # "commit" | "ledger"
+    kind: str  # "commit" | "ledger" | "traceability"
     source: str  # sha or file name
     snippet: str
 
@@ -292,6 +322,68 @@ def commit_files(repo_root: Path, sha: str) -> set[str]:
         check=True,
     ).stdout
     return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+# The oracle's own two files. A commit whose ENTIRE diff is confined to
+# these is ABOUT this program, never about an audited finding.
+_ORACLE_OWN_FILES = frozenset(
+    {
+        "scripts/audit_disposition.py",
+        "tests/test_audit_disposition.py",
+    },
+)
+
+
+def is_self_referential_commit(repo_root: Path, commit: CommitRecord) -> bool:
+    """True if ``commit`` is ABOUT this program itself, not about any
+    audited finding — either its own subject line uses the dev-tooling
+    scope (``is_dev_tooling_commit``), OR its entire diff is confined to
+    the oracle's own files (``_ORACLE_OWN_FILES``).
+
+    The file-diff check is the general-purpose, squash-merge-proof half:
+    PR #213 squash-merged this program's construction work under the
+    subject "feat: audit disposition census oracle (M4 exit gate) (#213)"
+    — no "(dev-tooling)" scope survives a GitHub squash rename — yet the
+    squashed commit body still narrates the oracle's own bugfix history in
+    the exact self-contaminating shape this program fixes. Confirmed: on
+    merged ``main`` the squash commit (``701ddbf``) re-triggered TWO false
+    DEFERREDs by itself — AUTH-01/W2-1 (the squash body's own docstring
+    excerpt quotes "W2-1" next to "owner+trigger"/"NO-GO") and a NEW
+    PAGINATION-03/W4-3 (the same body's regression-test description quotes
+    "W4-3" in a ledger-cross-contamination example, again next to
+    "owner+trigger"/"NO-GO") — both from the same commit's own body
+    describing this very fix. Text-based ``is_dev_tooling_commit`` alone
+    does not catch this, since the squash's subject carries the PR title,
+    not the original commit-type scope.
+
+    Only consulted for commits that mention at least one item at all (skips
+    the ``git diff-tree`` call otherwise — the large majority of this
+    repo's 500+ commit history mentions no work item and can never produce
+    false evidence regardless of file diff).
+    """
+    if is_dev_tooling_commit(commit.message):
+        return True
+    if not extract_all_items(commit.message):
+        return False
+    touched = commit_files(repo_root, commit.sha)
+    return bool(touched) and touched <= _ORACLE_OWN_FILES
+
+
+def _markdown_section(text: str, heading: str) -> str:
+    """Lines between a top-level ``heading`` (e.g. ``## Deliberate
+    deferrals``, matched by prefix) and the next ``## `` heading, or EOF.
+    """
+    lines: list[str] = []
+    in_section = False
+    for line in text.splitlines():
+        if line.startswith(heading):
+            in_section = True
+            continue
+        if in_section and line.startswith("## "):
+            break
+        if in_section:
+            lines.append(line)
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -439,6 +531,71 @@ def build_prose_signals(
     return deferred, decision_closed
 
 
+def parse_decision_closed_clarifications(repo_root: Path) -> dict[str, Evidence]:
+    """Parse ``99-traceability.md``'s "## Deliberate deferrals" section for
+    its per-item "confirm-only"/"decision-closed" clarification bullets, and
+    treat each item named THERE as DECISION_CLOSED evidence.
+
+    This is the only evidence source for a real terminal disposition that
+    has ZERO commits by design: W3-6/DOCS-02 resolved as *confirm-only*
+    (Path a) in M2/PR #203 — the finding was addressed by VERIFYING existing
+    behavior (the timeout/concurrency env vars were already wired, the
+    RESTGDF_AUTH_* vars were confirmed absent), not by shipping a change —
+    so no commit anywhere ever cites "W3-6" as closing anything, and neither
+    ``build_declared_landings`` nor ``build_prose_signals`` can ever see it.
+    The traceability doc itself records the clarification in prose instead
+    (see the module docstring's "## Deliberate deferrals" bullet:
+    "``W3-6`` was not dropped — it resolved as *confirm-only* (Path a)...").
+
+    The section legitimately narrates SEVERAL items in one place (the
+    ERRTAX-03/W2-5 DEFERRED record, a milestone-label correction for
+    W4-6/W5-9/W5-10/W5-11, and this confirm-only clarification for W3-6),
+    so — exactly like ``build_prose_signals`` — this reuses ``_item_clauses``
+    to scope the "confirm-only"/"decision-closed" marker
+    (``_DECISION_CLOSED_MARKER_RE``) to the SAME semicolon-delimited clause
+    as the item's own mention, not the whole bullet. This matters here too:
+    the real W3-6 bullet's own clause says "...resolved as confirm-only
+    (Path a) in M2/PR #203: the timeout/concurrency env vars were verified
+    wired..."; its NEXT clause (after a semicolon) says "...the
+    documentation rows were corrected under W6-7 (M4)" — W6-7 is a
+    different, genuinely LANDED item that happens to be name-dropped as a
+    cross-reference in the SAME bullet. Without clause-scoping, W6-7 would
+    also be marked DECISION_CLOSED here, silently overriding its real
+    LANDED evidence (``item_status_for_finding`` checks ``decision_closed``
+    before ever consulting commit-based evidence) — for DOCS-02 itself this
+    happens to still net out to the same finding-level disposition (DOCS-02
+    already needs its OTHER owning item, W3-6, to reach DECISION-CLOSED),
+    but W6-7 is ALSO TELEMETRY-01's other owning item, where it would
+    silently flip a truly LANDED finding to DECISION-CLOSED. Regression-
+    pinned by ``test_parse_decision_closed_clarifications_does_not_leak_to_
+    a_co_mentioned_item``.
+
+    A bullet naming ERRTAX-03/W2-5 (DEFERRED, not confirm-only) or the
+    W4-6/W5-9/W5-10/W5-11 milestone-label correction (no confirm-only/
+    decision-closed wording at all) never matches the marker and is
+    naturally excluded — this section is not otherwise scanned for
+    ``build_prose_signals``' owner+trigger/no-go language.
+    """
+    text = (repo_root / _TRACEABILITY_REL).read_text(encoding="utf-8")
+    section = _markdown_section(text, _DELIBERATE_DEFERRALS_HEADING)
+    decision_closed: dict[str, Evidence] = {}
+    for block in re.split(r"\n(?=- )", section):
+        block = block.strip()
+        if not block.startswith("- "):
+            continue
+        for item, clause in _item_clauses(block).items():
+            if _DECISION_CLOSED_MARKER_RE.search(clause):
+                decision_closed.setdefault(
+                    item,
+                    Evidence(
+                        kind="traceability",
+                        source=str(_TRACEABILITY_REL),
+                        snippet=block[:400],
+                    ),
+                )
+    return decision_closed
+
+
 # ---------------------------------------------------------------------------
 # Disposition
 # ---------------------------------------------------------------------------
@@ -543,13 +700,16 @@ def build_report(repo_root: Path) -> dict[str, Any]:
     findings = load_findings(repo_root)
     forward_map = load_forward_map(repo_root)
     all_commits = git_log_records(repo_root)
-    # This program's own dev-tooling commits (e.g. this module's genesis
-    # commit) narrate the oracle's OWN bugfix history in prose and are
-    # excluded from every evidence scan below — see
-    # `is_dev_tooling_commit`'s docstring for the false-positive this
-    # prevents (AUTH-01/W2-1 self-mislabeled DEFERRED by co-mentioning its
-    # own construction history).
-    commits = [c for c in all_commits if not is_dev_tooling_commit(c.message)]
+    # This program's own construction commits narrate the oracle's OWN
+    # bugfix history in prose and are excluded from every evidence scan
+    # below — see `is_self_referential_commit`'s docstring for the false
+    # positives this prevents (AUTH-01/W2-1 and PAGINATION-03/W4-3, both
+    # self-mislabeled DEFERRED by co-mentioning that item alongside
+    # deferral language while narrating this program's own construction
+    # history — including from the PR #213 squash-merge commit, which no
+    # longer carries the "(dev-tooling)" subject scope but still self-
+    # contaminates by file diff).
+    commits = [c for c in all_commits if not is_self_referential_commit(repo_root, c)]
     # NOTE: PROGRAM-LEDGER.md exists (`_LEDGER_REL`) but is deliberately NOT
     # read into the deferred/decision-close prose scan — see
     # build_prose_signals' docstring for why (its per-milestone rows compress
@@ -559,6 +719,15 @@ def build_report(repo_root: Path) -> dict[str, Any]:
     finding_ids = {f.id for f in findings}
     declared_landings, declared_findings = build_declared_landings(commits, finding_ids)
     deferred, decision_closed = build_prose_signals(commits)
+    # A finding's owning item can ALSO reach a terminal DECISION-CLOSED via
+    # the traceability doc's own "## Deliberate deferrals" clarifications
+    # (see parse_decision_closed_clarifications' docstring) -- this is the
+    # ONLY evidence source for W3-6/DOCS-02, which has zero commits by
+    # design. Never overrides an existing commit-derived `deferred` or
+    # `decision_closed` entry for the same item.
+    for item, ev in parse_decision_closed_clarifications(repo_root).items():
+        if item not in deferred and item not in decision_closed:
+            decision_closed[item] = ev
     file_cache: dict[str, set[str]] = {}
 
     orphans_no_mapping = sorted(finding_ids - forward_map.keys())

--- a/tests/test_audit_disposition.py
+++ b/tests/test_audit_disposition.py
@@ -382,6 +382,378 @@ def test_build_report_excludes_dev_tooling_commit_from_deferral_evidence(
 
 
 # ---------------------------------------------------------------------------
+# is_self_referential_commit — the squash-merge-proof file-diff check
+# ---------------------------------------------------------------------------
+
+
+def test_is_self_referential_commit_true_for_dev_tooling_subject(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """The message-based check alone is enough when the subject scope
+    survives — no git access needed since ``is_dev_tooling_commit`` short-
+    circuits first.
+    """
+    commit = ad.CommitRecord(
+        sha="deadbeef",
+        message="feat(dev-tooling): add M4 exit oracle audit_disposition.py + tests\n",
+    )
+    assert ad.is_self_referential_commit(tmp_path, commit)
+
+
+def test_is_self_referential_commit_true_for_squash_merge_confined_to_oracle_files(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """The real PR #213 shape: a squash-merge commit whose SUBJECT carries
+    the PR title (no "(dev-tooling)" scope survives the rename) but whose
+    ENTIRE diff is confined to the oracle's own two files, and whose body
+    mentions a work item (this program's own construction narrative). Must
+    still resolve self-referential via the file-diff check.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    # A root commit unrelated to the oracle -- `git diff-tree` on a true
+    # root commit (no parent) reports an empty diff regardless of content,
+    # so the oracle-files commit below must NOT be the repo's very first.
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-q", "-m", "chore: seed repo", cwd=repo)
+
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "audit_disposition.py").write_text(
+        "# oracle\n",
+        encoding="utf-8",
+    )
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_audit_disposition.py").write_text(
+        "# oracle tests\n",
+        encoding="utf-8",
+    )
+    _git("add", "-A", cwd=repo)
+    _git(
+        "commit",
+        "-q",
+        "-m",
+        "feat: audit disposition census oracle (M4 exit gate) (#213)\n\n"
+        "Mentions W2-1 as an illustrative example of the convention.\n",
+        cwd=repo,
+    )
+    sha = _git_head_sha(repo)
+    commit = ad.CommitRecord(sha=sha, message=_git_show_message(repo, sha))
+    assert not ad.is_dev_tooling_commit(commit.message)  # the scope did NOT survive
+    assert ad.is_self_referential_commit(repo, commit)
+
+
+def test_is_self_referential_commit_false_when_diff_touches_other_files_too(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """A commit that ALSO does real finding work (touches a file outside
+    ``_ORACLE_OWN_FILES``) must NOT be excluded, even if it mentions an
+    item and also happens to touch the oracle's own script.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    # A root commit first -- see the squash-merge test's comment: `git
+    # diff-tree` on a true root commit reports an empty diff regardless of
+    # content, which would make this test pass for the wrong reason.
+    (repo / "README.md").write_text("seed\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-q", "-m", "chore: seed repo", cwd=repo)
+
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "audit_disposition.py").write_text(
+        "# oracle\n",
+        encoding="utf-8",
+    )
+    (repo / "restgdf").mkdir()
+    (repo / "restgdf" / "real.py").write_text("x = 1\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-q", "-m", "feat: also touch real code (W9-9)\n", cwd=repo)
+    sha = _git_head_sha(repo)
+    commit = ad.CommitRecord(sha=sha, message=_git_show_message(repo, sha))
+    assert not ad.is_self_referential_commit(repo, commit)
+
+
+def test_is_self_referential_commit_false_when_no_item_mentioned(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """Short-circuits before ever calling ``git diff-tree`` when the message
+    mentions no item at all -- documented in the docstring as an
+    optimization, pinned here as a behavior contract: even a commit whose
+    diff IS confined to the oracle's own files is reported as NOT self-
+    referential if it names no work item (harmless either way, since such a
+    commit could never produce false evidence regardless).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "audit_disposition.py").write_text(
+        "# oracle\n",
+        encoding="utf-8",
+    )
+    _git("add", "-A", cwd=repo)
+    _git(
+        "commit",
+        "-q",
+        "-m",
+        "chore: tidy up the oracle script, no item cited\n",
+        cwd=repo,
+    )
+    sha = _git_head_sha(repo)
+    commit = ad.CommitRecord(sha=sha, message=_git_show_message(repo, sha))
+    assert not ad.is_self_referential_commit(repo, commit)
+
+
+def test_build_report_excludes_squash_merge_shaped_self_reference(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """End-to-end reproduction of the actual bug found on merged ``main``:
+    PR #213's squash-merge commit body mentions an item ID as an
+    illustrative example next to deferral language, with a subject that no
+    longer carries the "(dev-tooling)" scope. A SEPARATE, real commit lands
+    that item cleanly. Before the file-diff-based fix, this resolved
+    DEFERRED; after, it must resolve LANDED.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+
+    plan_dir = repo / "audit-recommendations" / "plan"
+    plan_dir.mkdir(parents=True)
+    findings = [
+        {
+            "id": "PAGINATION-03",
+            "axis": "PAGINATION",
+            "title": "unbounded nested IN-lists",
+            "severity": "low",
+            "files": ["restgdf/utils/getgdf.py"],
+        },
+    ]
+    (repo / "audit-recommendations" / "findings.json").write_text(
+        json.dumps(findings),
+        encoding="utf-8",
+    )
+    (plan_dir / "99-traceability.md").write_text(
+        "## Forward map\n\n| `PAGINATION-03` | low | t | `W4-3` | — |\n",
+        encoding="utf-8",
+    )
+    (repo / "restgdf" / "utils").mkdir(parents=True)
+    (repo / "restgdf" / "utils" / "getgdf.py").write_text("x = 1\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-q", "-m", "chore: seed repo", cwd=repo)
+
+    # The real landing.
+    (repo / "restgdf" / "utils" / "getgdf.py").write_text("x = 2\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-q", "-m", "fix: bound split OID lists (W4-3)", cwd=repo)
+
+    # A LATER squash-merge-shaped commit, confined to the oracle's own
+    # files, quotes "W4-3" next to deferral language while its subject
+    # carries a PR title rather than the "(dev-tooling)" scope.
+    (repo / "scripts").mkdir()
+    (repo / "scripts" / "audit_disposition.py").write_text(
+        "# oracle\n",
+        encoding="utf-8",
+    )
+    (repo / "tests").mkdir()
+    (repo / "tests" / "test_audit_disposition.py").write_text(
+        "# oracle tests\n",
+        encoding="utf-8",
+    )
+    _git("add", "-A", cwd=repo)
+    _git(
+        "commit",
+        "-q",
+        "-m",
+        "feat: audit disposition census oracle (M4 exit gate) (#213)\n\n"
+        "Regression example: a ledger-shaped row cross-contaminated "
+        "co-mentioned items with an owner+trigger/ NO-GO signal meant for "
+        "one item only; W4-3 citations undercounted landed items too.\n",
+        cwd=repo,
+    )
+
+    report = ad.build_report(repo)
+    by_id = {row["id"]: row for row in report["findings"]}
+    assert by_id["PAGINATION-03"]["disposition"] == "LANDED"
+
+
+# ---------------------------------------------------------------------------
+# parse_decision_closed_clarifications — traceability-doc-only evidence
+# ---------------------------------------------------------------------------
+
+
+def test_parse_decision_closed_clarifications_finds_confirm_only_bullet(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    plan_dir = tmp_path / "audit-recommendations" / "plan"
+    plan_dir.mkdir(parents=True)
+    traceability = (
+        "## Deliberate deferrals\n\n"
+        "One item is a recorded clarification:\n\n"
+        "- **`W3-6` was not dropped** — it resolved as *confirm-only* (Path a) "
+        "in M2/PR #203: the timeout/concurrency env vars were verified wired.\n"
+    )
+    (plan_dir / "99-traceability.md").write_text(traceability, encoding="utf-8")
+    decision_closed = ad.parse_decision_closed_clarifications(tmp_path)
+    assert "W3-6" in decision_closed
+    assert decision_closed["W3-6"].kind == "traceability"
+
+
+def test_parse_decision_closed_clarifications_does_not_leak_to_a_co_mentioned_item(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """Regression for the real W3-6 bullet's exact shape: it cross-
+    references a DIFFERENT, genuinely-landed item (W6-7) in the SAME bullet
+    (in a later, semicolon-separated clause) purely as a citation of where
+    the docs fix landed. Only W3-6 -- whose OWN clause carries "confirm-
+    only" -- may resolve DECISION-CLOSED here; W6-7 must not, or it would
+    silently override its real LANDED evidence for every OTHER finding it
+    also owns.
+    """
+    plan_dir = tmp_path / "audit-recommendations" / "plan"
+    plan_dir.mkdir(parents=True)
+    traceability = (
+        "## Deliberate deferrals\n\n"
+        "- **`W3-6` was not dropped** — it resolved as *confirm-only* (Path a) "
+        "in M2/PR #203: the timeout/concurrency env vars were verified wired "
+        "and the three `RESTGDF_AUTH_*` vars verified absent from the "
+        "resolver; the documentation rows were corrected under W6-7 (M4).\n"
+    )
+    (plan_dir / "99-traceability.md").write_text(traceability, encoding="utf-8")
+    decision_closed = ad.parse_decision_closed_clarifications(tmp_path)
+    assert "W3-6" in decision_closed
+    assert "W6-7" not in decision_closed
+
+
+def test_parse_decision_closed_clarifications_ignores_deferred_bullet(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """A DEFERRED (NO-GO) bullet -- e.g. the real ERRTAX-03/W2-5 record --
+    carries no "confirm-only"/"decision-closed" wording and must not be
+    picked up here; that item's DEFERRED disposition comes from
+    ``build_prose_signals`` reading the real commit history instead.
+    """
+    plan_dir = tmp_path / "audit-recommendations" / "plan"
+    plan_dir.mkdir(parents=True)
+    traceability = (
+        "## Deliberate deferrals\n\n"
+        "- **`ERRTAX-03` / `W2-5` — DEFERRED (NO-GO), M3.** Closed as NO-GO "
+        "per plan/02's own recommendation. Owner: a future pass. Trigger: "
+        "maintainer GO.\n"
+    )
+    (plan_dir / "99-traceability.md").write_text(traceability, encoding="utf-8")
+    decision_closed = ad.parse_decision_closed_clarifications(tmp_path)
+    assert "W2-5" not in decision_closed
+
+
+def test_parse_decision_closed_clarifications_ignores_milestone_label_bullet(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """A milestone-label correction (e.g. the real W4-6/W5-9/W5-10/W5-11
+    note) carries no confirm-only/decision-closed marker and must not be
+    treated as decision-closed evidence for any of the items it names.
+    """
+    plan_dir = tmp_path / "audit-recommendations" / "plan"
+    plan_dir.mkdir(parents=True)
+    traceability = (
+        "## Deliberate deferrals\n\n"
+        "- **`W4-6`/`W5-9`/`W5-10`/`W5-11`** carry an M2 milestone label but "
+        "landed in the M1 typing-transition stack (PR #196) per the runbook.\n"
+    )
+    (plan_dir / "99-traceability.md").write_text(traceability, encoding="utf-8")
+    decision_closed = ad.parse_decision_closed_clarifications(tmp_path)
+    assert decision_closed == {}
+
+
+def test_parse_decision_closed_clarifications_stops_at_next_heading(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    plan_dir = tmp_path / "audit-recommendations" / "plan"
+    plan_dir.mkdir(parents=True)
+    traceability = (
+        "## Deliberate deferrals\n\n"
+        "- **`W1-1`** resolved as *confirm-only*.\n\n"
+        "## Some other section\n\n"
+        "- **`W1-2`** resolved as *confirm-only* (should not be parsed).\n"
+    )
+    (plan_dir / "99-traceability.md").write_text(traceability, encoding="utf-8")
+    decision_closed = ad.parse_decision_closed_clarifications(tmp_path)
+    assert "W1-1" in decision_closed
+    assert "W1-2" not in decision_closed
+
+
+def test_build_report_resolves_zero_commit_item_via_traceability_clarification(
+    ad: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """End-to-end: an item with ZERO commits anywhere (resolved by
+    verifying existing behavior, never by shipping a change -- the real
+    W3-6/DOCS-02 shape) still reaches a terminal DECISION-CLOSED via the
+    traceability doc's clarification alone, with no commit evidence at all.
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "test@example.com", cwd=repo)
+    _git("config", "user.name", "Test", cwd=repo)
+
+    plan_dir = repo / "audit-recommendations" / "plan"
+    plan_dir.mkdir(parents=True)
+    findings = [
+        {
+            "id": "CONFIRM-01",
+            "axis": "FAKE",
+            "title": "confirm-only finding",
+            "severity": "medium",
+            "files": ["restgdf/nowhere.py"],
+        },
+    ]
+    (repo / "audit-recommendations" / "findings.json").write_text(
+        json.dumps(findings),
+        encoding="utf-8",
+    )
+    (plan_dir / "99-traceability.md").write_text(
+        "## Forward map\n\n| `CONFIRM-01` | medium | t | `W9-2` | — |\n\n"
+        "## Deliberate deferrals\n\n"
+        "- **`W9-2` was not dropped** — it resolved as *confirm-only* (Path a): "
+        "existing behavior was verified correct, no change shipped.\n",
+        encoding="utf-8",
+    )
+    (repo / "restgdf").mkdir()
+    (repo / "restgdf" / "nowhere.py").write_text("x = 1\n", encoding="utf-8")
+    _git("add", "-A", cwd=repo)
+    _git("commit", "-q", "-m", "chore: seed repo (no W9-2 commit anywhere)", cwd=repo)
+
+    report = ad.build_report(repo)
+    by_id = {row["id"]: row for row in report["findings"]}
+    assert by_id["CONFIRM-01"]["disposition"] == "DECISION-CLOSED"
+    assert by_id["CONFIRM-01"]["item_statuses"]["W9-2"]["status"] == "DECISION_CLOSED"
+    assert by_id["CONFIRM-01"]["item_statuses"]["W9-2"]["evidence"][0]["kind"] == (
+        "traceability"
+    )
+
+
+# ---------------------------------------------------------------------------
 # item_status_for_finding / disposition_for_finding — rollup logic
 # ---------------------------------------------------------------------------
 
@@ -644,6 +1016,28 @@ def _git(*args: str, cwd: Path) -> None:
         capture_output=True,
         text=True,
     )
+
+
+def _git_head_sha(cwd: Path) -> str:
+    return subprocess.run(  # nosec B603 B607 - test-only throwaway repo
+        ["git", "rev-parse", "HEAD"],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    ).stdout.strip()
+
+
+def _git_show_message(cwd: Path, sha: str) -> str:
+    return subprocess.run(  # nosec B603 B607 - test-only throwaway repo
+        ["git", "show", "--format=%B", "-s", sha],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+    ).stdout
 
 
 def test_end_to_end_against_a_throwaway_git_repo(


### PR DESCRIPTION
## Summary
Closes the census oracle's last three evidence blind spots, all with verified data (no fudged counts):
1. `findings.json` files lists amended with the **verified** landing files for AUTH-03 (W3-1 → `_config.py`, `_settings.py` via #203) and CONFIG-04 (W3-5 → the two `.rst` files via #206) — each checked against the commit's real diff; rationale in the commit body (JSON has no comments).
2. The traceability ledger's recorded decision-closes are now an evidence source: DOCS-02's W3-6 (confirm-only, zero commits by design) resolves **DECISION-CLOSED**, with clause-scoping so cross-referenced items don't leak.
3. Surprise catch: GitHub's squash rewrote #213's subject, defeating the `(dev-tooling)` exclusion and re-triggering the self-contamination bug — the exclusion is now diff-confinement-based (any commit confined to the oracle's own files), squash-proof.

**Definitive census (this tree, exit 0): 61 findings — 59 LANDED · 1 DECISION-CLOSED · 1 DEFERRED (ERRTAX-03, owner+trigger recorded) · 0 GAP · 0 ORPHAN.** This is the M4 exit evidence.

Tests 48 (+11) · suite 1361/4/4 · coverage 98% · pre-commit fixed point. Squash-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk