### PR TITLE
docs: 3.2.0 release prep — CHANGELOG consolidation + ledger M4 closeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [3.2.0] - 2026-07-24
 ### Added
 
 - **`FeatureLayer.from_config` / `Directory.from_config`** — opt-in

--- a/audit-recommendations/plan/PROGRAM-LEDGER.md
+++ b/audit-recommendations/plan/PROGRAM-LEDGER.md
@@ -16,8 +16,8 @@
 | M1 Validation/security | **COMPLETE** 2026-07-24 (items: PRs #193 #194 #195 #196 #197 #198 #199 #200 — see log; 3.1.0 release evidence added on publish) | M1 exit gate plus 3.1.0 release evidence |
 | M2 High correctness | **COMPLETE** 2026-07-24 (PRs #203–#207 + this PR; all five high findings closed with regression evidence — verifier-run census: AUTH-01 ×3, PAGINATION-01 ×7, PAGINATION-02 ×4, CONFIG-01/AUTH-03 ×8 test nodes green; CICD-01 = the structural release gate. verify_ssl proven end-to-end via real-connector introspection) | all five high findings closed with regression evidence |
 | M3 Medium correctness | **COMPLETE** 2026-07-24 (3 batched PRs; W2-2/3/11, W3-2/3/4, W2-13 warn-now, W4-3/4, W1-9, W5-2/3/6/13/14; decision-closes with recorded owner+trigger: W2-5 NO-GO per plan recommendation, W5-13 dedup-key kept context-free per anti-spam decision; wave verifier CONFIRMED, deferral ratified by coordinator) | M3 item/decision gates green |
-| M4 Docs/polish | not started | 61/61 findings closed or explicitly dispositioned |
-| R32 Release 3.2.0 | not started | clean tag-to-PyPI-to-install verification |
+| M4 Docs/polish | **COMPLETE** 2026-07-24 (PRs #212 docs reconciliation [V-M4 CONFIRMED, 21 claims sampled clean] + #213/#214 census oracle; definitive census on main: **61 findings = 59 LANDED / 1 DECISION-CLOSED [DOCS-02 via W3-6 confirm-only] / 1 DEFERRED [ERRTAX-03, owner+trigger] / 0 GAP / 0 ORPHAN**, `scripts/audit_disposition.py` exit 0) | 61/61 findings closed or explicitly dispositioned |
+| R32 Release 3.2.0 | dispatched 2026-07-24 after this PR merges (evidence: tag 3.2.0, PyPI 3.2.0 wheel+sdist, attestation-verify run green, clean-env install — verified post-publish, recorded in session close-out) | clean tag-to-PyPI-to-install verification |
 
 ## Log
 


### PR DESCRIPTION
Release prep for 3.2.0 (M4 exit): consolidates `[Unreleased]` into `## [3.2.0] - 2026-07-24` (the bump and publish gates key on the release section) and records M4 completion with the definitive census evidence (61 = 59 LANDED / 1 DECISION-CLOSED / 1 DEFERRED / 0 GAP / 0 ORPHAN). After merge: fresh-env gate already running in parallel → bumpver dispatch (minor) → release-env approval → PyPI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk