### PR TITLE
docs: program finalization — ledger, CLAUDE.md, audit banner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,7 @@
 ## What this is
 
 `restgdf` is a **lightweight async Esri/ArcGIS REST client** for Python ≥ 3.11, published to
-PyPI as a Production/Stable library (currently v3.1.0; a 3.2.0 release carrying the
-`## [Unreleased]` CHANGELOG entries is pending). The light core depends only on
+PyPI as a Production/Stable library (currently v3.2.0). The light core depends only on
 `aiohttp` + `pydantic` v2; GeoPandas/pandas, retry/rate-limiting, and OpenTelemetry are
 **optional extras** (`geo`, `resilience`, `telemetry`). The two public entry points are
 `FeatureLayer` (one ArcGIS feature layer) and `Directory` (service discovery / crawl).
@@ -24,11 +23,11 @@ namespace plus `restgdf.{adapters,compat,utils,errors}`.
   bullet under `## [Unreleased]`.
 - **`README.md`** — user-facing usage; **`SECURITY.md`** — vuln reporting + supply-chain.
 
-> Companion docs predate the 3.0 release in places and carry **known drift** (e.g.
-> CONTRIBUTING's `integration/3.0-rewrite` branch target and ARCHITECTURE.md's
-> `ErrorPayload`/`.env`/logger-name claims). **When code and companion prose disagree, the
-> code is the source of truth.** The `audit-recommendations/` directory catalogs the specific
-> drift; the remediation program is closing it item by item.
+> Companion docs were reconciled to the code by the 2026 audit-remediation program
+> (complete 2026-07-24; see `audit-recommendations/plan/PROGRAM-LEDGER.md`). If code and
+> companion prose ever disagree again, **the code is the source of truth** — fix the prose
+> in the same change set. `audit-recommendations/` is the audit's historical record and
+> disposition ledger; `scripts/audit_disposition.py` re-derives finding status on demand.
 
 ## Commands
 

--- a/audit-recommendations/README.md
+++ b/audit-recommendations/README.md
@@ -1,5 +1,11 @@
 # restgdf — comprehensive code audit
 
+> **REMEDIATION COMPLETE (2026-07-24).** All 61 findings are terminally dispositioned —
+> 59 landed, 1 decision-closed, 1 deferred with owner+trigger, 0 gaps (re-derive any time
+> with `python scripts/audit_disposition.py`). Delivered across releases **3.1.0** and
+> **3.2.0**; the authoritative phase record is [`plan/PROGRAM-LEDGER.md`](plan/PROGRAM-LEDGER.md).
+> Finding line numbers below remain pinned to the audit commit and are historical.
+>
 > **Read-only audit.** No source file was modified to produce this report set. Pinned to
 > commit `4673b08` (`main`, v3.0.0). Generated 2026-06-13.
 

--- a/audit-recommendations/plan/07-execution-runbook.md
+++ b/audit-recommendations/plan/07-execution-runbook.md
@@ -1,5 +1,9 @@
 # 07 — Remediation execution runbook
 
+> **EXECUTED TO COMPLETION 2026-07-23/24** — every phase below exited with recorded
+> evidence; see [`PROGRAM-LEDGER.md`](PROGRAM-LEDGER.md) for the authoritative per-phase
+> record. This document is retained as the program's operating history.
+>
 > **Operational source of truth for executing the audit remediation.** Snapshot reconciled
 > 2026-07-22 against local Git, GitHub PRs/checks, the 61-finding audit, all six workstream
 > specifications, `CONTRIBUTING.md`, `pyproject.toml`, pre-commit, and every workflow. The

--- a/audit-recommendations/plan/PROGRAM-LEDGER.md
+++ b/audit-recommendations/plan/PROGRAM-LEDGER.md
@@ -17,7 +17,7 @@
 | M2 High correctness | **COMPLETE** 2026-07-24 (PRs #203–#207 + this PR; all five high findings closed with regression evidence — verifier-run census: AUTH-01 ×3, PAGINATION-01 ×7, PAGINATION-02 ×4, CONFIG-01/AUTH-03 ×8 test nodes green; CICD-01 = the structural release gate. verify_ssl proven end-to-end via real-connector introspection) | all five high findings closed with regression evidence |
 | M3 Medium correctness | **COMPLETE** 2026-07-24 (3 batched PRs; W2-2/3/11, W3-2/3/4, W2-13 warn-now, W4-3/4, W1-9, W5-2/3/6/13/14; decision-closes with recorded owner+trigger: W2-5 NO-GO per plan recommendation, W5-13 dedup-key kept context-free per anti-spam decision; wave verifier CONFIRMED, deferral ratified by coordinator) | M3 item/decision gates green |
 | M4 Docs/polish | **COMPLETE** 2026-07-24 (PRs #212 docs reconciliation [V-M4 CONFIRMED, 21 claims sampled clean] + #213/#214 census oracle; definitive census on main: **61 findings = 59 LANDED / 1 DECISION-CLOSED [DOCS-02 via W3-6 confirm-only] / 1 DEFERRED [ERRTAX-03, owner+trigger] / 0 GAP / 0 ORPHAN**, `scripts/audit_disposition.py` exit 0) | 61/61 findings closed or explicitly dispositioned |
-| R32 Release 3.2.0 | dispatched 2026-07-24 after this PR merges (evidence: tag 3.2.0, PyPI 3.2.0 wheel+sdist, attestation-verify run green, clean-env install — verified post-publish, recorded in session close-out) | clean tag-to-PyPI-to-install verification |
+| R32 Release 3.2.0 | **COMPLETE** 2026-07-24: tag `3.2.0` (bump `93625fe`), PyPI wheel+sdist confirmed via the JSON API, PEP 740 attestation-verify run 30102287027 SUCCESS (green on rerun after the known ~1-3 min index-propagation race), GitHub release published, clean-env `pip install restgdf==3.2.0` imports 3.2.0 | clean tag-to-PyPI-to-install verification |
 
 ## Log
 
@@ -73,3 +73,10 @@
   59 LANDED / 1 DECISION-CLOSED [DOCS-02 via W3-6 confirm-only] / 1 DEFERRED [ERRTAX-03] / 0 GAP
   / 0 ORPHAN**, exit 0. Full offline suite green (1348 passed / 4 skipped / 4 deselected),
   targeted `test_audit_disposition.py` green (35 tests), pre-commit clean at a fixed point.
+- 2026-07-24 — **PROGRAM COMPLETE.** All phases exited: P0A–P0D, V0, M1–M4, releases 3.1.0
+  and 3.2.0 both live and verified. Definitive census on final `main`: 61 findings =
+  59 LANDED / 1 DECISION-CLOSED / 1 DEFERRED (ERRTAX-03, owner+trigger) / 0 GAP / 0 ORPHAN.
+  Remaining watch items (maintainer): #192 Snyk check detail (auth-walled; pip-audit clean);
+  one unreproduced 45-min hosted `pytest (py3.13)` hang (add a `faulthandler_timeout` probe
+  if it recurs); the warn-now inert retry/limiter knobs (TRANSPORT-01/W2-13) await their
+  separately-scoped wiring design; ERRTAX-03 re-opens on its recorded trigger.


### PR DESCRIPTION
Final truth-up after the verified 3.2.0 publish: R32 ledger row → COMPLETE with the actual evidence chain; program-complete log entry with the maintainer watch items; CLAUDE.md states v3.2.0 and drops the now-false known-drift claims; audit README gains the remediation-complete banner; runbook marked executed. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6pQkHXCBTQJBB5RasDMk