### PR TITLE
feat: resilience correctness + config wiring (3.3.0)

### DIFF
--- a/.github/workflows/publish_on_pypi.yml
+++ b/.github/workflows/publish_on_pypi.yml
@@ -168,6 +168,47 @@ jobs:
             exit 1
           fi
 
+      - name: Require CHANGELOG footer link for release
+        if: steps.release_meta.outputs.raw != ''
+        env:
+          RELEASE_VERSION: ${{ steps.release_meta.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Q1-a/Q1-b (critic.md): the "## [X.Y.Z]" section header alone is
+          # not enough -- the reference-style link definition
+          # "[X.Y.Z]: https://.../compare/...&|releases/tag/..." at the
+          # CHANGELOG footer is what actually makes the header resolve to a
+          # real GitHub URL. bumpver does not touch CHANGELOG.md
+          # (pyproject.toml file_patterns omits it), so this link is a
+          # manual step the maintainer can forget -- exactly what happened
+          # for 3.2.0 (missing "[3.2.0]:" definition, verified). Fail fast
+          # here rather than shipping a release whose CHANGELOG entry is a
+          # dangling reference. Git tags in this repo are unprefixed (e.g.
+          # "3.2.0", not "v3.2.0"), so only the unprefixed form is accepted.
+          #
+          # Matched literally and anchored to the START of a line: the link
+          # prefix contains "[" / "]" regex metacharacters (so no regex), and
+          # a reference-style link definition is only a definition in column
+          # 1 -- an unanchored substring match would be satisfied by a prose
+          # line that merely mentions "[X.Y.Z]:". awk's index($0, p) == 1
+          # gives both properties with no escaping.
+          link_prefix="[${RELEASE_VERSION}]:"
+
+          count="$(awk -v p="$link_prefix" 'index($0, p) == 1 { n++ } END { print n + 0 }' CHANGELOG.md)"
+          if [ "$count" -eq 0 ]; then
+            echo "::error file=CHANGELOG.md::Missing footer link definition '${link_prefix}' in CHANGELOG.md."
+            echo "Add a '${link_prefix} https://github.com/${GITHUB_REPOSITORY}/compare/<prev>...${RELEASE_VERSION}' line before publishing ${RELEASE_VERSION}."
+            exit 1
+          fi
+
+          if [ "$count" -gt 1 ]; then
+            echo "::error file=CHANGELOG.md::Duplicate footer link definition '${link_prefix}' appears ${count} times in CHANGELOG.md."
+            echo "Consolidate the duplicate '${link_prefix}' lines before publishing ${RELEASE_VERSION}."
+            exit 1
+          fi
+
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,16 +104,19 @@ restgdf                       # root logger (NullHandler; get_logger(""))
 ├── restgdf.auth              # token lifecycle, refresh attempts
 ├── restgdf.pagination        # streaming + split-on-truncation decisions
 ├── restgdf.normalization     # attribute / row normalization
-└── restgdf.schema_drift      # permissive-tier schema-drift warnings
+├── restgdf.schema_drift      # permissive-tier schema-drift warnings
+└── restgdf.crawl             # directory-crawl containment warnings (3.3)
 ```
 
-These eight suffixes are the *only* names `get_logger()` accepts (see
+These nine suffixes are the *only* names `get_logger()` accepts (see
 `LOGGER_SUFFIXES` in `restgdf/_logging.py`); any other suffix raises
 `ValueError`, so there are no `restgdf.featurelayer` / `restgdf.streaming`
 / `restgdf.directory` / `restgdf.telemetry` loggers. Subsystem → logger:
 HTTP transport → `restgdf.transport` (retries → `restgdf.retry`),
 streaming/pagination → `restgdf.pagination`, schema drift →
-`restgdf.schema_drift`, normalization → `restgdf.normalization`.
+`restgdf.schema_drift`, normalization → `restgdf.normalization`,
+per-layer crawl failures contained inside `service_metadata` →
+`restgdf.crawl` (WARNING).
 
 Loggers never emit at `DEBUG` with secrets; tokens and password-bearing
 request bodies are redacted at the transport layer.
@@ -204,10 +207,16 @@ restgdf[dev]               # + pytest, pre-commit, sphinx, twine, build
 Extras are additive and composable:
 
 ```bash
-pip install "restgdf[resilience,telemetry]"      # production resiliency
+pip install "restgdf[resilience,telemetry]"      # retry/rate-limit + tracing building blocks
 pip install "restgdf[geo]"                        # notebooks / analytics
 pip install -e ".[dev,resilience,telemetry,geo]" # full contributor install
 ```
+
+Installing `[resilience]` only makes `restgdf.resilience.ResilientSession`
+importable — it does not itself wire retry/rate-limiting into any request.
+A caller must construct `ResilientSession(inner, ResilienceConfig(enabled=
+True, ...))` and pass it as `session=` to `FeatureLayer`/`Directory`; see
+the `docs/recipes/bulk_crawl.md` recipe for a full worked example.
 
 Importing a module that depends on an un-installed extra raises
 `OptionalDependencyError` with a message that names the missing extra.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ All notable changes to restgdf are documented here. This project follows
   `InertConfigWarning` (whose text now names the live replacements instead of
   claiming the executor hardcodes its policy). The deprecated fields and env
   keys are removed in 4.0.
+- **`ResilienceConfig.backend` is deprecated.** It has always been dead config
+  — `"stamina"` is the only implementation and the executor never reads the
+  field. Setting `RESTGDF_RESILIENCE_BACKEND` now emits a `DeprecationWarning`
+  (previously it was silently accepted, the one inert resilience knob that
+  escaped `InertConfigWarning`). The field stays reachable and defaults to
+  `"stamina"` for back-compat; it is removed in 4.0 (R5).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+
+## [3.3.0] - 2026-07-24
 ### Added
 
 - **Rate-limit / cooldown granularity is now selectable.**
@@ -1055,7 +1057,8 @@ Earlier releases were not formally tracked here. See the
 [PyPI release notes](https://pypi.org/project/restgdf/#history) for pre-2.0
 changes.
 
-[Unreleased]: https://github.com/joshuasundance-swca/restgdf/compare/3.2.0...HEAD
+[Unreleased]: https://github.com/joshuasundance-swca/restgdf/compare/3.3.0...HEAD
+[3.3.0]: https://github.com/joshuasundance-swca/restgdf/compare/3.2.0...3.3.0
 [3.2.0]: https://github.com/joshuasundance-swca/restgdf/compare/3.1.0...3.2.0
 [3.1.0]: https://github.com/joshuasundance-swca/restgdf/compare/3.0.0...3.1.0
 [3.0.0]: https://github.com/joshuasundance-swca/restgdf/compare/2.0.0...3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Added
+
+- **The resilient retry path now emits DEBUG observability logs.** The
+  `restgdf.retry` logger (previously created but never used) now records a
+  DEBUG line for each scheduled retry (attempt number, backoff wait, and the
+  failure that triggered it), each 429 cooldown set (service-root key and
+  seconds), and each exhaustion mapping (the `restgdf.errors` type the final
+  underlying failure is mapped to). Set `logging.getLogger("restgdf.retry")`
+  to `DEBUG` to trace throttling and retries during a bulk crawl — making the
+  `docs/recipes/tracing.md` promise true (H1-N4).
+
 ### Fixed
 
 - **Sub-1.0 rate limits no longer crash.** A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,19 @@ All notable changes to restgdf are documented here. This project follows
   (`restgdf.resilience._limiter.LimiterRegistry.get`), so the limiter paces at
   the requested rate. Rates `>= 1` keep their existing burst semantics exactly
   (H1-M1).
+- **Mid-flight transport errors are now retried and mapped.** The resilient
+  retry path (`restgdf.resilience._retry`) previously retried and typed only
+  connect-time (`ClientConnectorError` → `TransportError`) and read-timeout
+  (`ServerTimeoutError` → `RestgdfTimeoutError`) failures. Server disconnects,
+  connection resets (`ServerDisconnectedError`, `ClientOSError`/ECONNRESET,
+  `ClientConnectionResetError`), and truncated response bodies
+  (`ClientPayloadError`) — the most common transient failures when crawling
+  thousands of flaky ArcGIS hosts — leaked out raw and unretried on the first
+  occurrence. They are now retried to exhaustion and surfaced as
+  `restgdf.errors.TransportError` (connection-shaped and payload/truncated-body
+  alike), so a caller catching `TransportError` no longer silently misses half
+  the transport failures. Deterministic 4xx responses still never retry
+  (H1-M2).
 
 ## [3.2.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ All notable changes to restgdf are documented here. This project follows
   alike), so a caller catching `TransportError` no longer silently misses half
   the transport failures. Deterministic 4xx responses still never retry
   (H1-M2).
+- **429 cooldowns are no longer erased by a racing waiter.**
+  `CooldownRegistry.wait_if_cooling` (`restgdf.resilience._limiter`) popped the
+  stored deadline unconditionally after sleeping, so if a fresh 429 installed a
+  *longer* cooldown while an older waiter was still asleep, the waking waiter
+  erased the newer deadline — occasionally not honouring a cooldown at high
+  crawl concurrency. It now re-reads the deadline after sleeping and honours a
+  concurrently-set fresher one instead of clearing it (H1-N2).
 
 ## [3.2.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,21 @@ All notable changes to restgdf are documented here. This project follows
   failure is visible rather than silently dropped. A service-*root* metadata
   failure is unchanged — `safe_crawl` still records it as a whole-service
   `CrawlError` (H2-1).
+  **Monitoring note (behaviour change):** a contained per-layer failure is
+  *not* a `CrawlError`, so it no longer appears in `CrawlReport.errors` at all
+  — a service whose every layer failed now looks healthy if you only count
+  `len(report.errors)`. Count `layer_error` markers in the returned layer lists
+  instead. Each contained failure also emits one `WARNING` on the new
+  `restgdf.crawl` logger (`"layer metadata failed, contained: url=… error=…"`,
+  with `service_root` / `layer_id` / `exception_type` in the structured extra),
+  so a crawl has an aggregate failure signal without inspecting the data.
+  Containment is scoped to transport and response failures
+  (`RestgdfResponseError`, `TransportError`, `RestgdfTimeoutError`,
+  `aiohttp.ClientConnectionError`, `aiohttp.ClientPayloadError`, `TimeoutError`)
+  — deliberately *not* the `RestgdfError` / `aiohttp.ClientError` roots, so
+  `ConfigurationError`, `OptionalDependencyError` and `aiohttp.InvalidURL`
+  keep failing loudly on the first service instead of degrading into thousands
+  of identical markers.
 
 ## [3.2.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,9 @@ All notable changes to restgdf are documented here. This project follows
   so one attempt's cooldown stays bounded by `respect_retry_after_max_s`
   however many requests are in flight on the key — stamina evaluates the retry
   budget only *between* attempts, so an unbounded in-attempt sleep would be
-  uninterruptible.
+  uninterruptible. Trade-off: the waking waiter itself proceeds, so one
+  request per waker may dispatch while a concurrently-set fresher cooldown is
+  still in force; the next attempt on the key waits it out.
 - **A single failing layer no longer discards a whole service's metadata.**
   `service_metadata` (`restgdf.utils.getinfo`) fanned its per-layer
   `get_metadata` calls out through `bounded_gather` with the default
@@ -142,7 +144,9 @@ All notable changes to restgdf are documented here. This project follows
   instead. Each contained failure also emits one `WARNING` on the new
   `restgdf.crawl` logger (`"layer metadata failed, contained: url=… error=…"`,
   with `service_root` / `layer_id` / `exception_type` in the structured extra),
-  so a crawl has an aggregate failure signal without inspecting the data.
+  so a crawl has an aggregate failure signal without inspecting the data. URLs
+  in both the message and the extras are scrubbed of `token=` query values
+  before logging.
   Containment is scoped to transport and response failures
   (`RestgdfResponseError`, `TransportError`, `RestgdfTimeoutError`,
   `aiohttp.ClientConnectionError`, `aiohttp.ClientPayloadError`, `TimeoutError`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to restgdf are documented here. This project follows
 ## [Unreleased]
 ### Added
 
+- **Rate-limit / cooldown granularity is now selectable.**
+  `ResilienceConfig.limiter_key` (env `RESTGDF_RESILIENCE_LIMITER_KEY`) chooses
+  whether the token bucket and 429 cooldown key on the ArcGIS *service root*
+  (`"service_root"`, the default — behaviour-preserving) or the *host*
+  (`"host"`). Host granularity applies one polite rate across every service
+  behind a single government host — the correct politeness key when many
+  independent services share one box. The 429 cooldown always follows the same
+  selected key, so a host-level throttle produces a host-wide cooldown (R1 /
+  politeness decision D1). Combined with the sub-1.0 rate fix above, a polite
+  `limiter_key="host"` + `rate_per_service_root_per_second=0.5` bulk crawl now
+  works.
+- **Retry attempts, budget and backoff are now tunable on `ResilienceConfig`.**
+  The stamina executor reads `max_attempts`, `retry_budget_s`, `wait_initial_s`,
+  `wait_max_s` and `wait_jitter_s` (env `RESTGDF_RESILIENCE_MAX_ATTEMPTS`,
+  `RESTGDF_RESILIENCE_RETRY_BUDGET_S`, `RESTGDF_RESILIENCE_WAIT_INITIAL_S`,
+  `RESTGDF_RESILIENCE_WAIT_MAX_S`, `RESTGDF_RESILIENCE_WAIT_JITTER_S`) from the
+  config it already receives, instead of hardcoded literals. Defaults
+  (`5` / `60.0` / `0.5` / `10.0` / `1.0`) preserve the historical retry policy
+  byte-for-byte, and `ResilienceConfig.enabled` remains the *sole* gate — the
+  new knobs only tune an already-enabled session, they never turn retries off
+  (R2). These live knobs supersede the inert `RetryConfig` fields (now
+  deprecated).
 - **The resilient retry path now emits DEBUG observability logs.** The
   `restgdf.retry` logger (previously created but never used) now records a
   DEBUG line for each scheduled retry (attempt number, backoff wait, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to restgdf are documented here. This project follows
 [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+### Fixed
+
+- **Sub-1.0 rate limits no longer crash.** A
+  `ResilienceConfig.rate_per_service_root_per_second` below `1.0` (e.g. `0.5`
+  req/s — the natural setting for a polite bulk crawl) previously raised a raw,
+  unmapped `ValueError` ("Can't acquire more than the maximum capacity") on the
+  very first request, because the limiter built `AsyncLimiter(rate, 1)` and
+  `acquire(1)` refuses any amount above a fractional `max_rate`. Sub-1 rates are
+  now spelled as one token per `1 / rate` seconds
+  (`restgdf.resilience._limiter.LimiterRegistry.get`), so the limiter paces at
+  the requested rate. Rates `>= 1` keep their existing burst semantics exactly
+  (H1-M1).
 
 ## [3.2.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,20 @@ All notable changes to restgdf are documented here. This project follows
   erased the newer deadline — occasionally not honouring a cooldown at high
   crawl concurrency. It now re-reads the deadline after sleeping and honours a
   concurrently-set fresher one instead of clearing it (H1-N2).
+- **A single failing layer no longer discards a whole service's metadata.**
+  `service_metadata` (`restgdf.utils.getinfo`) fanned its per-layer
+  `get_metadata` calls out through `bounded_gather` with the default
+  `return_exceptions=False`, so one layer that raised — a secured / deleted /
+  admin-disabled layer returning an ArcGIS `{"error": ...}` envelope
+  (`RestgdfError`), a dropped connection (`aiohttp.ClientError`), or a timeout
+  (`TimeoutError`) — cancelled its siblings and discarded the entire service's
+  layer inventory behind a single generic error (the exact failure mode at
+  public multi-server crawl scale). Such a layer is now contained: its siblings
+  are returned as before, and the failed layer stays present in the layer list
+  annotated with a `layer_error` marker (`"<ExcType>: <message>"`) so the
+  failure is visible rather than silently dropped. A service-*root* metadata
+  failure is unchanged — `safe_crawl` still records it as a whole-service
+  `CrawlError` (H2-1).
 
 ## [3.2.0] - 2026-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,9 @@ All notable changes to restgdf are documented here. This project follows
 - **The resilient retry path now emits DEBUG observability logs.** The
   `restgdf.retry` logger (previously created but never used) now records a
   DEBUG line for each scheduled retry (attempt number, backoff wait, and the
-  failure that triggered it), each 429 cooldown set (service-root key and
-  seconds), and each exhaustion mapping (the `restgdf.errors` type the final
+  failure that triggered it), each 429 cooldown set (limiter key — the service
+  root, or the host under `limiter_key="host"` — and seconds), and each
+  exhaustion mapping (the `restgdf.errors` type the final
   underlying failure is mapped to). Set `logging.getLogger("restgdf.retry")`
   to `DEBUG` to trace throttling and retries during a bulk crawl — making the
   `docs/recipes/tracing.md` promise true (H1-N4).
@@ -153,11 +154,16 @@ All notable changes to restgdf are documented here. This project follows
   (`restgdf.utils._http.default_headers`, W2-10 / CONFIG-01 / AUTH-03).
   **Wire-visible behavior change:** some Esri deployments sniff the
   `User-Agent`, so a WAF or usage policy keyed on `"Mozilla/5.0"` may now
-  see `restgdf/<version>`. Override it explicitly per request
-  (`headers={"User-Agent": ...}`, still wins) or globally via
-  `RESTGDF_TRANSPORT_USER_AGENT` / `TransportConfig.user_agent`. The
-  exported `DEFAULT_METADATA_HEADERS` constant keeps its historical value
-  for back-compat but no longer determines the wire `User-Agent`.
+  see `restgdf/<version>`. Override it globally via
+  `RESTGDF_TRANSPORT_USER_AGENT` / `TransportConfig.user_agent` — the
+  sole lever on the metadata/`Directory`/crawl path, which has no
+  `headers=` seam — or per request (`headers={"User-Agent": ...}`, still
+  wins) on the feature/query surfaces (`get_feature_count`,
+  `get_object_ids`, streaming/`get_gdf`/stats) that accept one (3.3
+  correction: this bullet originally implied the per-request override
+  applies everywhere). The exported `DEFAULT_METADATA_HEADERS` constant
+  keeps its historical value for back-compat but no longer determines the
+  wire `User-Agent`.
 - **Setting a currently-inert `RESTGDF_*` knob now warns.** `Config.from_env`
   (hence `get_config()`) emits one `restgdf._config.InertConfigWarning`
   (a `UserWarning`) naming any set-but-unwired `RESTGDF_RETRY_*` /
@@ -1000,7 +1006,8 @@ Earlier releases were not formally tracked here. See the
 [PyPI release notes](https://pypi.org/project/restgdf/#history) for pre-2.0
 changes.
 
-[Unreleased]: https://github.com/joshuasundance-swca/restgdf/compare/v3.1.0...HEAD
-[3.1.0]: https://github.com/joshuasundance-swca/restgdf/compare/v3.0.0...v3.1.0
-[3.0.0]: https://github.com/joshuasundance-swca/restgdf/compare/v2.0.0...v3.0.0
-[2.0.0]: https://github.com/joshuasundance-swca/restgdf/releases/tag/v2.0.0
+[Unreleased]: https://github.com/joshuasundance-swca/restgdf/compare/3.2.0...HEAD
+[3.2.0]: https://github.com/joshuasundance-swca/restgdf/compare/3.1.0...3.2.0
+[3.1.0]: https://github.com/joshuasundance-swca/restgdf/compare/3.0.0...3.1.0
+[3.0.0]: https://github.com/joshuasundance-swca/restgdf/compare/2.0.0...3.0.0
+[2.0.0]: https://github.com/joshuasundance-swca/restgdf/releases/tag/2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ All notable changes to restgdf are documented here. This project follows
   to `DEBUG` to trace throttling and retries during a bulk crawl — making the
   `docs/recipes/tracing.md` promise true (H1-N4).
 
+### Deprecated
+
+- **`RetryConfig.max_attempts` / `RetryConfig.max_delay_s` and
+  `LimiterConfig.rate_per_host` are deprecated.** They validate but have never
+  been read by the resilience executor, and are now superseded by the live
+  `ResilienceConfig` knobs added above: `max_attempts` →
+  `ResilienceConfig.max_attempts`, `max_delay_s` →
+  `ResilienceConfig.retry_budget_s`, and `rate_per_host` →
+  `ResilienceConfig.rate_per_service_root_per_second` with
+  `ResilienceConfig.limiter_key="host"`. Their `RESTGDF_RETRY_*` /
+  `RESTGDF_LIMITER_*` env keys stay wired as a back-compat seam and still emit
+  `InertConfigWarning` (whose text now names the live replacements instead of
+  claiming the executor hardcodes its policy). The deprecated fields and env
+  keys are removed in 4.0.
+
 ### Fixed
 
 - **Sub-1.0 rate limits no longer crash.** A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,25 @@ All notable changes to restgdf are documented here. This project follows
   exhaustion mapping (the `restgdf.errors` type the final
   underlying failure is mapped to). Set `logging.getLogger("restgdf.retry")`
   to `DEBUG` to trace throttling and retries during a bulk crawl — making the
-  `docs/recipes/tracing.md` promise true (H1-N4).
+  `docs/recipes/tracing.md` promise true (H1-N4). The logged `wait=` is the
+  *scheduled* pre-jitter backoff; the actual sleep adds up to `wait_jitter_s`
+  on top. These records carry a new structured-`extra` key, `limit_key`
+  (added to `restgdf._logging.LOG_EXTRA_KEYS`), holding the rate-limit /
+  cooldown key — deliberately not `service_root`, which would mislabel the
+  value under `limiter_key="host"`.
+
+### Changed
+
+- **Resilient retries now run through `stamina.retry_context` instead of the
+  `@stamina.retry` decorator.** The retry policy, backoff schedule and kwargs
+  are identical (a fresh iterator per call, exactly as the decorator builds);
+  the context form is what makes each attempt's number and scheduled backoff
+  available to the new DEBUG logging. One consumer-visible seam: subscribers to
+  `stamina.instrumentation` now see `RetryDetails.name` reported as
+  `"<context block>"` (stamina hardcodes it for `retry_context`) instead of the
+  decorator-derived function name, so any metric keyed on that label — e.g.
+  stamina's Prometheus integration, which labels its retry counter with it —
+  changes label value on upgrade.
 
 ### Deprecated
 
@@ -71,19 +89,25 @@ All notable changes to restgdf are documented here. This project follows
   (`restgdf.resilience._limiter.LimiterRegistry.get`), so the limiter paces at
   the requested rate. Rates `>= 1` keep their existing burst semantics exactly
   (H1-M1).
-- **Mid-flight transport errors are now retried and mapped.** The resilient
+- **Dispatch-time transport errors are now retried and mapped.** The resilient
   retry path (`restgdf.resilience._retry`) previously retried and typed only
   connect-time (`ClientConnectorError` → `TransportError`) and read-timeout
-  (`ServerTimeoutError` → `RestgdfTimeoutError`) failures. Server disconnects,
-  connection resets (`ServerDisconnectedError`, `ClientOSError`/ECONNRESET,
-  `ClientConnectionResetError`), and truncated response bodies
-  (`ClientPayloadError`) — the most common transient failures when crawling
-  thousands of flaky ArcGIS hosts — leaked out raw and unretried on the first
-  occurrence. They are now retried to exhaustion and surfaced as
-  `restgdf.errors.TransportError` (connection-shaped and payload/truncated-body
-  alike), so a caller catching `TransportError` no longer silently misses half
-  the transport failures. Deterministic 4xx responses still never retry
-  (H1-M2).
+  (`ServerTimeoutError` → `RestgdfTimeoutError`) failures. Server disconnects
+  and connection resets (`ServerDisconnectedError`, `ClientOSError`/ECONNRESET,
+  `ClientConnectionResetError`) raised while the request is dispatched — common
+  transient failures when crawling thousands of flaky ArcGIS hosts — leaked out
+  raw and unretried on the first occurrence. They are now retried to exhaustion
+  and surfaced as `restgdf.errors.TransportError`, so a caller catching
+  `TransportError` no longer misses them. Deterministic 4xx responses still
+  never retry (H1-M2).
+  **Known limitation (scope):** the retry wrapper covers the request only up to
+  *headers received*; callers read the response body afterwards. A failure
+  raised while the **body** is read — the truncated/incomplete-body
+  `aiohttp.ClientPayloadError`, or a mid-body disconnect — is therefore still
+  neither retried nor mapped, and surfaces raw from `response.json(...)`.
+  Callers who need to survive truncated bodies should catch
+  `aiohttp.ClientPayloadError` alongside `restgdf.errors.TransportError`.
+  Extending retry across body consumption is a design item for a later release.
 - **429 cooldowns are no longer erased by a racing waiter.**
   `CooldownRegistry.wait_if_cooling` (`restgdf.resilience._limiter`) popped the
   stored deadline unconditionally after sleeping, so if a fresh 429 installed a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,8 +113,14 @@ All notable changes to restgdf are documented here. This project follows
   stored deadline unconditionally after sleeping, so if a fresh 429 installed a
   *longer* cooldown while an older waiter was still asleep, the waking waiter
   erased the newer deadline — occasionally not honouring a cooldown at high
-  crawl concurrency. It now re-reads the deadline after sleeping and honours a
-  concurrently-set fresher one instead of clearing it (H1-N2).
+  crawl concurrency. It now re-reads the deadline after sleeping and leaves a
+  concurrently-set fresher one in place for the next attempt/request to honour
+  instead of clearing it (H1-N2). A single `wait_if_cooling` call sleeps at
+  most until the deadline it observed on entry and never chains a second wait,
+  so one attempt's cooldown stays bounded by `respect_retry_after_max_s`
+  however many requests are in flight on the key — stamina evaluates the retry
+  budget only *between* attempts, so an unbounded in-attempt sleep would be
+  uninterruptible.
 - **A single failing layer no longer discards a whole service's metadata.**
   `service_metadata` (`restgdf.utils.getinfo`) fanned its per-layer
   `get_metadata` calls out through `bounded_gather` with the default

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -331,18 +331,33 @@ required to materialize the frame.
 **Resilience extra** (`pip install restgdf[resilience]`)
 
 - `restgdf.resilience.ResilientSession` wraps any `AsyncHTTPSession`
-  with stamina-based retry (429/5xx awareness, configurable
-  max-attempts) and per-service-root token-bucket rate limiting.
+  with stamina-based retry (429/5xx awareness) and token-bucket rate
+  limiting.
 - Controlled by `restgdf.ResilienceConfig` (a peer sub-config on
   `Config.resilience`). Disabled by default; opt in via
   `RESTGDF_RESILIENCE_ENABLED=1` or `ResilienceConfig(enabled=True)`.
   When disabled, `ResilientSession` is a zero-overhead pass-through.
+  `enabled` is the sole gate.
+- Retry attempts and backoff are tunable on `ResilienceConfig`
+  (**3.3+**): `max_attempts` (default `5`), `retry_budget_s` (total
+  wall-clock budget, default `60.0`), and the backoff shape
+  `wait_initial_s` / `wait_max_s` / `wait_jitter_s` (`0.5` / `10.0` /
+  `1.0`). Defaults preserve the pre-3.3 hardcoded policy exactly. These
+  supersede the inert, now-**deprecated** `RetryConfig.max_attempts` /
+  `RetryConfig.max_delay_s` (removed in 4.0).
 - `LimiterRegistry` (backed by `aiolimiter.AsyncLimiter`) and
-  `CooldownRegistry` provide per-service-root rate limiting and
-  separate 429 back-off. The `_service_root()` helper truncates the
-  URL at `FeatureServer` / `MapServer` / `ImageServer` / `SceneServer`
-  to derive the rate-limit key. Cooldown is separate from the token
-  bucket — 429 back-off does NOT drain tokens.
+  `CooldownRegistry` provide the rate limiting and separate 429
+  back-off. `ResilienceConfig.rate_per_service_root_per_second` sets the
+  rate (sub-1.0 rates such as `0.5` are valid from 3.3); the
+  granularity is chosen by `ResilienceConfig.limiter_key` (**3.3+**):
+  `"service_root"` (default) keys per ArcGIS service root via the
+  `_service_root()` helper (truncated at `FeatureServer` / `MapServer`
+  / `ImageServer` / `SceneServer`), while `"host"` keys per
+  `scheme://host` so one polite rate covers every service behind a
+  host. The 429 cooldown follows the same selected key. `"host"`
+  supersedes the inert, now-**deprecated** `LimiterConfig.rate_per_host`
+  (removed in 4.0). Cooldown is separate from the token bucket — 429
+  back-off does NOT drain tokens.
 
 **Telemetry extra** (`pip install restgdf[telemetry]`)
 
@@ -413,8 +428,13 @@ happen in a future major release.
 - `TransportConfig` — user-agent, default headers, verify-SSL.
 - `TimeoutConfig` — `total_s` (default `30.0`); replaces the flat
   `Settings.timeout_seconds`.
-- `RetryConfig` — stamina knobs surfaced via the resilience extra.
-- `LimiterConfig` — aiolimiter token-bucket knobs.
+- `RetryConfig` — **deprecated (3.3)**, inert. `max_attempts` /
+  `max_delay_s` were never read by the executor; the live retry knobs
+  are `ResilienceConfig.max_attempts` / `ResilienceConfig.retry_budget_s`.
+  Removed in 4.0.
+- `LimiterConfig` — **deprecated (3.3)**, inert. `rate_per_host` was
+  never read; use `ResilienceConfig.rate_per_service_root_per_second`
+  with `ResilienceConfig.limiter_key="host"`. Removed in 4.0.
 - `ConcurrencyConfig` — `max_concurrent_requests` (default **8**,
   matches aiohttp `TCPConnector` default). Enforced at the three
   internal `asyncio.gather` sites (orchestrator call paths), not at
@@ -425,9 +445,14 @@ happen in a future major release.
 - `TelemetryConfig` — `enabled` (default `False`), log level, span
   attributes.
 - `ResilienceConfig` — opt-in wrapper for the stamina-based retry
-  policy and per-service-root token-bucket rate limiter. Disabled by
-  default (`enabled=False`); toggle via `RESTGDF_RESILIENCE_ENABLED=1`
-  or an explicit `ResilienceConfig(enabled=True, ...)`.
+  policy and token-bucket rate limiter, and (from 3.3) the single home
+  for the executor's live retry/limiter knobs: `max_attempts`,
+  `retry_budget_s`, `wait_initial_s`, `wait_max_s`, `wait_jitter_s`,
+  `rate_per_service_root_per_second`, and `limiter_key`
+  (`"service_root"` | `"host"`). Disabled by default (`enabled=False`,
+  the sole gate); toggle via `RESTGDF_RESILIENCE_ENABLED=1` or an
+  explicit `ResilienceConfig(enabled=True, ...)`. All knobs also resolve
+  from `RESTGDF_RESILIENCE_*` env vars.
 
 Use `restgdf.get_config()` to resolve the process-wide cached instance
 and `restgdf.reset_config_cache()` to clear it (tests, long-running

--- a/README.md
+++ b/README.md
@@ -132,10 +132,15 @@ per-service-root rate limiting, install the optional resilience extra:
 pip install restgdf[resilience]
 ```
 
-This adds `stamina` and `aiolimiter`. Wrap any `AsyncHTTPSession` with
-`restgdf.resilience.ResilientSession` and configure via
-`restgdf.resilience.ResilienceConfig` or `RESTGDF_RESILIENCE_ENABLED=1`.
-See [`MIGRATION.md`](MIGRATION.md) for details.
+This adds `stamina` and `aiolimiter`. Installing it applies nothing on its
+own: wrap any `AsyncHTTPSession` with `restgdf.resilience.ResilientSession`,
+configured via a `restgdf.ResilienceConfig` with `enabled=True`
+(`RESTGDF_RESILIENCE_ENABLED=1` sets that flag on the process-global config,
+but only a session you explicitly wrap with `ResilientSession` reads it —
+setting the env var alone does not add resilience to a `FeatureLayer` or
+`Directory` call). See [`MIGRATION.md`](MIGRATION.md) and the
+[polite bulk crawl recipe](https://restgdf.readthedocs.io/en/latest/recipes/bulk_crawl.html)
+for details.
 
 </details>
 
@@ -182,6 +187,22 @@ pip install "restgdf[geo]"
 - `FeatureLayer.fieldtypes`
 - pandas-backed helpers like `get_value_counts()` and `get_nested_count()`
 - low-level `restgdf.utils.getgdf` helpers
+
+Install the resilience extra for automatic retry with exponential back-off
+and configurable (per-service-root or per-host) rate limiting — useful for
+bulk/multi-server crawls:
+
+```bash
+pip install "restgdf[resilience]"
+```
+
+`restgdf[resilience]` adds `stamina` and `aiolimiter`. It changes no request
+behavior by itself — wrap your own `aiohttp.ClientSession` with
+`restgdf.resilience.ResilientSession` (configured via
+`restgdf.ResilienceConfig`) and pass the wrapped session as
+`session=` to `FeatureLayer`/`Directory`. See the
+[polite bulk crawl recipe](https://restgdf.readthedocs.io/en/latest/recipes/bulk_crawl.html)
+for a full worked example.
 
 Treat the split above as the stable dependency boundary: geo-enabled
 environments should depend on `restgdf[geo]` explicitly. See
@@ -465,3 +486,7 @@ contents.
 
 - [restgdf_api](https://github.com/joshuasundance-swca/restgdf_api)
 - [govgis_nov2023](https://huggingface.co/datasets/joshuasundance/govgis_nov2023)
+  — a bulk, multi-host crawl; see the
+  [polite bulk crawl recipe](https://restgdf.readthedocs.io/en/latest/recipes/bulk_crawl.html)
+  for the resilience + concurrency + User-Agent composition this kind of
+  workload needs.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -59,22 +59,76 @@ are supported with a ``DeprecationWarning``.
      - Description
    * - ``RESTGDF_TIMEOUT_TOTAL_S``
      - ``30``
-     - Total HTTP timeout in seconds
+     - Total HTTP timeout in seconds, applied per request on the metadata/crawl and query paths
    * - ``RESTGDF_TRANSPORT_USER_AGENT``
      - ``"restgdf/<version>"``
-     - User-Agent header value
+     - User-Agent header value. This is the sanctioned lever for bulk/crawl
+       traffic (see :doc:`recipes/bulk_crawl`) — a per-request
+       ``headers={"User-Agent": ...}`` override still wins, but only on the
+       feature/query surfaces, not on the metadata/``Directory``/crawl path,
+       and a session-level ``ClientSession(headers=...)`` User-Agent does not
+       survive there either.
    * - ``RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS``
      - ``8``
-     - Global concurrency cap for parallel page fetches
+     - Concurrency cap for parallel page/layer fetches **within one**
+       top-level call (``safe_crawl``/``Directory.crawl``/streaming) — not a
+       process-wide budget. Concurrent top-level calls each get their own
+       cap; bound your own outer concurrency across calls (see
+       :doc:`recipes/bulk_crawl`).
    * - ``RESTGDF_RESILIENCE_ENABLED``
      - ``false``
-     - Enable retry + rate limiting (requires ``restgdf[resilience]``)
+     - Sole gate for retry + rate limiting on a ``ResilientSession``
+       (requires ``restgdf[resilience]``); setting it alone does not apply
+       resilience unless a session is explicitly wrapped with
+       ``ResilientSession`` and passed to ``FeatureLayer``/``Directory``.
+   * - ``RESTGDF_RESILIENCE_LIMITER_KEY``
+     - ``"service_root"``
+     - Rate-limit/cooldown key granularity: ``"service_root"`` (default,
+       one bucket per ArcGIS service) or ``"host"`` (one bucket per
+       ``scheme://host`` — the polite choice when many services share a
+       host)
    * - ``RESTGDF_RESILIENCE_RATE_PER_SERVICE_ROOT_PER_SECOND``
-     - ``10.0``
-     - Token-bucket refill rate per service root
+     - unset (limiter disabled)
+     - Token-bucket refill rate, enforced at ``RESTGDF_RESILIENCE_LIMITER_KEY``
+       granularity; sub-1.0 rates (e.g. ``0.5``) are valid
    * - ``RESTGDF_RESILIENCE_RESPECT_RETRY_AFTER_MAX_S``
      - ``60``
      - Max seconds to honor from a server ``Retry-After`` header
+   * - ``RESTGDF_RESILIENCE_FALLBACK_RETRY_AFTER_SECONDS``
+     - ``5``
+     - Cooldown used for a 429 with no ``Retry-After`` header
+   * - ``RESTGDF_RESILIENCE_MAX_ATTEMPTS``
+     - ``5``
+     - Retry attempts before exhaustion
+   * - ``RESTGDF_RESILIENCE_RETRY_BUDGET_S``
+     - ``60``
+     - Total wall-clock retry budget (in-attempt cooldown sleeps count
+       against it — see :doc:`recipes/bulk_crawl`)
+   * - ``RESTGDF_RESILIENCE_WAIT_INITIAL_S``
+     - ``0.5``
+     - Initial exponential-backoff wait
+   * - ``RESTGDF_RESILIENCE_WAIT_MAX_S``
+     - ``10``
+     - Max exponential-backoff wait
+   * - ``RESTGDF_RESILIENCE_WAIT_JITTER_S``
+     - ``1``
+     - Max random jitter added to each backoff wait
+   * - ``RESTGDF_RESILIENCE_BACKEND``
+     - ``"stamina"``
+     - **Deprecated (3.3), removed in 4.0.** Dead config — ``"stamina"`` is
+       the only implementation; setting this now emits a
+       ``DeprecationWarning``.
+   * - ``RESTGDF_RETRY_MAX_ATTEMPTS`` / ``RESTGDF_RETRY_MAX_DELAY_S``
+     - n/a
+     - **Inert + deprecated (3.3), removed in 4.0.** Superseded by
+       ``RESTGDF_RESILIENCE_MAX_ATTEMPTS`` / ``RESTGDF_RESILIENCE_RETRY_BUDGET_S``;
+       setting either emits ``InertConfigWarning``.
+   * - ``RESTGDF_LIMITER_RATE_PER_HOST``
+     - n/a
+     - **Inert + deprecated (3.3), removed in 4.0.** Superseded by
+       ``RESTGDF_RESILIENCE_RATE_PER_SERVICE_ROOT_PER_SECOND`` with
+       ``RESTGDF_RESILIENCE_LIMITER_KEY=host``; setting it emits
+       ``InertConfigWarning``.
    * - ``RESTGDF_TELEMETRY_ENABLED``
      - ``false``
      - Enable OpenTelemetry spans (requires ``restgdf[telemetry]``)
@@ -86,6 +140,9 @@ The token-session knobs ``AuthConfig.transport``, ``refresh_leeway_s``, and
 ``clock_skew_s`` are **not** driven by dedicated ``RESTGDF_AUTH_*`` environment
 variables. Set them on an explicit ``Config`` instead — for example
 ``Config(auth=AuthConfig(transport="body", refresh_leeway_s=180, clock_skew_s=45))``.
+
+For a full worked example composing the resilience + concurrency + User-Agent
+knobs above for a bulk, multi-host crawl, see :doc:`recipes/bulk_crawl`.
 
 Config model reference
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -185,6 +185,7 @@ Explore the docs
    recipes/observability
    recipes/streaming
    recipes/tracing
+   recipes/bulk_crawl
 
 .. toctree::
    :hidden:

--- a/docs/recipes/bulk_crawl.md
+++ b/docs/recipes/bulk_crawl.md
@@ -1,0 +1,343 @@
+# Polite Bulk / Multi-Host Crawl
+
+This recipe is for the "crawl many independent ArcGIS servers" scenario —
+discovering services across hundreds or thousands of government/enterprise
+hosts, where each host is a small box that must not be hammered, while a
+handful of large multi-tenant SaaS hosts need a very different rate.
+
+It composes four things that exist in `restgdf` today but have no single
+worked example anywhere else in the docs: a wrapped, rate-limited session;
+the crawl entry point; a descriptive User-Agent; and your own outer
+concurrency bound.
+
+## Prerequisites
+
+```bash
+pip install "restgdf[resilience]"
+```
+
+`restgdf[resilience]` adds `stamina` (retry) and `aiolimiter` (token-bucket
+rate limiting). Installing it does **not** change any crawl behavior on its
+own — `Directory`/`FeatureLayer` always take a caller-owned session and never
+construct or wrap one for you (`restgdf/directory/directory.py`,
+`restgdf/resilience/_retry.py`). You opt in explicitly, in two steps.
+
+## Step 1 — wrap your session
+
+```python
+from contextlib import asynccontextmanager
+
+from aiohttp import ClientSession
+from restgdf import ResilienceConfig
+from restgdf.resilience import ResilientSession
+
+resilience_cfg = ResilienceConfig(
+    enabled=True,
+    rate_per_service_root_per_second=0.5,  # sub-1.0 rates are valid (3.3)
+    limiter_key="host",                    # one polite rate PER HOST
+)
+
+@asynccontextmanager
+async def make_session():
+    async with ClientSession() as raw:      # closes the inner session on exit
+        yield ResilientSession(raw, resilience_cfg)
+```
+
+`ResilienceConfig.enabled` is the sole gate — the retry/rate-limit knobs
+below only tune an *already-enabled* session; none of them can silently turn
+resilience on or off on their own. `ResilientSession` is transparent: it
+implements the same `get`/`post` shape as a plain `aiohttp.ClientSession`, so
+it drops straight into `session=` on `Directory`/`FeatureLayer`.
+
+### Two configuration mechanisms — know which one you are using
+
+The knob table below has one "live" column, but the knobs reach the request
+path by two different routes, and mixing them up is the single easiest way to
+configure nothing at all:
+
+- **Resilience knobs are per-session and passed explicitly.** A
+  `ResilienceConfig` you construct is read only by the `ResilientSession` you
+  hand it to. Constructing one does **not** consult
+  `RESTGDF_RESILIENCE_*`. To honour the environment, build the session from
+  the process-global config instead:
+
+  ```python
+  from restgdf import get_config
+  from restgdf.resilience import ResilientSession
+
+  session = ResilientSession(raw, get_config().resilience)  # honours RESTGDF_RESILIENCE_*
+  ```
+
+  (`get_config()` is cached; call `restgdf.reset_config_cache()` after
+  changing an env var in-process.)
+- **Transport / concurrency / timeout knobs are process-global env vars.**
+  `RESTGDF_TRANSPORT_USER_AGENT`, `RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS`
+  and `RESTGDF_TIMEOUT_TOTAL_S` are read from `get_config()` at request time.
+  A `Config(...)` instance you build yourself is **not** threaded into the
+  request path (CONFIG-03) — passing one somewhere and expecting it to
+  override the process global silently does nothing.
+
+### Why `limiter_key="host"` for a bulk crawl
+
+The default `limiter_key="service_root"` keys the token bucket (and the 429
+cooldown) per ArcGIS *service*, not per host. A single government host
+commonly exposes dozens of services under one directory — `limiter_key=
+"service_root"` at `rate=0.5` still lets that host receive many times 0.5
+req/s in aggregate, because each service gets its own independent bucket.
+`limiter_key="host"` (added in 3.3) applies one shared rate across every
+service on `scheme://host` — the actual politeness unit for "don't hammer
+this box." The 429 cooldown always follows the same key you select, so a
+host-level throttle produces a host-wide cooldown, not a per-service one.
+
+**Exception — multi-tenant SaaS hosts.** A small number of hosts (Esri's own
+`services*.arcgis.com` shards, for example) front many independent tenants
+on shared infrastructure, not one government office's box. Host-keying those
+at a polite single-host rate would starve a shard serving thousands of
+unrelated services for no politeness benefit. Give SaaS-shaped hosts their
+own `ResilientSession` (built from a separate `ResilienceConfig`, since
+`limiter_key`/rate are per-session, not global) at `limiter_key="service_root"`
+or a deliberately higher host rate, and record that choice — a `Resilience
+Config` is cheap to build per shard.
+
+**Sub-1.0 rates now work.** Before 3.3, `rate_per_service_root_per_second`
+below `1.0` raised a raw `ValueError` on the first request — exactly the
+range a polite per-host rate needs (`0.5`, `0.2`, ...). That is fixed; rates
+below 1.0 now pace correctly instead of crashing.
+
+## Step 2 — pass the wrapped session to `Directory`
+
+```python
+from restgdf import Directory
+
+async def crawl_one_host(url: str, session) -> list:
+    directory = await Directory.from_url(url, session=session)
+    return await directory.crawl()  # uses Directory.safe_crawl internally
+```
+
+Because the session is wrapped once and reused for every request `Directory`
+issues, resilience applies uniformly to the whole crawl — service discovery,
+per-folder metadata, and per-layer metadata all go through the same rate
+limiter, cooldown, and retry policy. Prefer `Directory.crawl()` over the
+legacy `fetch_all_data()` — it delegates to the module function
+`restgdf.utils.crawl.safe_crawl` (not a `Directory` method), which contains a
+failing service or folder as a `CrawlError` and keeps crawling the rest.
+
+A single failing *layer* inside an otherwise-healthy service is also
+contained (3.3): the service's surviving layers are returned, and the failed
+layer stays in the list carrying a `layer_error` marker naming the exception,
+instead of the whole service's inventory being discarded.
+
+**Count your `layer_error`s.** A contained layer failure is deliberately
+*not* a `CrawlError`, so it never reaches `CrawlReport.errors` — a service
+whose every layer failed looks healthy if you only check
+`len(report.errors)`. Each one does emit a `WARNING` on the `restgdf.crawl`
+logger, and the markers are countable in the returned data:
+
+```python
+broken = [
+    layer
+    for entry in report.services
+    for layer in (entry.metadata.layers if entry.metadata else [])
+    if getattr(layer, "layer_error", None)
+]
+```
+
+### What retry does and does not cover
+
+The resilient retry path wraps each request up to *headers received*. A
+connection failure at dispatch (server disconnect, reset, DNS, connect
+timeout) is retried and surfaces as `restgdf.errors.TransportError`. A
+failure raised while the response **body** is read — the truncated-body
+`aiohttp.ClientPayloadError`, or a mid-body disconnect — is outside that
+scope: it is not retried and reaches you as the raw aiohttp exception. On
+flaky estates, catch `aiohttp.ClientPayloadError` alongside
+`restgdf.errors.TransportError` (a crawl that treats either as "retry this
+host later" needs both).
+
+## Step 3 — set a descriptive, contactable User-Agent
+
+```bash
+export RESTGDF_TRANSPORT_USER_AGENT="mycrawler/1.0 (contact: you@example.org)"
+```
+
+or, to set it from inside the process:
+
+```python
+import os
+from restgdf import reset_config_cache
+
+os.environ["RESTGDF_TRANSPORT_USER_AGENT"] = "mycrawler/1.0 (contact: you@example.org)"
+reset_config_cache()  # get_config() is cached; re-read the environment
+```
+
+```{warning}
+Building `Config(transport=TransportConfig(user_agent=...))` does **not**
+set the crawl User-Agent. The wire header is read from the *process-global*
+`get_config()` at request time, and a directly constructed `Config` is never
+threaded into the request path (CONFIG-03) — it is test-only. Use the
+environment variable, as above.
+```
+
+A descriptive User-Agent identifying the crawl and a contact point is bulk-
+crawl etiquette, and it is the **only** effective lever on the metadata/crawl
+path:
+
+- The env var is live — every metadata/crawl request reads
+  `get_config().transport.user_agent` on every call, so `reset_config_cache()`
+  (if you change the variable mid-process) takes effect immediately.
+- A **session-level** `aiohttp.ClientSession(headers={"User-Agent": ...})`
+  does **not** survive on this path — `get_metadata` (the primitive behind
+  `Directory`/`safe_crawl`) always supplies its own per-request `User-Agent`
+  header, and aiohttp's per-request headers win over the session default.
+- **Per-request `headers={"User-Agent": ...}` override still wins — but only
+  on the feature/query surfaces** (`get_feature_count`, `get_object_ids`,
+  the streaming/`get_gdf`/stats helpers), which accept a `headers=`/`**kwargs`
+  passthrough. `get_metadata` — the sole primitive behind `Directory.crawl`,
+  `Directory.safe_crawl`, and `Directory.prep` — takes no `headers` argument
+  at all, so per-request override is not available on the crawl path. The
+  config/env lever above is the only way to set the UA for crawl traffic.
+
+## Step 4 — bound your own outer concurrency
+
+`ConcurrencyConfig.max_concurrent_requests` (default `8`, env
+`RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS`) caps in-flight requests
+**per `safe_crawl`/`Directory.crawl` call**, not process-wide. If you crawl
+`N` hosts by launching `N` concurrent `Directory.crawl()` calls, you get up
+to `8 × N` in-flight requests, not a shared budget of 8. Bound your own
+outer concurrency explicitly — for example, one `Directory.crawl()` in
+flight per host at a time, gated by your own `asyncio.Semaphore`:
+
+```python
+import asyncio
+
+host_sem = asyncio.Semaphore(50)  # your own outer bound, tuned to your fleet
+
+async def crawl_bounded(url: str, session):
+    async with host_sem:
+        return await crawl_one_host(url, session)
+```
+
+`RESTGDF_TIMEOUT_TOTAL_S` (default `30` seconds) applies a per-request
+timeout to every metadata call, so one black-holing host cannot hang the
+crawl indefinitely — but one `Directory.crawl()` call still walks its
+*folders* serially (one `get_metadata` per folder, in a plain loop), so a
+directory with many slow folders/services accumulates those timeouts inside
+that single call. That is another reason to bound your own outer concurrency
+across hosts rather than relying on the per-call cap alone.
+
+**Cap `max_attempts` on flaky estates.** Layer-failure containment (3.3)
+means every layer of a dead service is now dispatched instead of the first
+failure cancelling its siblings — measured at 3.1× the per-layer requests
+against a 50-layer dead service. That composes with the broadened retried
+set: at the default `max_attempts=5`, one dead service goes from ~80 attempts
+to ~250. The token bucket and 429 cooldown still pace the *rate*, so this is
+volume and wall-clock, not a politeness violation — but on an estate with
+many dead or half-dead hosts, lower `ResilienceConfig.max_attempts` (2–3) or
+`retry_budget_s` so a dead service is written off quickly.
+
+If you are aggregating `Directory.report` (`CrawlReport`) across many hosts,
+note that `CrawlError.exception` retains the live exception object (and its
+traceback) for re-raise support — drop reports (or clear
+`report.errors[*].exception`) between shards on a very large, long-running
+aggregate crawl to avoid holding onto tracebacks longer than you need to.
+
+## Live vs. inert vs. deprecated knobs (3.3)
+
+"Live" means the knob is read at runtime — but by which route depends on the
+knob: the `ResilienceConfig.*` rows are read from the config object you hand
+to a `ResilientSession` (their `RESTGDF_RESILIENCE_*` env forms apply only if
+you build the session from `get_config().resilience`), while the bare
+`RESTGDF_*` rows at the bottom are process-global and read from `get_config()`
+at request time. See [Two configuration mechanisms](#two-configuration-mechanisms-know-which-one-you-are-using).
+
+| Knob | Status | Notes |
+|---|---|---|
+| `ResilienceConfig.enabled` / `RESTGDF_RESILIENCE_ENABLED` | live | sole retry/limiter gate |
+| `ResilienceConfig.rate_per_service_root_per_second` / `RESTGDF_RESILIENCE_RATE_PER_SERVICE_ROOT_PER_SECOND` | live | sub-1.0 valid (3.3) |
+| `ResilienceConfig.limiter_key` / `RESTGDF_RESILIENCE_LIMITER_KEY` | live (new 3.3) | `"service_root"` (default) or `"host"` |
+| `ResilienceConfig.respect_retry_after_max_s` / `RESTGDF_RESILIENCE_RESPECT_RETRY_AFTER_MAX_S` | live | caps an honoured `Retry-After` |
+| `ResilienceConfig.fallback_retry_after_seconds` / `RESTGDF_RESILIENCE_FALLBACK_RETRY_AFTER_SECONDS` | live | used when a 429 has no `Retry-After` |
+| `ResilienceConfig.max_attempts` / `RESTGDF_RESILIENCE_MAX_ATTEMPTS` | live (new 3.3) | default `5` |
+| `ResilienceConfig.retry_budget_s` / `RESTGDF_RESILIENCE_RETRY_BUDGET_S` | live (new 3.3) | total wall-clock budget, default `60.0` |
+| `ResilienceConfig.wait_initial_s` / `RESTGDF_RESILIENCE_WAIT_INITIAL_S` | live (new 3.3) | default `0.5` |
+| `ResilienceConfig.wait_max_s` / `RESTGDF_RESILIENCE_WAIT_MAX_S` | live (new 3.3) | default `10.0` |
+| `ResilienceConfig.wait_jitter_s` / `RESTGDF_RESILIENCE_WAIT_JITTER_S` | live (new 3.3) | default `1.0` |
+| `ResilienceConfig.backend` / `RESTGDF_RESILIENCE_BACKEND` | **deprecated** (3.3) | `"stamina"` is the only backend; setting the env var now warns |
+| `RetryConfig.max_attempts` / `RESTGDF_RETRY_MAX_ATTEMPTS` | inert + deprecated | superseded by `ResilienceConfig.max_attempts`; still warns |
+| `RetryConfig.max_delay_s` / `RESTGDF_RETRY_MAX_DELAY_S` | inert + deprecated | superseded by `ResilienceConfig.retry_budget_s`; still warns |
+| `LimiterConfig.rate_per_host` / `RESTGDF_LIMITER_RATE_PER_HOST` | inert + deprecated | superseded by `rate_per_service_root_per_second` + `limiter_key="host"`; still warns |
+| `RESTGDF_TRANSPORT_USER_AGENT` | live | the sanctioned crawl-path UA lever (Step 3) |
+| `RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS` | live | per-call, not process-wide (Step 4) |
+| `RESTGDF_TIMEOUT_TOTAL_S` | live | per-request timeout (Step 4) |
+
+Setting an inert or deprecated `RESTGDF_*` knob emits a one-time
+`InertConfigWarning`/`DeprecationWarning` naming its live replacement — see
+{doc}`/configuration`.
+
+### Budget vs. cooldown, briefly
+
+`retry_budget_s` is a *total* wall-clock budget for one request's retry
+loop, and an honoured 429 `Retry-After` cooldown sleeps *inside* that budget
+— it is not extra time on top. If `respect_retry_after_max_s` (default
+`60.0`) is at or above `retry_budget_s` (default `60.0`), one long cooldown
+can consume the whole budget, collapsing "5 attempts" down to roughly one
+cooldown cycle before the request gives up. The two are equal by default
+deliberately; lower `respect_retry_after_max_s` below `retry_budget_s` if
+you want more than one real retry to survive a 429.
+
+## Putting it together
+
+```python
+import asyncio
+import os
+
+from aiohttp import ClientSession
+from restgdf import Directory, ResilienceConfig, reset_config_cache
+from restgdf.resilience import ResilientSession
+
+HOST_URLS = [
+    "https://gis1.example-county.gov/arcgis/rest/services",
+    "https://gis.example-city.gov/arcgis/rest/services",
+    # ... many more small government hosts
+]
+
+# Process-global transport knob: must go through the environment, and must be
+# set before the first request (or followed by reset_config_cache()).
+os.environ["RESTGDF_TRANSPORT_USER_AGENT"] = "mycrawler/1.0 (contact: you@example.org)"
+reset_config_cache()
+
+# Per-session knob: read only by the ResilientSession it is handed to.
+polite_resilience = ResilienceConfig(
+    enabled=True,
+    rate_per_service_root_per_second=0.5,
+    limiter_key="host",
+    max_attempts=3,  # write off dead hosts quickly on a large estate
+)
+
+host_sem = asyncio.Semaphore(50)
+
+async def crawl_host(url: str) -> list:
+    async with ClientSession() as raw, host_sem:
+        session = ResilientSession(raw, polite_resilience)
+        directory = await Directory.from_url(url, session=session)
+        return await directory.crawl()
+
+async def main():
+    return await asyncio.gather(*(crawl_host(u) for u in HOST_URLS))
+
+asyncio.run(main())
+```
+
+For a known multi-tenant SaaS shard, build a second `ResilienceConfig` with
+`limiter_key="service_root"` (or a higher host rate) and route that shard's
+hosts through a session wrapped with it instead — one `ResilienceConfig` per
+politeness policy, not one for the whole crawl.
+
+## See also
+
+- {doc}`/resilience` — the `ResilienceConfig`/`ResilientSession` reference
+  and a minimal wrapping example.
+- {doc}`/configuration` — the full `RESTGDF_*` environment variable table.
+- {doc}`tracing` — set `logging.getLogger("restgdf.retry")` to `DEBUG` to
+  observe scheduled retries, 429 cooldowns, and exhaustion mapping live
+  during a crawl.

--- a/docs/recipes/tracing.md
+++ b/docs/recipes/tracing.md
@@ -27,8 +27,30 @@ cfg = Config(
 ```
 
 The `restgdf.resilience` module logs every retry attempt, 429 cooldown, and
-error mapping through the `restgdf.retry` logger at **DEBUG** level.  Set
-the logger to `DEBUG` to see each attempt:
+error mapping through the `restgdf.retry` logger at **DEBUG** level:
+
+- `retry scheduled: attempt=N wait=…s caused_by=…` before each retried attempt.
+  The `wait` is the *scheduled* pre-jitter backoff — the actual sleep adds up
+  to `ResilienceConfig.wait_jitter_s` (default `1.0` s) on top, so a logged
+  `wait=0.500s` can be a 1.4 s sleep.
+- `429 cooldown set: key=… seconds=…` whenever a 429 sets a cooldown deadline
+  (the `key` is the service root, or the host when
+  `ResilienceConfig.limiter_key="host"`)
+- `retry exhausted: … mapped to <ExceptionType>` when retries give up and the
+  underlying failure is mapped to a `restgdf.errors` type
+
+Each record also carries structured `extra` fields — `limit_key` (the
+rate-limit/cooldown key), `retry_attempt`, `retry_delay_s`, `limiter_wait_s`
+and `exception_type` — for a structured-logging handler.
+
+Retries cover the request up to *headers received*. A failure raised while
+the response body is read (a truncated body, `aiohttp.ClientPayloadError`) is
+outside the retry scope and is not logged here — it surfaces raw to the
+caller.
+
+Set the logger to `DEBUG` to see each event (the `logging.basicConfig` call
+above already does this if the root logger is at `DEBUG`; use the line below
+if you only want `restgdf.retry` at a finer level than the rest of your app):
 
 ```python
 logging.getLogger("restgdf.retry").setLevel(logging.DEBUG)
@@ -75,18 +97,20 @@ Example:
 ```python
 from restgdf.errors import RateLimitError, RestgdfTimeoutError
 
-try:
-    await session.get(url).__aenter__()
-except RateLimitError as exc:
-    print(f"429 at {exc.url}, retry after {exc.retry_after}s")
-except RestgdfTimeoutError as exc:
-    print(f"Timeout ({exc.timeout_kind}) for {exc.url}")
+async def query_with_error_detail(session, url, params):
+    try:
+        async with session.get(url, params=params) as resp:
+            return await resp.json()
+    except RateLimitError as exc:
+        print(f"429 at {exc.url}, retry after {exc.retry_after}s")
+    except RestgdfTimeoutError as exc:
+        print(f"Timeout ({exc.timeout_kind}) for {exc.url}")
 ```
 
 ## Integrating with OpenTelemetry
 
 For full distributed tracing with automatic span creation, install the
-``restgdf[telemetry]`` extra — see the :doc:`/recipes/observability` recipe.
+``restgdf[telemetry]`` extra — see the {doc}`/recipes/observability` recipe.
 The example below shows how to add *manual* spans around resilience-wrapped
 calls using the structured error attributes:
 
@@ -119,8 +143,10 @@ When a 429 response is received, the retry wrapper:
 
 1. Parses the `Retry-After` header (integer seconds or RFC 7231 HTTP-date).
 2. Clamps the value to `ResilienceConfig.respect_retry_after_max_s` (default 60 s).
-3. Sets a *cooldown deadline* for the service root — subsequent requests to
-   the same `FeatureServer`/`MapServer` wait until the deadline passes.
+3. Sets a *cooldown deadline* keyed by `ResilienceConfig.limiter_key`
+   (default `"service_root"` — subsequent requests to the same
+   `FeatureServer`/`MapServer` wait until the deadline passes; `"host"`
+   applies the same cooldown to every service on that host).
 4. Stamina's exponential back-off then retries the request.
 
 The cooldown is **separate** from the token-bucket limiter — a 429 does

--- a/docs/resilience.rst
+++ b/docs/resilience.rst
@@ -2,14 +2,80 @@ Resilience
 ==========
 
 The ``restgdf[resilience]`` extra adds automatic retry with exponential
-back-off, per-service-root rate limiting, and 429 cooldown handling.
-Install it alongside the base package:
+back-off, configurable per-service-root or per-host rate limiting, and 429
+cooldown handling. **Installing the extra does not change any request
+behavior on its own** — ``FeatureLayer``/``Directory`` always take a
+caller-owned session and never construct or wrap one for you. Opting in is
+two explicit steps:
+
+1. Install the extra and construct a ``restgdf.ResilienceConfig`` with
+   ``enabled=True``.
+2. Wrap your own :class:`~aiohttp.ClientSession` with
+   :class:`~restgdf.resilience.ResilientSession` and pass *that* as the
+   ``session=`` argument everywhere you would normally pass a plain
+   ``aiohttp.ClientSession``.
 
 .. code-block:: bash
 
    pip install "restgdf[resilience]"
 
-See :doc:`recipes/tracing` for a practical integration guide.
+.. code-block:: python
+
+   from aiohttp import ClientSession
+   from restgdf import Directory, ResilienceConfig
+   from restgdf.resilience import ResilientSession
+
+   resilience_cfg = ResilienceConfig(
+       enabled=True,
+       rate_per_service_root_per_second=5.0,
+   )
+
+   async def main():
+       async with ClientSession() as raw:
+           session = ResilientSession(raw, resilience_cfg)
+           directory = await Directory.from_url(
+               "https://maps1.vcgov.org/arcgis/rest/services",
+               session=session,
+           )
+           return await directory.crawl()
+
+``ResilientSession`` is transparent: it implements the same ``get``/``post``
+shape as a plain ``aiohttp.ClientSession``, so every request issued through
+it — by ``Directory``, ``FeatureLayer``, or a raw call — is rate-limited and
+retried uniformly. ``ResilienceConfig.enabled`` is the sole gate; the other
+fields only tune an already-enabled session.
+
+For a crawl spanning many independent hosts — including how to pick
+per-host vs. per-service-root rate-limit granularity, set a polite
+User-Agent, and bound your own outer concurrency — see
+:doc:`recipes/bulk_crawl`. See :doc:`recipes/tracing` for observing retries
+and cooldowns via logging.
+
+Environment variables vs. explicit config
+-----------------------------------------
+
+A ``ResilienceConfig`` you construct is read **only** by the
+``ResilientSession`` you hand it to, and building one does not consult
+``RESTGDF_RESILIENCE_*``. The example above therefore ignores the
+environment by design. To honour it, build the session from the
+process-global config instead:
+
+.. code-block:: python
+
+   from restgdf import get_config, reset_config_cache
+   from restgdf.resilience import ResilientSession
+
+   # reads RESTGDF_RESILIENCE_ENABLED / _MAX_ATTEMPTS / _LIMITER_KEY / ...
+   session = ResilientSession(raw, get_config().resilience)
+
+``get_config()`` is cached; call ``reset_config_cache()`` if you change a
+variable mid-process. Note the asymmetry: resilience knobs are per-session
+and passed explicitly, while the transport / concurrency / timeout knobs
+(``RESTGDF_TRANSPORT_USER_AGENT``,
+``RESTGDF_CONCURRENCY_MAX_CONCURRENT_REQUESTS``, ``RESTGDF_TIMEOUT_TOTAL_S``)
+are process-global and read from ``get_config()`` at request time — a
+``Config`` instance you build yourself is never threaded into the request
+path (CONFIG-03).
 
 restgdf.resilience
 ------------------

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -341,7 +341,10 @@ class ResilienceConfig(BaseModel):
     sleeps count against it: honouring a ``Retry-After`` at or above
     ``retry_budget_s`` collapses the whole retry loop to roughly a single
     cooldown cycle before giving up. ``respect_retry_after_max_s`` caps how
-    long a single honoured ``Retry-After`` may be; setting it at or above
+    long a single honoured ``Retry-After`` may be -- one in-attempt cooldown
+    wait is bounded by the deadline in force when the attempt reaches it and
+    never chains a second wait, so the cap holds regardless of how many
+    requests are in flight on the same key; setting it at or above
     ``retry_budget_s`` therefore lets one cooldown consume the entire budget.
     Keep ``respect_retry_after_max_s`` below ``retry_budget_s`` if you want
     more than one real retry after a 429 (the defaults are deliberately equal

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -61,26 +61,30 @@ _FROZEN = ConfigDict(extra="forbid", frozen=True, populate_by_name=True)
 
 
 class InertConfigWarning(UserWarning):
-    """A ``RESTGDF_*`` env var is set but does not (yet) affect runtime.
+    """A ``RESTGDF_*`` env var is set but does not affect runtime.
 
     Emitted once (per :func:`Config.from_env` resolution) when a caller sets
-    a validated-but-currently-inert knob -- the ``RESTGDF_RETRY_*`` /
-    ``RESTGDF_LIMITER_*`` values (the resilience executor hardcodes its retry
-    and rate-limit policy) or ``RESTGDF_AUTH_REFRESH_THRESHOLD_S`` (token
-    sessions do not read ``AuthConfig``; see :class:`AuthConfig`). The value
-    still validates into :class:`Config`, but nothing consumes it yet
-    (warn-now, wire-later per the AUTH-04 / TRANSPORT-01 decision). Silence it
-    with
+    a validated-but-inert knob -- the **deprecated** ``RESTGDF_RETRY_*`` /
+    ``RESTGDF_LIMITER_*`` values (superseded in 3.3 by the live
+    ``RESTGDF_RESILIENCE_*`` knobs on :class:`ResilienceConfig`; see the
+    deprecation notes on :class:`RetryConfig` / :class:`LimiterConfig`) or
+    ``RESTGDF_AUTH_REFRESH_THRESHOLD_S`` (token sessions do not read
+    ``AuthConfig``; see :class:`AuthConfig`). The value still validates into
+    :class:`Config`, but nothing consumes it (the RETRY/LIMITER knobs are
+    removed in 4.0). Silence it with
     ``warnings.filterwarnings("ignore", category=restgdf._config.InertConfigWarning)``.
     """
 
 
 # ``RESTGDF_*`` env keys that validate into :class:`Config` but that no live
-# code path reads yet (verified 2026-07-24: the ``@stamina.retry`` executor
-# hardcodes its policy and never reads ``config.retry``/``config.limiter``;
-# ``AuthConfig.refresh_threshold_s`` is surfaced only through the deprecated
-# ``Settings`` shim, never applied to a token session). Kept intact as a
-# back-compat seam (tests pin them); real wiring is deferred (W2-13/AUTH-04).
+# code path reads (verified 2026-07-24: the resilience executor reads its
+# retry/limiter policy from ``config.resilience`` (:class:`ResilienceConfig`)
+# and never reads ``config.retry``/``config.limiter``; the ``RESTGDF_RETRY_*``
+# / ``RESTGDF_LIMITER_*`` knobs are deprecated in 3.3 and superseded by the
+# ``RESTGDF_RESILIENCE_*`` replacements. ``AuthConfig.refresh_threshold_s`` is
+# surfaced only through the deprecated ``Settings`` shim, never applied to a
+# token session). Kept intact as a back-compat seam (tests pin them); the
+# deprecated RETRY/LIMITER knobs are removed in 4.0 (W2-13/AUTH-04).
 _INERT_ENV_KEYS: tuple[str, ...] = (
     "RESTGDF_RETRY_ENABLED",
     "RESTGDF_RETRY_MAX_ATTEMPTS",
@@ -148,7 +152,19 @@ class TimeoutConfig(BaseModel):
 
 
 class RetryConfig(BaseModel):
-    """Retry policy (disabled by default; phase-3a wires the executor)."""
+    """Retry policy holder (validated but inert; see the deprecation note).
+
+    .. deprecated:: 3.3
+        ``max_attempts`` and ``max_delay_s`` are inert and superseded by the
+        live :class:`ResilienceConfig` retry knobs -- ``max_attempts`` maps to
+        ``ResilienceConfig.max_attempts`` and ``max_delay_s`` to
+        ``ResilienceConfig.retry_budget_s`` (the total wall-clock budget). The
+        resilience executor reads only :class:`ResilienceConfig`; these two
+        fields (and their ``RESTGDF_RETRY_MAX_ATTEMPTS`` /
+        ``RESTGDF_RETRY_MAX_DELAY_S`` env keys) validate but change nothing.
+        They stay wired as a back-compat seam and emit
+        :class:`InertConfigWarning` when set; both are removed in 4.0.
+    """
 
     model_config = _FROZEN
 
@@ -158,7 +174,18 @@ class RetryConfig(BaseModel):
 
 
 class LimiterConfig(BaseModel):
-    """Rate-limiter configuration (disabled by default)."""
+    """Rate-limiter configuration holder (validated but inert).
+
+    .. deprecated:: 3.3
+        ``rate_per_host`` is inert and superseded by the live
+        :class:`ResilienceConfig` rate limiter: set
+        ``ResilienceConfig.rate_per_service_root_per_second`` together with
+        ``ResilienceConfig.limiter_key = "host"`` for per-host rate limiting.
+        The resilience executor reads only :class:`ResilienceConfig`; this
+        field (and its ``RESTGDF_LIMITER_RATE_PER_HOST`` env key) validates but
+        changes nothing. It stays wired as a back-compat seam and emits
+        :class:`InertConfigWarning` when set; it is removed in 4.0.
+    """
 
     model_config = _FROZEN
 
@@ -555,13 +582,18 @@ class Config(BaseModel):
         inert_present = [key for key in _INERT_ENV_KEYS if key in source]
         if inert_present:
             warnings.warn(
-                "These RESTGDF_* environment variables are set but currently "
-                "inert -- they validate into Config yet do not affect runtime "
-                "behavior (the resilience executor hardcodes retry/limiter "
-                "policy; token sessions do not read "
-                "AuthConfig.refresh_threshold_s): "
-                f"{', '.join(sorted(inert_present))}. Real wiring is deferred "
-                "(warn-now, wire-later; see AUTH-04 / TRANSPORT-01).",
+                "These RESTGDF_* environment variables are set but are inert -- "
+                "they validate into Config yet do not affect runtime behavior: "
+                f"{', '.join(sorted(inert_present))}. The RESTGDF_RETRY_* and "
+                "RESTGDF_LIMITER_* knobs are deprecated (removed in 4.0); use "
+                "their live RESTGDF_RESILIENCE_* replacements instead -- "
+                "RESTGDF_RESILIENCE_MAX_ATTEMPTS, "
+                "RESTGDF_RESILIENCE_RETRY_BUDGET_S, and "
+                "RESTGDF_RESILIENCE_RATE_PER_SERVICE_ROOT_PER_SECOND with "
+                "RESTGDF_RESILIENCE_LIMITER_KEY=host. "
+                "RESTGDF_AUTH_REFRESH_THRESHOLD_S is still not read by token "
+                "sessions (construct TokenSessionConfig explicitly). "
+                "See AUTH-04 / TRANSPORT-01.",
                 InertConfigWarning,
                 stacklevel=_warn_stacklevel,
             )

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -346,6 +346,13 @@ class ResilienceConfig(BaseModel):
     Keep ``respect_retry_after_max_s`` below ``retry_budget_s`` if you want
     more than one real retry after a 429 (the defaults are deliberately equal
     at ``60.0`` -- one honoured max-length cooldown, then give up).
+
+    .. deprecated:: 3.3
+        ``backend`` is dead config -- ``"stamina"`` is the only implementation
+        and the executor never reads the field. Setting
+        ``RESTGDF_RESILIENCE_BACKEND`` emits a :class:`DeprecationWarning`; the
+        field stays reachable (default ``"stamina"``) for back-compat and is
+        removed in 4.0.
     """
 
     model_config = _FROZEN
@@ -572,6 +579,22 @@ class Config(BaseModel):
                 stacklevel=_warn_stacklevel,
             )
             _coerce(old_key, dotted, caster)
+
+        # R5: ``backend`` is dead config -- "stamina" is the only backend and
+        # the resilience executor never reads the field. It shipped as a public
+        # field in 3.2.0, so it cannot be removed in a minor; deprecate the
+        # env-var path here (mirroring the _DEPRECATED_ALIASES precedent above)
+        # and remove the field + this warning in 4.0. Field *construction* is
+        # intentionally NOT deprecated -- Field(deprecated=True) warns on every
+        # attribute read and would trip the restgdf.* DeprecationWarning
+        # escalation (judge-R5 footgun note).
+        if "RESTGDF_RESILIENCE_BACKEND" in source:
+            warnings.warn(
+                "RESTGDF_RESILIENCE_BACKEND is deprecated and has no effect "
+                "('stamina' is the only backend); it is removed in 4.0.",
+                DeprecationWarning,
+                stacklevel=_warn_stacklevel,
+            )
 
         # W2-13 (TRANSPORT-01 / AUTH-04): a validated-but-inert knob is a
         # silent lie -- the caller set it expecting an effect it never has.

--- a/restgdf/_config.py
+++ b/restgdf/_config.py
@@ -275,17 +275,64 @@ class TelemetryConfig(BaseModel):
 class ResilienceConfig(BaseModel):
     """Resilience adapter configuration (BL-31).
 
-    Controls the optional stamina-based retry wrapper and per-service-root
-    token-bucket rate limiter. Disabled by default; callers opt in via
-    ``RESTGDF_RESILIENCE_ENABLED=1`` or by constructing explicitly.
+    Controls the optional stamina-based retry wrapper and token-bucket rate
+    limiter used by :class:`restgdf.resilience.ResilientSession`. Disabled by
+    default; callers opt in via ``RESTGDF_RESILIENCE_ENABLED=1`` or by
+    constructing explicitly. ``enabled`` is the **sole** gate for the retry
+    executor -- the retry-tuning fields below never re-gate an
+    already-enabled session; they only shape its behaviour.
+
+    Rate-limit granularity (``limiter_key``)
+    ----------------------------------------
+    ``limiter_key`` selects the key the single token bucket (and the shared
+    429 cooldown) is keyed on:
+
+    * ``"service_root"`` (default, behaviour-preserving) -- one bucket per
+      ArcGIS service root (truncated at ``FeatureServer``/``MapServer``/...),
+      so ``rate_per_service_root_per_second`` is enforced *per service*.
+    * ``"host"`` -- one bucket per ``scheme://host``, so the same rate is
+      enforced across every service on that host. This is the polite default
+      when many independent services sit behind one government host; the
+      configured rate then applies **per host** rather than per service root.
+
+    Both granularities share the one ``rate_per_service_root_per_second``
+    value and one registry -- the field name is historical; read it as
+    "the configured rate, enforced at ``limiter_key`` granularity". Sub-1.0
+    rates (e.g. ``0.5`` req/s -- the natural polite setting) are valid.
+
+    Retry attempts / backoff / budget
+    ---------------------------------
+    The stamina executor reads ``max_attempts``, ``retry_budget_s``,
+    ``wait_initial_s``, ``wait_max_s`` and ``wait_jitter_s`` directly from this
+    config (defaults preserve the historical hardcoded policy exactly). These
+    supersede the inert :class:`RetryConfig` knobs (deprecated in 3.3).
+
+    Budget / cooldown coherence (H1-N3)
+    -----------------------------------
+    A 429 ``Retry-After`` cooldown sleep happens *inside* a retried attempt and
+    ``retry_budget_s`` is a **total** wall-clock budget, so in-attempt cooldown
+    sleeps count against it: honouring a ``Retry-After`` at or above
+    ``retry_budget_s`` collapses the whole retry loop to roughly a single
+    cooldown cycle before giving up. ``respect_retry_after_max_s`` caps how
+    long a single honoured ``Retry-After`` may be; setting it at or above
+    ``retry_budget_s`` therefore lets one cooldown consume the entire budget.
+    Keep ``respect_retry_after_max_s`` below ``retry_budget_s`` if you want
+    more than one real retry after a 429 (the defaults are deliberately equal
+    at ``60.0`` -- one honoured max-length cooldown, then give up).
     """
 
     model_config = _FROZEN
 
     enabled: bool = False
     rate_per_service_root_per_second: float | None = Field(default=None, gt=0)
+    limiter_key: Literal["service_root", "host"] = "service_root"
     respect_retry_after_max_s: float = Field(default=60.0, gt=0)
     fallback_retry_after_seconds: float = Field(default=5.0, gt=0)
+    max_attempts: int = Field(default=5, ge=1)
+    retry_budget_s: float = Field(default=60.0, gt=0)
+    wait_initial_s: float = Field(default=0.5, ge=0)
+    wait_max_s: float = Field(default=10.0, gt=0)
+    wait_jitter_s: float = Field(default=1.0, ge=0)
     backend: str = "stamina"
 
 
@@ -328,6 +375,7 @@ _NEW_ENV_SPEC: tuple[tuple[str, str, _Caster], ...] = (
         "resilience.rate_per_service_root_per_second",
         float,
     ),
+    ("RESTGDF_RESILIENCE_LIMITER_KEY", "resilience.limiter_key", str),
     (
         "RESTGDF_RESILIENCE_RESPECT_RETRY_AFTER_MAX_S",
         "resilience.respect_retry_after_max_s",
@@ -338,6 +386,11 @@ _NEW_ENV_SPEC: tuple[tuple[str, str, _Caster], ...] = (
         "resilience.fallback_retry_after_seconds",
         float,
     ),
+    ("RESTGDF_RESILIENCE_MAX_ATTEMPTS", "resilience.max_attempts", int),
+    ("RESTGDF_RESILIENCE_RETRY_BUDGET_S", "resilience.retry_budget_s", float),
+    ("RESTGDF_RESILIENCE_WAIT_INITIAL_S", "resilience.wait_initial_s", float),
+    ("RESTGDF_RESILIENCE_WAIT_MAX_S", "resilience.wait_max_s", float),
+    ("RESTGDF_RESILIENCE_WAIT_JITTER_S", "resilience.wait_jitter_s", float),
     ("RESTGDF_RESILIENCE_BACKEND", "resilience.backend", str),
 )
 

--- a/restgdf/_logging.py
+++ b/restgdf/_logging.py
@@ -30,6 +30,9 @@ LOGGER_SUFFIXES: Final[tuple[str, ...]] = (
     "pagination",
     "normalization",
     "schema_drift",
+    # 3.3: directory-crawl visibility -- per-layer metadata failures contained
+    # inside ``service_metadata`` are reported here at WARNING (H2-1 / V2-M1).
+    "crawl",
 )
 
 LOG_EXTRA_KEYS: Final[tuple[str, ...]] = (

--- a/restgdf/_logging.py
+++ b/restgdf/_logging.py
@@ -34,6 +34,7 @@ LOGGER_SUFFIXES: Final[tuple[str, ...]] = (
 
 LOG_EXTRA_KEYS: Final[tuple[str, ...]] = (
     "service_root",
+    "limit_key",
     "layer_id",
     "operation",
     "page_index",
@@ -112,6 +113,7 @@ def _scrub_url(url: str | None) -> str | None:
 def build_log_extra(
     *,
     service_root: str | None = None,
+    limit_key: str | None = None,
     layer_id: int | None = None,
     operation: str | None = None,
     page_index: int | None = None,
@@ -125,13 +127,21 @@ def build_log_extra(
 ) -> dict[str, Any]:
     """Build a normalized ``extra=`` envelope for library log records.
 
-    Only keys with non-``None`` values are included. ``service_root`` is scrubbed
-    via :func:`_scrub_url` so ``?token=`` values never reach log handlers. Keys
-    are drawn from :data:`LOG_EXTRA_KEYS`; the keyword list is the contract —
-    unknown keys raise :class:`TypeError` from the signature.
+    Only keys with non-``None`` values are included. ``service_root`` and
+    ``limit_key`` are scrubbed via :func:`_scrub_url` so ``?token=`` values never
+    reach log handlers. Keys are drawn from :data:`LOG_EXTRA_KEYS`; the keyword
+    list is the contract — unknown keys raise :class:`TypeError` from the
+    signature.
+
+    ``limit_key`` is the *rate-limit/cooldown* key emitted by the resilience
+    retry path. It is deliberately distinct from ``service_root``: under
+    :attr:`restgdf.ResilienceConfig.limiter_key` ``= "host"`` the value is a
+    bare ``scheme://host``, not a service root, so reusing ``service_root``
+    would mislabel it (3.3).
     """
     raw: dict[str, Any] = {
         "service_root": _scrub_url(service_root),
+        "limit_key": _scrub_url(limit_key),
         "layer_id": layer_id,
         "operation": operation,
         "page_index": page_index,

--- a/restgdf/_models/crawl.py
+++ b/restgdf/_models/crawl.py
@@ -42,6 +42,12 @@ class CrawlError(PermissiveModel):
     * ``"service_metadata"`` — a per-service ``service_metadata`` call
       failed.
 
+    A failed *layer* has no stage: since 3.3 a per-layer metadata failure
+    is contained inside ``service_metadata`` (H2-1) and surfaces as a
+    ``layer_error`` marker on the layer entry plus one ``WARNING`` on the
+    ``restgdf.crawl`` logger — never as a :class:`CrawlError`. A crawl with
+    an empty ``errors`` list can therefore still contain broken layers.
+
     ``exception`` preserves the original :class:`BaseException` so
     callers can re-raise; it is excluded from the default
     :meth:`~pydantic.BaseModel.model_dump` output for JSON safety.

--- a/restgdf/resilience/_limiter.py
+++ b/restgdf/resilience/_limiter.py
@@ -82,12 +82,30 @@ class CooldownRegistry:
         self._deadlines[key] = time.monotonic() + seconds
 
     async def wait_if_cooling(self, key: str) -> None:
-        """Sleep until *key*'s cooldown expires (no-op if none set)."""
-        deadline = self._deadlines.get(key)
-        if deadline is None:
+        """Sleep until *key*'s cooldown expires (no-op if none set).
+
+        After sleeping, re-reads the deadline before clearing it. A
+        concurrent :meth:`set_cooldown` (a fresh 429 on the same key) may
+        have installed a *newer* deadline while this waiter slept;
+        unconditionally popping would erase it, so this waiter is occasionally
+        not honoured at high concurrency (H1-N2). If the deadline changed
+        while sleeping, honour the new one; only clear it when it is unchanged.
+        """
+        while True:
+            deadline = self._deadlines.get(key)
+            if deadline is None:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                await asyncio.sleep(remaining)
+            # Re-read after sleeping: a concurrent set_cooldown may have
+            # replaced the deadline we just waited on.
+            current = self._deadlines.get(key)
+            if current is None:
+                return
+            if current != deadline:
+                # A different (typically fresher) deadline was set — honour it.
+                continue
+            # Unchanged — safe to clear and finish.
+            self._deadlines.pop(key, None)
             return
-        remaining = deadline - time.monotonic()
-        if remaining > 0:
-            await asyncio.sleep(remaining)
-        # Expired — clean up
-        self._deadlines.pop(key, None)

--- a/restgdf/resilience/_limiter.py
+++ b/restgdf/resilience/_limiter.py
@@ -17,18 +17,32 @@ _SERVER_TYPE_RE = re.compile(
 )
 
 
+def _host(url: str) -> str:
+    """Derive a per-host rate-limit key (``scheme://netloc``) from a URL.
+
+    This is the coarser granularity selected by
+    :attr:`restgdf.ResilienceConfig.limiter_key` ``= "host"``: every service
+    on one host shares a single token bucket (and 429 cooldown), the polite
+    default when many independent ArcGIS services sit behind a single
+    government host. It is exactly :func:`_service_root`'s
+    no-server-suffix fallback branch, factored out for reuse.
+    """
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
 def _service_root(url: str) -> str:
     """Derive a per-service rate-limit key from a request URL.
 
     Truncates at the first ``FeatureServer``, ``MapServer``,
     ``ImageServer``, or ``SceneServer`` path segment. Falls back to
-    ``scheme://host`` when none of those segments are present.
+    ``scheme://host`` (:func:`_host`) when none of those segments are present.
     """
     parsed = urlparse(url)
     m = _SERVER_TYPE_RE.match(parsed.path)
     if m:
         return f"{parsed.scheme}://{parsed.netloc}{m.group(1)}"
-    return f"{parsed.scheme}://{parsed.netloc}"
+    return _host(url)
 
 
 class LimiterRegistry:

--- a/restgdf/resilience/_limiter.py
+++ b/restgdf/resilience/_limiter.py
@@ -108,6 +108,12 @@ class CooldownRegistry:
         next attempt/request to honour (H1-N2). Only a deadline this call
         actually waited out — unchanged since entry — is cleared.
 
+        Trade-off (R2): the waking waiter itself *proceeds* — its request may
+        dispatch while that fresher deadline is still in force. One request
+        per waking waiter can slip into a live cooldown window; the next
+        attempt on the key waits it out. This is the accepted cost of keeping
+        a single wait bounded.
+
         Re-waiting here instead would make a single in-attempt wait scale with
         the number of concurrent waiters on the key (measured: 0.52s at
         concurrency 1 rising to 14.8s at 16 against a 0.5s cooldown), which

--- a/restgdf/resilience/_limiter.py
+++ b/restgdf/resilience/_limiter.py
@@ -98,28 +98,39 @@ class CooldownRegistry:
     async def wait_if_cooling(self, key: str) -> None:
         """Sleep until *key*'s cooldown expires (no-op if none set).
 
-        After sleeping, re-reads the deadline before clearing it. A
-        concurrent :meth:`set_cooldown` (a fresh 429 on the same key) may
-        have installed a *newer* deadline while this waiter slept;
-        unconditionally popping would erase it, so this waiter is occasionally
-        not honoured at high concurrency (H1-N2). If the deadline changed
-        while sleeping, honour the new one; only clear it when it is unchanged.
+        **Bounded by construction:** one call sleeps at most until the deadline
+        observed on entry. It never chains a second sleep.
+
+        After sleeping, the deadline is re-read before being cleared. A
+        concurrent :meth:`set_cooldown` (a fresh 429 on the same key) may have
+        installed a *newer* deadline while this waiter slept; unconditionally
+        popping would erase it, so the newer deadline is left in place for the
+        next attempt/request to honour (H1-N2). Only a deadline this call
+        actually waited out — unchanged since entry — is cleared.
+
+        Re-waiting here instead would make a single in-attempt wait scale with
+        the number of concurrent waiters on the key (measured: 0.52s at
+        concurrency 1 rising to 14.8s at 16 against a 0.5s cooldown), which
+        neither ``max_attempts`` nor ``retry_budget_s`` can interrupt —
+        stamina evaluates ``stop_after_delay`` only *between* attempts — and
+        would falsify
+        :attr:`restgdf.ResilienceConfig.respect_retry_after_max_s`'s cap on a
+        single honoured ``Retry-After``.
         """
-        while True:
-            deadline = self._deadlines.get(key)
-            if deadline is None:
-                return
-            remaining = deadline - time.monotonic()
-            if remaining > 0:
-                await asyncio.sleep(remaining)
-            # Re-read after sleeping: a concurrent set_cooldown may have
-            # replaced the deadline we just waited on.
-            current = self._deadlines.get(key)
-            if current is None:
-                return
-            if current != deadline:
-                # A different (typically fresher) deadline was set — honour it.
-                continue
-            # Unchanged — safe to clear and finish.
-            self._deadlines.pop(key, None)
+        deadline = self._deadlines.get(key)
+        if deadline is None:
             return
+        remaining = deadline - time.monotonic()
+        if remaining > 0:
+            await asyncio.sleep(remaining)
+        # Re-read after sleeping: a concurrent set_cooldown may have replaced
+        # the deadline we just waited on.
+        current = self._deadlines.get(key)
+        if current is None:
+            return
+        if current != deadline:
+            # A fresher deadline was installed while we slept. Leave it for the
+            # next attempt/request rather than chaining another wait here.
+            return
+        # Unchanged — this call waited it out, so clear it.
+        self._deadlines.pop(key, None)

--- a/restgdf/resilience/_limiter.py
+++ b/restgdf/resilience/_limiter.py
@@ -43,10 +43,21 @@ class LimiterRegistry:
         self._limiters: dict[str, AsyncLimiter] = {}
 
     def get(self, service_root: str) -> AsyncLimiter:
-        """Return (or create) the limiter for *service_root*."""
+        """Return (or create) the limiter for *service_root*.
+
+        ``AsyncLimiter.acquire(1)`` refuses any amount above ``max_rate``,
+        so a fractional ``max_rate`` (rate < 1 req/s with ``time_period=1``)
+        crashes on the very first request. For sub-1 rates we instead spell
+        the bucket as one token per ``1 / rate`` seconds — the idiomatic
+        aiolimiter form — which paces at the requested rate. Rates >= 1 keep
+        the historical ``AsyncLimiter(rate, 1)`` burst semantics exactly.
+        """
         lim = self._limiters.get(service_root)
         if lim is None:
-            lim = AsyncLimiter(max_rate=self._rate, time_period=1)
+            if self._rate >= 1:
+                lim = AsyncLimiter(max_rate=self._rate, time_period=1)
+            else:
+                lim = AsyncLimiter(max_rate=1, time_period=1 / self._rate)
             self._limiters[service_root] = lim
         return lim
 

--- a/restgdf/resilience/_retry.py
+++ b/restgdf/resilience/_retry.py
@@ -9,7 +9,7 @@ import aiohttp
 import stamina
 
 from restgdf._config import ResilienceConfig
-from restgdf._logging import get_logger
+from restgdf._logging import build_log_extra, get_logger
 from restgdf.errors import (
     RateLimitError,
     RestgdfResponseError,
@@ -170,16 +170,12 @@ async def _do_retried_request(
         aiohttp.ClientConnectionError,
         aiohttp.ClientPayloadError,
     )
+    # Cause of the most recent failed attempt. stamina swallows the exception
+    # between attempts, so we record it here to name it in the retry-scheduled
+    # and exhaustion-mapping DEBUG logs (H1-N4).
+    last_cause: dict[str, str] = {}
 
-    @stamina.retry(
-        on=retry_on,
-        attempts=5,
-        timeout=60.0,
-        wait_initial=0.5,
-        wait_max=10.0,
-        wait_jitter=1.0,
-    )
-    async def _attempt() -> Any:
+    async def _attempt() -> tuple[Any, Any]:
         # 429 cooldown: wait if a previous 429 set a deadline for this service
         if cooldown is not None:
             await cooldown.wait_if_cooling(svc_root)
@@ -187,7 +183,11 @@ async def _do_retried_request(
         if limiter is not None:
             await limiter.get(svc_root).acquire()
         dispatch = getattr(inner, method)
-        ctx, resp = await _enter_request(dispatch(url, **kwargs))
+        try:
+            ctx, resp = await _enter_request(dispatch(url, **kwargs))
+        except (aiohttp.ClientConnectionError, aiohttp.ClientPayloadError) as exc:
+            last_cause["cause"] = type(exc).__name__
+            raise
 
         if resp.status in _RETRYABLE_STATUS:
             headers = dict(getattr(resp, "headers", {}))
@@ -200,7 +200,18 @@ async def _do_retried_request(
                     else config.fallback_retry_after_seconds
                 )
                 cooldown.set_cooldown(svc_root, cd)
+                _log.debug(
+                    "429 cooldown set: key=%s seconds=%.3f",
+                    svc_root,
+                    cd,
+                    extra=build_log_extra(
+                        service_root=svc_root,
+                        operation="cooldown",
+                        limiter_wait_s=cd,
+                    ),
+                )
             await ctx.__aexit__(None, None, None)
+            last_cause["cause"] = f"status={resp.status}"
             raise _RetryableHTTPError(resp.status, headers)
 
         if 400 <= resp.status < 500:
@@ -216,10 +227,48 @@ async def _do_retried_request(
 
         return ctx, resp
 
+    # ``retry_context`` is the equivalent of the ``@stamina.retry`` decorator
+    # (same kwargs) but exposes each attempt's number and backoff, so the
+    # per-retry DEBUG log can name them (H1-N4). ``prev_wait`` carries the
+    # backoff that was applied *before* the current attempt.
+    prev_wait = 0.0
     try:
-        return await _attempt()
+        async for attempt in stamina.retry_context(
+            on=retry_on,
+            attempts=5,
+            timeout=60.0,
+            wait_initial=0.5,
+            wait_max=10.0,
+            wait_jitter=1.0,
+        ):
+            if attempt.num > 1:
+                _log.debug(
+                    "retry scheduled: attempt=%d wait=%.3fs caused_by=%s",
+                    attempt.num,
+                    prev_wait,
+                    last_cause.get("cause", "unknown"),
+                    extra=build_log_extra(
+                        service_root=svc_root,
+                        retry_attempt=attempt.num,
+                        retry_delay_s=prev_wait,
+                        exception_type=last_cause.get("cause"),
+                    ),
+                )
+            prev_wait = attempt.next_wait
+            with attempt:
+                return await _attempt()
+        raise AssertionError(  # pragma: no cover - retry_context always returns or raises
+            "stamina.retry_context exited without returning or raising",
+        )
     except _RetryableHTTPError as exc:
         if exc.status == 429:
+            _log.debug(
+                "retry exhausted: status=429 mapped to RateLimitError",
+                extra=build_log_extra(
+                    service_root=svc_root,
+                    exception_type="RateLimitError",
+                ),
+            )
             retry_after = _parse_retry_after(exc.headers.get("Retry-After", ""))
             raise RateLimitError(
                 f"Rate limited (429) at {url}",
@@ -227,6 +276,14 @@ async def _do_retried_request(
                 url=url,
                 status_code=429,
             ) from exc
+        _log.debug(
+            "retry exhausted: status=%d mapped to RestgdfResponseError",
+            exc.status,
+            extra=build_log_extra(
+                service_root=svc_root,
+                exception_type="RestgdfResponseError",
+            ),
+        )
         raise RestgdfResponseError(
             f"Server error ({exc.status}) at {url}",
             model_name="",
@@ -238,18 +295,42 @@ async def _do_retried_request(
     except aiohttp.ServerTimeoutError as exc:
         # ServerTimeoutError subclasses ClientConnectionError — map it first so
         # read timeouts keep their dedicated RestgdfTimeoutError type fidelity.
+        _log.debug(
+            "retry exhausted: %s mapped to RestgdfTimeoutError",
+            type(exc).__name__,
+            extra=build_log_extra(
+                service_root=svc_root,
+                exception_type="RestgdfTimeoutError",
+            ),
+        )
         raise RestgdfTimeoutError(
             f"Read timeout: {exc}",
             url=url,
             timeout_kind="read",
         ) from exc
     except aiohttp.ClientPayloadError as exc:
+        _log.debug(
+            "retry exhausted: %s mapped to TransportError",
+            type(exc).__name__,
+            extra=build_log_extra(
+                service_root=svc_root,
+                exception_type="TransportError",
+            ),
+        )
         raise TransportError(
             f"Truncated or incomplete response body for {url}",
             url=url,
             status_code=None,
         ) from exc
     except aiohttp.ClientConnectionError as exc:
+        _log.debug(
+            "retry exhausted: %s mapped to TransportError",
+            type(exc).__name__,
+            extra=build_log_extra(
+                service_root=svc_root,
+                exception_type="TransportError",
+            ),
+        )
         raise TransportError(
             f"Connection failed for {url}",
             url=url,

--- a/restgdf/resilience/_retry.py
+++ b/restgdf/resilience/_retry.py
@@ -171,10 +171,20 @@ async def _do_retried_request(
     # ``ClientConnectionError`` is the common base for every connection-shaped
     # aiohttp failure — ``ClientConnectorError`` (DNS/connect), ``ClientOSError``
     # (incl. ECONNRESET), ``ClientConnectionResetError``, ``ServerDisconnectedError``,
-    # and ``ServerTimeoutError`` — so retrying it covers mid-flight disconnects and
+    # and ``ServerTimeoutError`` — so retrying it covers dispatch-time disconnects and
     # resets that a bulk crawl routinely hits, not just connect-time and read-timeout
-    # failures. ``ClientPayloadError`` (truncated/incomplete body) is a sibling of
-    # ``ClientError`` outside that base, so it is listed separately.
+    # failures.
+    #
+    # SCOPE (verified): this wrapper covers the request only up to *headers
+    # received* — ``_enter_request(dispatch(...))``. Callers read the body after
+    # ``_do_retried_request`` has returned (``restgdf.utils._query`` awaits
+    # ``response.json(...)``), and aiohttp raises ``ClientPayloadError`` on the
+    # payload stream, not from the request await. A truncated/mid-body failure
+    # therefore surfaces raw at the read, outside this retry loop; the
+    # ``ClientPayloadError`` entry below only covers inner sessions that surface
+    # it from dispatch itself (a wrapping session, or aiohttp draining a redirect
+    # body). Extending retry across the body read needs ``_RetriedCtx`` to own
+    # response consumption — a deliberate design item, not done here.
     retry_on = (
         _RetryableHTTPError,
         aiohttp.ClientConnectionError,
@@ -215,7 +225,7 @@ async def _do_retried_request(
                     limit_key,
                     cd,
                     extra=build_log_extra(
-                        service_root=limit_key,
+                        limit_key=limit_key,
                         operation="cooldown",
                         limiter_wait_s=cd,
                     ),
@@ -261,7 +271,7 @@ async def _do_retried_request(
                     prev_wait,
                     last_cause.get("cause", "unknown"),
                     extra=build_log_extra(
-                        service_root=limit_key,
+                        limit_key=limit_key,
                         retry_attempt=attempt.num,
                         retry_delay_s=prev_wait,
                         exception_type=last_cause.get("cause"),
@@ -278,7 +288,7 @@ async def _do_retried_request(
             _log.debug(
                 "retry exhausted: status=429 mapped to RateLimitError",
                 extra=build_log_extra(
-                    service_root=limit_key,
+                    limit_key=limit_key,
                     exception_type="RateLimitError",
                 ),
             )
@@ -293,7 +303,7 @@ async def _do_retried_request(
             "retry exhausted: status=%d mapped to RestgdfResponseError",
             exc.status,
             extra=build_log_extra(
-                service_root=limit_key,
+                limit_key=limit_key,
                 exception_type="RestgdfResponseError",
             ),
         )
@@ -312,7 +322,7 @@ async def _do_retried_request(
             "retry exhausted: %s mapped to RestgdfTimeoutError",
             type(exc).__name__,
             extra=build_log_extra(
-                service_root=limit_key,
+                limit_key=limit_key,
                 exception_type="RestgdfTimeoutError",
             ),
         )
@@ -326,7 +336,7 @@ async def _do_retried_request(
             "retry exhausted: %s mapped to TransportError",
             type(exc).__name__,
             extra=build_log_extra(
-                service_root=limit_key,
+                limit_key=limit_key,
                 exception_type="TransportError",
             ),
         )
@@ -340,7 +350,7 @@ async def _do_retried_request(
             "retry exhausted: %s mapped to TransportError",
             type(exc).__name__,
             extra=build_log_extra(
-                service_root=limit_key,
+                limit_key=limit_key,
                 exception_type="TransportError",
             ),
         )

--- a/restgdf/resilience/_retry.py
+++ b/restgdf/resilience/_retry.py
@@ -17,7 +17,12 @@ from restgdf.errors import (
     TransportError,
 )
 from restgdf.resilience._errors import _parse_retry_after
-from restgdf.resilience._limiter import CooldownRegistry, LimiterRegistry, _service_root
+from restgdf.resilience._limiter import (
+    CooldownRegistry,
+    LimiterRegistry,
+    _host,
+    _service_root,
+)
 
 
 _log = get_logger("retry")
@@ -157,7 +162,12 @@ async def _do_retried_request(
     cooldown: CooldownRegistry | None = None,
 ) -> tuple[Any, Any]:
     """Execute request with stamina retry, token-bucket, and cooldown."""
-    svc_root = _service_root(url)
+    # Select the rate-limit/cooldown key granularity once from config, and use
+    # the SAME key for the token bucket AND the 429 cooldown (politeness
+    # decision D1: a host-level block wants a host-wide cooldown). Default
+    # "service_root" preserves the historical per-service keying exactly.
+    key_fn = _host if config.limiter_key == "host" else _service_root
+    limit_key = key_fn(url)
     # ``ClientConnectionError`` is the common base for every connection-shaped
     # aiohttp failure — ``ClientConnectorError`` (DNS/connect), ``ClientOSError``
     # (incl. ECONNRESET), ``ClientConnectionResetError``, ``ServerDisconnectedError``,
@@ -178,10 +188,10 @@ async def _do_retried_request(
     async def _attempt() -> tuple[Any, Any]:
         # 429 cooldown: wait if a previous 429 set a deadline for this service
         if cooldown is not None:
-            await cooldown.wait_if_cooling(svc_root)
+            await cooldown.wait_if_cooling(limit_key)
         # Token-bucket rate limit
         if limiter is not None:
-            await limiter.get(svc_root).acquire()
+            await limiter.get(limit_key).acquire()
         dispatch = getattr(inner, method)
         try:
             ctx, resp = await _enter_request(dispatch(url, **kwargs))
@@ -199,13 +209,13 @@ async def _do_retried_request(
                     if ra
                     else config.fallback_retry_after_seconds
                 )
-                cooldown.set_cooldown(svc_root, cd)
+                cooldown.set_cooldown(limit_key, cd)
                 _log.debug(
                     "429 cooldown set: key=%s seconds=%.3f",
-                    svc_root,
+                    limit_key,
                     cd,
                     extra=build_log_extra(
-                        service_root=svc_root,
+                        service_root=limit_key,
                         operation="cooldown",
                         limiter_wait_s=cd,
                     ),
@@ -230,16 +240,19 @@ async def _do_retried_request(
     # ``retry_context`` is the equivalent of the ``@stamina.retry`` decorator
     # (same kwargs) but exposes each attempt's number and backoff, so the
     # per-retry DEBUG log can name them (H1-N4). ``prev_wait`` carries the
-    # backoff that was applied *before* the current attempt.
+    # backoff that was applied *before* the current attempt. The retry policy
+    # is read from ``config`` (R2); the defaults on ``ResilienceConfig``
+    # (5 / 60.0 / 0.5 / 10.0 / 1.0) preserve the historical hardcoded values
+    # byte-for-byte, and ``config.enabled`` remains the sole retry gate.
     prev_wait = 0.0
     try:
         async for attempt in stamina.retry_context(
             on=retry_on,
-            attempts=5,
-            timeout=60.0,
-            wait_initial=0.5,
-            wait_max=10.0,
-            wait_jitter=1.0,
+            attempts=config.max_attempts,
+            timeout=config.retry_budget_s,
+            wait_initial=config.wait_initial_s,
+            wait_max=config.wait_max_s,
+            wait_jitter=config.wait_jitter_s,
         ):
             if attempt.num > 1:
                 _log.debug(
@@ -248,7 +261,7 @@ async def _do_retried_request(
                     prev_wait,
                     last_cause.get("cause", "unknown"),
                     extra=build_log_extra(
-                        service_root=svc_root,
+                        service_root=limit_key,
                         retry_attempt=attempt.num,
                         retry_delay_s=prev_wait,
                         exception_type=last_cause.get("cause"),
@@ -265,7 +278,7 @@ async def _do_retried_request(
             _log.debug(
                 "retry exhausted: status=429 mapped to RateLimitError",
                 extra=build_log_extra(
-                    service_root=svc_root,
+                    service_root=limit_key,
                     exception_type="RateLimitError",
                 ),
             )
@@ -280,7 +293,7 @@ async def _do_retried_request(
             "retry exhausted: status=%d mapped to RestgdfResponseError",
             exc.status,
             extra=build_log_extra(
-                service_root=svc_root,
+                service_root=limit_key,
                 exception_type="RestgdfResponseError",
             ),
         )
@@ -299,7 +312,7 @@ async def _do_retried_request(
             "retry exhausted: %s mapped to RestgdfTimeoutError",
             type(exc).__name__,
             extra=build_log_extra(
-                service_root=svc_root,
+                service_root=limit_key,
                 exception_type="RestgdfTimeoutError",
             ),
         )
@@ -313,7 +326,7 @@ async def _do_retried_request(
             "retry exhausted: %s mapped to TransportError",
             type(exc).__name__,
             extra=build_log_extra(
-                service_root=svc_root,
+                service_root=limit_key,
                 exception_type="TransportError",
             ),
         )
@@ -327,7 +340,7 @@ async def _do_retried_request(
             "retry exhausted: %s mapped to TransportError",
             type(exc).__name__,
             extra=build_log_extra(
-                service_root=svc_root,
+                service_root=limit_key,
                 exception_type="TransportError",
             ),
         )

--- a/restgdf/resilience/_retry.py
+++ b/restgdf/resilience/_retry.py
@@ -158,10 +158,17 @@ async def _do_retried_request(
 ) -> tuple[Any, Any]:
     """Execute request with stamina retry, token-bucket, and cooldown."""
     svc_root = _service_root(url)
+    # ``ClientConnectionError`` is the common base for every connection-shaped
+    # aiohttp failure — ``ClientConnectorError`` (DNS/connect), ``ClientOSError``
+    # (incl. ECONNRESET), ``ClientConnectionResetError``, ``ServerDisconnectedError``,
+    # and ``ServerTimeoutError`` — so retrying it covers mid-flight disconnects and
+    # resets that a bulk crawl routinely hits, not just connect-time and read-timeout
+    # failures. ``ClientPayloadError`` (truncated/incomplete body) is a sibling of
+    # ``ClientError`` outside that base, so it is listed separately.
     retry_on = (
         _RetryableHTTPError,
-        aiohttp.ClientConnectorError,
-        aiohttp.ServerTimeoutError,
+        aiohttp.ClientConnectionError,
+        aiohttp.ClientPayloadError,
     )
 
     @stamina.retry(
@@ -179,13 +186,8 @@ async def _do_retried_request(
         # Token-bucket rate limit
         if limiter is not None:
             await limiter.get(svc_root).acquire()
-        try:
-            dispatch = getattr(inner, method)
-            ctx, resp = await _enter_request(dispatch(url, **kwargs))
-        except aiohttp.ClientConnectorError:
-            raise  # retryable
-        except aiohttp.ServerTimeoutError:
-            raise  # retryable
+        dispatch = getattr(inner, method)
+        ctx, resp = await _enter_request(dispatch(url, **kwargs))
 
         if resp.status in _RETRYABLE_STATUS:
             headers = dict(getattr(resp, "headers", {}))
@@ -233,17 +235,25 @@ async def _do_retried_request(
             url=url,
             status_code=exc.status,
         ) from exc
-    except aiohttp.ClientConnectorError as exc:
-        raise TransportError(
-            f"Connection failed for {url}",
-            url=url,
-            status_code=None,
-        ) from exc
     except aiohttp.ServerTimeoutError as exc:
+        # ServerTimeoutError subclasses ClientConnectionError — map it first so
+        # read timeouts keep their dedicated RestgdfTimeoutError type fidelity.
         raise RestgdfTimeoutError(
             f"Read timeout: {exc}",
             url=url,
             timeout_kind="read",
+        ) from exc
+    except aiohttp.ClientPayloadError as exc:
+        raise TransportError(
+            f"Truncated or incomplete response body for {url}",
+            url=url,
+            status_code=None,
+        ) from exc
+    except aiohttp.ClientConnectionError as exc:
+        raise TransportError(
+            f"Connection failed for {url}",
+            url=url,
+            status_code=None,
         ) from exc
 
 

--- a/restgdf/utils/crawl.py
+++ b/restgdf/utils/crawl.py
@@ -133,16 +133,34 @@ async def safe_crawl(
     """Crawl an ArcGIS REST directory and aggregate results + errors.
 
     Unlike :func:`fetch_all_data`, this function never short-circuits on
-    the first failure. Every recoverable error is captured as a typed
-    :class:`~restgdf._models.crawl.CrawlError` entry in
+    the first failure. Every recoverable *service-level* error is captured
+    as a typed :class:`~restgdf._models.crawl.CrawlError` entry in
     :attr:`CrawlReport.errors` and successful services are always
     present in :attr:`CrawlReport.services`.
 
-    The three failure stages are ``"base_metadata"`` (root
+    The three ``CrawlError`` stages are ``"base_metadata"`` (root
     ``get_metadata`` call), ``"folder_metadata"`` (per-folder
     ``get_metadata`` call), and ``"service_metadata"`` (per-service
     ``service_metadata`` call). When a folder's metadata fails, services
     discovered in earlier folders (and the base) are still returned.
+
+    **Per-layer failures are NOT ``CrawlError`` entries.** Since 3.3, a
+    layer whose metadata call fails is contained *inside*
+    ``service_metadata`` (H2-1) so its siblings survive: the service still
+    lands in :attr:`CrawlReport.services` with ``metadata`` populated, and
+    the failed layer stays in the layer list carrying a ``layer_error``
+    marker (``"<ExcType>: <message>"``). Nothing is added to
+    :attr:`CrawlReport.errors`, so ``len(report.errors)`` alone will report
+    a service whose every layer failed as healthy. Each contained failure
+    emits one ``WARNING`` on the ``restgdf.crawl`` logger, and the markers
+    are countable in the returned data::
+
+        broken = [
+            layer
+            for entry in report.services
+            for layer in (entry.metadata.layers if entry.metadata else [])
+            if getattr(layer, "layer_error", None)
+        ]
     """
     errors: list[CrawlError] = []
     services_raw: list[dict[str, Any]] = []

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from aiohttp import ClientSession, ServerTimeoutError
+from aiohttp import ClientError, ClientSession, ServerTimeoutError
 from pydantic import BaseModel
 
 from restgdf._client._protocols import AsyncHTTPSession
@@ -52,7 +52,7 @@ from restgdf.utils._stats import (
     nested_count,
     nestedcount,
 )
-from restgdf.errors import RestgdfTimeoutError
+from restgdf.errors import RestgdfError, RestgdfTimeoutError
 
 try:
     from restgdf.resilience import bounded_retry_timeout as _resilience_bounded_retry
@@ -209,10 +209,32 @@ async def service_metadata(
         _raw.model_dump(by_alias=True) if isinstance(_raw, BaseModel) else dict(_raw)
     )
 
-    async def _comprehensive_metadata(layer_url: str) -> dict[str, Any]:
+    async def _comprehensive_metadata(
+        layer_id: Any,
+        layer_url: str,
+    ) -> dict[str, Any]:
         # ``bounded_gather`` below acquires ``sem`` once per task, so do NOT
         # re-acquire here — ``asyncio.Semaphore`` is not re-entrant.
-        layer_raw = await get_metadata(layer_url, session, token=token)
+        #
+        # H2-1: contain a per-layer metadata failure so one bad/secured/slow
+        # layer (an ArcGIS ``{"error": ...}`` envelope -> ``RestgdfError``, a
+        # dropped connection -> ``aiohttp.ClientError``, or a timeout ->
+        # ``TimeoutError``) does not propagate out of the ``bounded_gather``
+        # fan-out below (default ``return_exceptions=False``) and discard every
+        # sibling layer of the service. The failed layer stays VISIBLE in the
+        # returned layer list, annotated with a ``layer_error`` marker, instead
+        # of the whole service vanishing behind a single generic error. A
+        # service-ROOT metadata failure is deliberately NOT contained here (see
+        # the un-guarded ``get_metadata`` above): ``safe_crawl`` records that as
+        # a whole-service ``CrawlError``.
+        try:
+            layer_raw = await get_metadata(layer_url, session, token=token)
+        except (RestgdfError, ClientError, TimeoutError) as exc:
+            return {
+                "id": layer_id,
+                "url": layer_url,
+                "layer_error": f"{type(exc).__name__}: {exc}",
+            }
         metadata: dict[str, Any] = (
             layer_raw.model_dump(by_alias=True)
             if isinstance(layer_raw, BaseModel)
@@ -232,7 +254,7 @@ async def service_metadata(
         return metadata
 
     tasks = [
-        _comprehensive_metadata(f"{service_url}/{layer['id']}")
+        _comprehensive_metadata(layer["id"], f"{service_url}/{layer['id']}")
         for layer in _service_metadata.get("layers") or []
     ]
     # BL-01: enumerated fan-out site. ``bounded_gather`` holds ``sem`` for

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -57,7 +57,7 @@ from restgdf.utils._stats import (
     nested_count,
     nestedcount,
 )
-from restgdf._logging import build_log_extra, get_logger
+from restgdf._logging import _scrub_url, build_log_extra, get_logger
 from restgdf.errors import (
     RestgdfResponseError,
     RestgdfTimeoutError,
@@ -264,9 +264,12 @@ async def service_metadata(
             # ``CrawlReport.errors`` would see a 100%-failed service as healthy.
             # One WARNING per contained layer gives the crawl an aggregate
             # failure signal.
+            # R2: scrub the URL in the *message* too — ``build_log_extra``
+            # scrubs the extras, but a ``?token=`` in the message text would
+            # still reach handlers/aggregators verbatim.
             _crawl_log.warning(
                 "layer metadata failed, contained: url=%s error=%s",
-                layer_url,
+                _scrub_url(layer_url),
                 type(exc).__name__,
                 extra=build_log_extra(
                     service_root=service_url,

--- a/restgdf/utils/getinfo.py
+++ b/restgdf/utils/getinfo.py
@@ -16,7 +16,12 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from aiohttp import ClientError, ClientSession, ServerTimeoutError
+from aiohttp import (
+    ClientConnectionError,
+    ClientPayloadError,
+    ClientSession,
+    ServerTimeoutError,
+)
 from pydantic import BaseModel
 
 from restgdf._client._protocols import AsyncHTTPSession
@@ -52,12 +57,35 @@ from restgdf.utils._stats import (
     nested_count,
     nestedcount,
 )
-from restgdf.errors import RestgdfError, RestgdfTimeoutError
+from restgdf._logging import build_log_extra, get_logger
+from restgdf.errors import (
+    RestgdfResponseError,
+    RestgdfTimeoutError,
+    TransportError,
+)
 
 try:
     from restgdf.resilience import bounded_retry_timeout as _resilience_bounded_retry
 except ImportError:  # pragma: no cover - resilience extra not installed
     _resilience_bounded_retry = None  # type: ignore[assignment]
+
+_crawl_log = get_logger("crawl")
+
+# H2-1 / V2-M3: the transport + response failures a per-layer ``get_metadata``
+# may hit on a healthy crawl, contained so one bad layer cannot discard its
+# siblings. Deliberately NOT the ``RestgdfError`` / ``aiohttp.ClientError``
+# roots: those also cover ``ConfigurationError`` / ``OptionalDependencyError``
+# and ``InvalidURL`` / ``TooManyRedirects`` -- programming and misconfiguration
+# bugs, which must keep failing loudly on the first service instead of
+# degrading into thousands of identical ``layer_error`` strings.
+_CONTAINED_LAYER_ERRORS = (
+    RestgdfResponseError,
+    TransportError,
+    RestgdfTimeoutError,
+    ClientConnectionError,
+    ClientPayloadError,
+    TimeoutError,
+)
 
 __all__ = [
     "ClientSession",
@@ -217,19 +245,36 @@ async def service_metadata(
         # re-acquire here — ``asyncio.Semaphore`` is not re-entrant.
         #
         # H2-1: contain a per-layer metadata failure so one bad/secured/slow
-        # layer (an ArcGIS ``{"error": ...}`` envelope -> ``RestgdfError``, a
-        # dropped connection -> ``aiohttp.ClientError``, or a timeout ->
-        # ``TimeoutError``) does not propagate out of the ``bounded_gather``
-        # fan-out below (default ``return_exceptions=False``) and discard every
-        # sibling layer of the service. The failed layer stays VISIBLE in the
-        # returned layer list, annotated with a ``layer_error`` marker, instead
-        # of the whole service vanishing behind a single generic error. A
-        # service-ROOT metadata failure is deliberately NOT contained here (see
-        # the un-guarded ``get_metadata`` above): ``safe_crawl`` records that as
-        # a whole-service ``CrawlError``.
+        # layer (an ArcGIS ``{"error": ...}`` envelope -> ``RestgdfResponseError``,
+        # a dropped/truncated connection -> ``aiohttp.ClientConnectionError`` /
+        # ``ClientPayloadError`` / ``TransportError``, or a timeout) does not
+        # propagate out of the ``bounded_gather`` fan-out below (default
+        # ``return_exceptions=False``) and discard every sibling layer of the
+        # service. The failed layer stays VISIBLE in the returned layer list,
+        # annotated with a ``layer_error`` marker, instead of the whole service
+        # vanishing behind a single generic error. A service-ROOT metadata
+        # failure is deliberately NOT contained here (see the un-guarded
+        # ``get_metadata`` above): ``safe_crawl`` records that as a whole-service
+        # ``CrawlError``.
         try:
             layer_raw = await get_metadata(layer_url, session, token=token)
-        except (RestgdfError, ClientError, TimeoutError) as exc:
+        except _CONTAINED_LAYER_ERRORS as exc:
+            # V2-M1: the marker lives in returned DATA only, and a contained
+            # failure produces no ``CrawlError``, so an operator counting
+            # ``CrawlReport.errors`` would see a 100%-failed service as healthy.
+            # One WARNING per contained layer gives the crawl an aggregate
+            # failure signal.
+            _crawl_log.warning(
+                "layer metadata failed, contained: url=%s error=%s",
+                layer_url,
+                type(exc).__name__,
+                extra=build_log_extra(
+                    service_root=service_url,
+                    layer_id=layer_id if isinstance(layer_id, int) else None,
+                    operation="service_metadata",
+                    exception_type=type(exc).__name__,
+                ),
+            )
             return {
                 "id": layer_id,
                 "url": layer_url,

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -191,7 +191,6 @@ class TestResilienceBackendDeprecation:
     precedent) and keeps the field reachable and pinned here until 4.0.
     """
 
-    @pytest.mark.xfail(strict=True, reason="R5: fixed in next commit")
     def test_backend_env_var_emits_deprecation_warning(self) -> None:
         from restgdf._config import Config
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -176,3 +176,34 @@ def test_defaultdict_contents():
     assert DEFAULTDICT["returnGeometry"] is True
     assert DEFAULTDICT["returnCountOnly"] is False
     assert DEFAULTDICT["f"] == "json"
+
+
+# ---------------------------------------------------------------------------
+# ResilienceConfig.backend deprecation seam (R5) — deprecated 3.3, removed 4.0
+# ---------------------------------------------------------------------------
+
+
+class TestResilienceBackendDeprecation:
+    """``backend`` is a dead public field (only 'stamina' is implemented).
+
+    Per the repo's removal policy it cannot be deleted in a minor, so 3.3
+    deprecates the env-var path (mirroring the ``_DEPRECATED_ALIASES``
+    precedent) and keeps the field reachable and pinned here until 4.0.
+    """
+
+    @pytest.mark.xfail(strict=True, reason="R5: fixed in next commit")
+    def test_backend_env_var_emits_deprecation_warning(self) -> None:
+        from restgdf._config import Config
+
+        with pytest.warns(DeprecationWarning, match="RESTGDF_RESILIENCE_BACKEND"):
+            Config.from_env(env={"RESTGDF_RESILIENCE_BACKEND": "tenacity"})
+
+    def test_backend_field_stays_reachable_defaulting_to_stamina(self) -> None:
+        # Reachability is preserved in 3.3 (removal is 4.0) — green now and after
+        # the fix. Field construction must NOT warn (only the env path does), so
+        # this also guards against a Field(deprecated=True) regression that would
+        # trip the restgdf.* DeprecationWarning escalation.
+        from restgdf._config import ResilienceConfig
+
+        assert ResilienceConfig().backend == "stamina"
+        assert ResilienceConfig(backend="tenacity").backend == "tenacity"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -339,6 +339,21 @@ def test_inert_warning_lists_all_set_keys_in_one_warning() -> None:
     assert "RESTGDF_LIMITER_ENABLED" in msg
 
 
+def test_inert_warning_names_live_resilience_replacements() -> None:
+    # F5: the consolidated warning must point at the live RESTGDF_RESILIENCE_*
+    # replacements and say the RETRY/LIMITER knobs are deprecated -- not merely
+    # name what is dead.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Config.from_env(env={"RESTGDF_RETRY_MAX_ATTEMPTS": "10"})
+    inert = [w for w in caught if issubclass(w.category, InertConfigWarning)]
+    assert len(inert) == 1
+    msg = str(inert[0].message)
+    assert "deprecated" in msg.lower()
+    assert "RESTGDF_RESILIENCE_MAX_ATTEMPTS" in msg
+    assert "RESTGDF_RESILIENCE_LIMITER_KEY" in msg
+
+
 def test_honored_env_var_does_not_warn_inert() -> None:
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -1,13 +1,19 @@
 import asyncio
 import importlib
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aiohttp import ClientConnectionError, ClientSession
+from aiohttp import ClientConnectionError, ClientSession, InvalidURL
 from pandas import DataFrame
 
 from restgdf import get_config
-from restgdf.errors import FieldDoesNotExistError, RestgdfResponseError
+from restgdf.errors import (
+    ConfigurationError,
+    FieldDoesNotExistError,
+    OptionalDependencyError,
+    RestgdfResponseError,
+)
 from tests.id_schema_fixtures import load_id_schema_fixture
 from restgdf.utils.utils import ends_with_num, where_var_in_list
 from restgdf.utils.getinfo import (
@@ -815,3 +821,91 @@ async def test_service_metadata_still_raises_on_service_level_failure():
                 object(),
                 "https://example.com/service",
             )
+
+
+# ---------------------------------------------------------------------------
+# H2-1 follow-ups (V2-M1 / V2-M3): containment must be AUDIBLE, and it must
+# not absorb configuration / programming errors.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_service_metadata_logs_warning_per_contained_layer(caplog):
+    """A contained layer produces no ``CrawlError``, so it must at least
+    produce one ``restgdf.crawl`` WARNING naming the layer and the failure."""
+
+    async def fake_get_metadata(url, session, token=None):
+        if url.endswith("/service"):
+            return {"layers": [{"id": 0}, {"id": 1}, {"id": 2}]}
+        if url.endswith("/0"):
+            return {"type": "Feature Layer", "name": "ok"}
+        raise TimeoutError(f"{url} timed out")
+
+    with caplog.at_level(logging.WARNING, logger="restgdf.crawl"):
+        with patch(
+            "restgdf.utils.getinfo.get_metadata",
+            side_effect=fake_get_metadata,
+        ):
+            result = await service_metadata(
+                object(),
+                "https://example.com/service",
+            )
+
+    assert len(result.layers) == 3
+    records = [r for r in caplog.records if r.name == "restgdf.crawl"]
+    assert len(records) == 2, [r.getMessage() for r in records]
+    messages = sorted(r.getMessage() for r in records)
+    assert "https://example.com/service/1" in messages[0]
+    assert "TimeoutError" in messages[0]
+    assert "https://example.com/service/2" in messages[1]
+    assert records[0].levelno == logging.WARNING
+    assert records[0].exception_type == "TimeoutError"
+
+
+@pytest.mark.asyncio
+async def test_service_metadata_healthy_service_logs_nothing(caplog):
+    """Behaviour guard: no warning noise when every layer succeeds."""
+
+    async def fake_get_metadata(url, session, token=None):
+        if url.endswith("/service"):
+            return {"layers": [{"id": 0}]}
+        return {"type": "Feature Layer", "name": "ok"}
+
+    with caplog.at_level(logging.DEBUG, logger="restgdf"):
+        with patch(
+            "restgdf.utils.getinfo.get_metadata",
+            side_effect=fake_get_metadata,
+        ):
+            await service_metadata(object(), "https://example.com/service")
+
+    assert [r for r in caplog.records if r.name == "restgdf.crawl"] == []
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ConfigurationError("RESTGDF_TIMEOUT_TOTAL_S must be > 0"),
+        OptionalDependencyError("geopandas is required; pip install restgdf[geo]"),
+        InvalidURL("http://[bad"),
+    ],
+    ids=["configuration", "optional_dependency", "invalid_url"],
+)
+@pytest.mark.asyncio
+async def test_service_metadata_does_not_contain_config_or_programming_errors(exc):
+    """V2-M3: the catch set is the transport/response subset, not the
+    ``RestgdfError`` / ``aiohttp.ClientError`` roots. A misconfiguration or a
+    missing optional dependency must still fail loudly on the first service
+    rather than degrading into thousands of identical ``layer_error`` strings.
+    """
+
+    async def fake_get_metadata(url, session, token=None):
+        if url.endswith("/service"):
+            return {"layers": [{"id": 0}, {"id": 1}]}
+        raise exc
+
+    with patch(
+        "restgdf.utils.getinfo.get_metadata",
+        side_effect=fake_get_metadata,
+    ):
+        with pytest.raises(type(exc)):
+            await service_metadata(object(), "https://example.com/service")

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -3,11 +3,11 @@ import importlib
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from aiohttp import ClientSession
+from aiohttp import ClientConnectionError, ClientSession
 from pandas import DataFrame
 
 from restgdf import get_config
-from restgdf.errors import FieldDoesNotExistError
+from restgdf.errors import FieldDoesNotExistError, RestgdfResponseError
 from tests.id_schema_fixtures import load_id_schema_fixture
 from restgdf.utils.utils import ends_with_num, where_var_in_list
 from restgdf.utils.getinfo import (
@@ -684,3 +684,137 @@ async def test_service_metadata_sets_feature_count_none_when_count_lookup_fails(
         )
 
     assert result.layers[0].feature_count is None
+
+
+# ---------------------------------------------------------------------------
+# H2-1 — per-layer failure containment in ``service_metadata``
+#
+# Before the fix, a single layer whose ``get_metadata`` raises (a secured /
+# deleted / slow layer returning an ArcGIS ``{"error": ...}`` envelope, a
+# timeout, or a dropped connection) propagates out of ``service_metadata`` via
+# ``bounded_gather(return_exceptions=False)`` and discards EVERY sibling layer
+# of that service. These tests pin the containment contract: siblings survive
+# and the failed layer is annotated with a ``layer_error`` marker rather than
+# silently dropped.  Red-first (``xfail(strict=True)``) then flip green in the
+# fix commit per the repo's red-first rule.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(strict=True, reason="H2-1: fixed in next commit")
+@pytest.mark.asyncio
+async def test_service_metadata_contains_layer_response_error():
+    metadata_by_url = {
+        "https://example.com/service": {
+            "layers": [{"id": 0}, {"id": 1}, {"id": 2}],
+        },
+        "https://example.com/service/0": {"type": "Feature Layer", "name": "A"},
+        "https://example.com/service/2": {"type": "Feature Layer", "name": "C"},
+    }
+
+    async def fake_get_metadata(url, session, token=None):
+        if url.endswith("/1"):
+            raise RestgdfResponseError(
+                "LayerMetadata received ArcGIS error envelope "
+                "(code=499): Token Required",
+                model_name="LayerMetadata",
+                context=url,
+            )
+        return dict(metadata_by_url[url])
+
+    with patch(
+        "restgdf.utils.getinfo.get_metadata",
+        side_effect=fake_get_metadata,
+    ):
+        result = await service_metadata(
+            object(),
+            "https://example.com/service",
+        )
+
+    # The two sibling layers survived instead of the whole service vanishing.
+    assert len(result.layers) == 3
+    assert result.layers[0].name == "A"
+    assert result.layers[2].name == "C"
+
+    # The failed layer is present and VISIBLY annotated (not a silent drop).
+    failed = result.layers[1]
+    assert failed.id == 1
+    assert failed.url == "https://example.com/service/1"
+    dumped = failed.model_dump(by_alias=True)
+    assert "RestgdfResponseError" in dumped["layer_error"]
+    assert "Token Required" in dumped["layer_error"]
+
+
+@pytest.mark.xfail(strict=True, reason="H2-1: fixed in next commit")
+@pytest.mark.asyncio
+async def test_service_metadata_contains_layer_timeout():
+    async def fake_get_metadata(url, session, token=None):
+        if url.endswith("/service"):
+            return {"layers": [{"id": 0}, {"id": 1}]}
+        if url.endswith("/1"):
+            raise TimeoutError("layer /1 timed out")
+        return {"type": "Raster Layer", "name": "ok"}
+
+    with patch(
+        "restgdf.utils.getinfo.get_metadata",
+        side_effect=fake_get_metadata,
+    ):
+        result = await service_metadata(
+            object(),
+            "https://example.com/service",
+        )
+
+    assert len(result.layers) == 2
+    assert result.layers[0].name == "ok"
+    failed = result.layers[1]
+    assert failed.id == 1
+    assert failed.model_dump(by_alias=True)["layer_error"].startswith("TimeoutError")
+
+
+@pytest.mark.xfail(strict=True, reason="H2-1: fixed in next commit")
+@pytest.mark.asyncio
+async def test_service_metadata_contains_layer_connection_error():
+    async def fake_get_metadata(url, session, token=None):
+        if url.endswith("/service"):
+            return {"layers": [{"id": 0}, {"id": 1}]}
+        if url.endswith("/1"):
+            raise ClientConnectionError("connection reset by peer")
+        return {"type": "Feature Layer", "name": "ok"}
+
+    with patch(
+        "restgdf.utils.getinfo.get_metadata",
+        side_effect=fake_get_metadata,
+    ):
+        result = await service_metadata(
+            object(),
+            "https://example.com/service",
+        )
+
+    assert len(result.layers) == 2
+    assert result.layers[0].name == "ok"
+    failed = result.layers[1]
+    assert failed.id == 1
+    assert "ClientConnectionError" in failed.model_dump(by_alias=True)["layer_error"]
+
+
+@pytest.mark.asyncio
+async def test_service_metadata_still_raises_on_service_level_failure():
+    """Containment is per-layer only: a service-ROOT metadata failure still
+    propagates (the whole-service ``CrawlError`` path in ``safe_crawl`` relies
+    on this)."""
+
+    async def fake_get_metadata(url, session, token=None):
+        raise RestgdfResponseError(
+            "service root unreachable",
+            model_name="LayerMetadata",
+            context=url,
+        )
+
+    with patch(
+        "restgdf.utils.getinfo.get_metadata",
+        side_effect=fake_get_metadata,
+    ):
+        with pytest.raises(RestgdfResponseError):
+            await service_metadata(
+                object(),
+                "https://example.com/service",
+            )

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -863,6 +863,34 @@ async def test_service_metadata_logs_warning_per_contained_layer(caplog):
 
 
 @pytest.mark.asyncio
+async def test_contained_layer_warning_scrubs_token_urls(caplog):
+    """R2: the WARNING *message* must not leak ``?token=`` values. The
+    structured extras are scrubbed by ``build_log_extra``; the message text
+    interpolates the layer URL and must be scrubbed the same way."""
+
+    secret = "SUPERSECRETTOKEN123"  # noqa: S105 - fake credential for the probe
+    service_url = f"https://example.com/service?token={secret}"
+
+    async def fake_get_metadata(url, session, token=None):
+        if url == service_url:
+            return {"layers": [{"id": 0}]}
+        raise TimeoutError("boom")
+
+    with caplog.at_level(logging.WARNING, logger="restgdf.crawl"):
+        with patch(
+            "restgdf.utils.getinfo.get_metadata",
+            side_effect=fake_get_metadata,
+        ):
+            await service_metadata(object(), service_url)
+
+    records = [r for r in caplog.records if r.name == "restgdf.crawl"]
+    assert len(records) == 1
+    message = records[0].getMessage()
+    assert secret not in message, message
+    assert "token=***" in message
+
+
+@pytest.mark.asyncio
 async def test_service_metadata_healthy_service_logs_nothing(caplog):
     """Behaviour guard: no warning noise when every layer succeeds."""
 

--- a/tests/test_getinfo.py
+++ b/tests/test_getinfo.py
@@ -700,7 +700,6 @@ async def test_service_metadata_sets_feature_count_none_when_count_lookup_fails(
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason="H2-1: fixed in next commit")
 @pytest.mark.asyncio
 async def test_service_metadata_contains_layer_response_error():
     metadata_by_url = {
@@ -744,7 +743,6 @@ async def test_service_metadata_contains_layer_response_error():
     assert "Token Required" in dumped["layer_error"]
 
 
-@pytest.mark.xfail(strict=True, reason="H2-1: fixed in next commit")
 @pytest.mark.asyncio
 async def test_service_metadata_contains_layer_timeout():
     async def fake_get_metadata(url, session, token=None):
@@ -770,7 +768,6 @@ async def test_service_metadata_contains_layer_timeout():
     assert failed.model_dump(by_alias=True)["layer_error"].startswith("TimeoutError")
 
 
-@pytest.mark.xfail(strict=True, reason="H2-1: fixed in next commit")
 @pytest.mark.asyncio
 async def test_service_metadata_contains_layer_connection_error():
     async def fake_get_metadata(url, session, token=None):

--- a/tests/test_logging_extra_and_scrub.py
+++ b/tests/test_logging_extra_and_scrub.py
@@ -86,6 +86,7 @@ def test_build_log_extra_drops_none_keys() -> None:
 def test_build_log_extra_full_envelope_keys_match_contract() -> None:
     extra = build_log_extra(
         service_root="https://host/rest",
+        limit_key="https://host",
         layer_id=0,
         operation="query",
         page_index=1,
@@ -104,6 +105,21 @@ def test_build_log_extra_scrubs_service_root() -> None:
     extra = build_log_extra(service_root="https://host/x?token=X")
     assert "token=***" in extra["service_root"]
     assert "token=X" not in extra["service_root"]
+
+
+def test_build_log_extra_scrubs_limit_key() -> None:
+    # limit_key carries a URL-shaped rate-limit key (service root or bare host),
+    # so it gets the same token scrubbing as service_root.
+    extra = build_log_extra(limit_key="https://host/x?token=X")
+    assert "token=***" in extra["limit_key"]
+    assert "token=X" not in extra["limit_key"]
+
+
+def test_build_log_extra_limit_key_is_distinct_from_service_root() -> None:
+    # Under limiter_key="host" the emitted key is a bare host, which would be a
+    # mislabel under service_root (V1-M6).
+    extra = build_log_extra(limit_key="https://host")
+    assert set(extra.keys()) == {"limit_key"}
 
 
 def test_build_log_extra_caplog_roundtrip(

--- a/tests/test_resilience_config.py
+++ b/tests/test_resilience_config.py
@@ -60,3 +60,90 @@ class TestResilienceConfig:
                 get_config()
         finally:
             reset_config_cache()
+
+    # ---- R1: limiter_key granularity selector -----------------------------
+
+    def test_limiter_key_defaults_to_service_root(self) -> None:
+        assert ResilienceConfig().limiter_key == "service_root"
+
+    def test_limiter_key_accepts_host(self) -> None:
+        assert ResilienceConfig(limiter_key="host").limiter_key == "host"
+
+    def test_limiter_key_rejects_unknown_value(self) -> None:
+        with pytest.raises(ValidationError):
+            ResilienceConfig(limiter_key="region")  # type: ignore[arg-type]
+
+    def test_limiter_key_env_var_resolves(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RESTGDF_RESILIENCE_LIMITER_KEY", "host")
+        reset_config_cache()
+        try:
+            assert get_config().resilience.limiter_key == "host"
+        finally:
+            reset_config_cache()
+
+    def test_limiter_key_env_var_rejects_bad_value(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RESTGDF_RESILIENCE_LIMITER_KEY", "planet")
+        reset_config_cache()
+        try:
+            with pytest.raises((ConfigurationError, RestgdfResponseError)):
+                get_config()
+        finally:
+            reset_config_cache()
+
+    # ---- R2: retry knobs on ResilienceConfig ------------------------------
+
+    def test_retry_knob_defaults_preserve_hardcoded_policy(self) -> None:
+        cfg = ResilienceConfig()
+        assert cfg.max_attempts == 5
+        assert cfg.retry_budget_s == 60.0
+        assert cfg.wait_initial_s == 0.5
+        assert cfg.wait_max_s == 10.0
+        assert cfg.wait_jitter_s == 1.0
+
+    def test_max_attempts_env_var_resolves(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RESTGDF_RESILIENCE_MAX_ATTEMPTS", "2")
+        reset_config_cache()
+        try:
+            assert get_config().resilience.max_attempts == 2
+        finally:
+            reset_config_cache()
+
+    def test_retry_budget_env_var_resolves(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RESTGDF_RESILIENCE_RETRY_BUDGET_S", "12.5")
+        reset_config_cache()
+        try:
+            assert get_config().resilience.retry_budget_s == 12.5
+        finally:
+            reset_config_cache()
+
+    def test_wait_knob_env_vars_resolve(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("RESTGDF_RESILIENCE_WAIT_INITIAL_S", "0.25")
+        monkeypatch.setenv("RESTGDF_RESILIENCE_WAIT_MAX_S", "3.0")
+        monkeypatch.setenv("RESTGDF_RESILIENCE_WAIT_JITTER_S", "0")
+        reset_config_cache()
+        try:
+            cfg = get_config().resilience
+            assert cfg.wait_initial_s == 0.25
+            assert cfg.wait_max_s == 3.0
+            assert cfg.wait_jitter_s == 0.0
+        finally:
+            reset_config_cache()
+
+    def test_max_attempts_rejects_below_one(self) -> None:
+        with pytest.raises(ValidationError):
+            ResilienceConfig(max_attempts=0)

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -320,13 +320,17 @@ class TestCooldownRaceSafety:
                 reg.set_cooldown(key, 100.0)
 
         monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        before = reg._deadlines[key]
         await reg.wait_if_cooling(key)
 
         # Buggy code slept once on the 0.05s deadline then unconditionally
         # popped, erasing the fresher 100s cooldown. The fix re-reads the
-        # deadline after sleeping and honours the newer one (a second sleep).
-        assert len(sleeps) >= 2
-        assert max(sleeps) > 1.0
+        # deadline after sleeping and leaves the newer one in place for the
+        # next attempt/request to honour -- WITHOUT chaining a second wait
+        # inside this call (see TestCooldownWaitIsBounded).
+        assert key in reg._deadlines
+        assert reg._deadlines[key] > before
+        assert len(sleeps) == 1
 
     @pytest.mark.asyncio
     async def test_wait_clears_own_deadline_when_unchanged(
@@ -366,6 +370,77 @@ class TestCooldownRaceSafety:
 
         monkeypatch.setattr("asyncio.sleep", fake_sleep)
         await reg.wait_if_cooling(key)
+        assert key not in reg._deadlines
+
+
+class TestCooldownWaitIsBounded:
+    """A single in-attempt cooldown wait must not scale with concurrency.
+
+    ``wait_if_cooling`` is awaited *inside* a retried attempt, and stamina
+    evaluates ``stop_after_delay`` only between attempts, so neither
+    ``max_attempts`` nor ``retry_budget_s`` can interrupt a wait that re-loops.
+    Chaining waits made one attempt block for 14.8s at concurrency 16 against a
+    0.5s cooldown, falsifying ``respect_retry_after_max_s``'s documented cap
+    (V1-M2).
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_wait_even_under_repeated_concurrent_cooldowns(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from restgdf.resilience._limiter import CooldownRegistry
+
+        reg = CooldownRegistry()
+        key = "https://example.com/arcgis/rest/services/W/FeatureServer"
+        reg.set_cooldown(key, 0.05)
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(d: float, *a: Any, **kw: Any) -> None:
+            sleeps.append(d)
+            if len(sleeps) > 3:
+                raise AssertionError(
+                    "wait_if_cooling chained waits: one call must sleep once",
+                )
+            # Every wake loses the race to a fresh 429 on the same key -- the
+            # pathological shape that serialised every waiter pre-fix.
+            reg.set_cooldown(key, 100.0)
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        await reg.wait_if_cooling(key)
+
+        assert len(sleeps) == 1
+        assert sleeps[0] <= 0.05
+
+    @pytest.mark.asyncio
+    async def test_deferred_fresher_deadline_is_honoured_next_call(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Boundedness must not cost the N2 protection: the fresher deadline is
+        # deferred, not dropped -- the next attempt/request waits it out.
+        from restgdf.resilience._limiter import CooldownRegistry
+
+        reg = CooldownRegistry()
+        key = "https://example.com/arcgis/rest/services/V/FeatureServer"
+        reg.set_cooldown(key, 0.05)
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(d: float, *a: Any, **kw: Any) -> None:
+            sleeps.append(d)
+            if len(sleeps) == 1:
+                reg.set_cooldown(key, 7.0)
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        await reg.wait_if_cooling(key)
+        assert len(sleeps) == 1
+        assert key in reg._deadlines
+
+        await reg.wait_if_cooling(key)
+        assert len(sleeps) == 2
+        assert sleeps[1] > 1.0
         assert key not in reg._deadlines
 
 

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -160,7 +160,6 @@ _TRANSPORT_FACTORIES: list[tuple[str, Callable[[], Exception]]] = [
 
 
 class TestTransportErrorRetryAndMapping:
-    @pytest.mark.xfail(strict=True, reason="H1-M2: fixed in next commit")
     @pytest.mark.parametrize(
         ("_id", "make_exc"),
         _TRANSPORT_FACTORIES,

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -254,6 +254,26 @@ class TestCooldownRaceSafety:
         await reg.wait_if_cooling(key)
         assert key not in reg._deadlines
 
+    @pytest.mark.asyncio
+    async def test_wait_returns_when_deadline_cleared_during_sleep(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Defensive branch: if the key is cleared concurrently while sleeping,
+        # the waiter returns cleanly rather than re-looping.
+        from restgdf.resilience._limiter import CooldownRegistry
+
+        reg = CooldownRegistry()
+        key = "https://example.com/arcgis/rest/services/Z/FeatureServer"
+        reg.set_cooldown(key, 0.05)
+
+        async def fake_sleep(_d: float, *a: Any, **kw: Any) -> None:
+            reg._deadlines.pop(key, None)  # concurrent clear during the sleep
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        await reg.wait_if_cooling(key)
+        assert key not in reg._deadlines
+
 
 # ---------------------------------------------------------------------------
 # H1-N4 — the restgdf.retry logger must actually emit (dead-logger fix)
@@ -265,7 +285,6 @@ def _retry_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
 
 
 class TestRetryLogging:
-    @pytest.mark.xfail(strict=True, reason="H1-N4: fixed in next commit")
     @pytest.mark.asyncio
     async def test_retry_scheduled_emits_debug_log(
         self,
@@ -284,7 +303,6 @@ class TestRetryLogging:
             "retry scheduled" in m and "attempt=" in m and "wait=" in m for m in msgs
         ), msgs
 
-    @pytest.mark.xfail(strict=True, reason="H1-N4: fixed in next commit")
     @pytest.mark.asyncio
     async def test_429_cooldown_set_emits_debug_log(
         self,
@@ -301,7 +319,6 @@ class TestRetryLogging:
         msgs = _retry_messages(caplog)
         assert any("cooldown set" in m for m in msgs), msgs
 
-    @pytest.mark.xfail(strict=True, reason="H1-N4: fixed in next commit")
     @pytest.mark.asyncio
     async def test_exhaustion_mapping_emits_debug_log(
         self,

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -4,8 +4,12 @@ Covers four defects surfaced by the H1 adversarial health review, all latent
 behind the pre-3.3 all-green suite:
 
 * **H1-M1** — a sub-1.0 rate limit crashed with a raw, unmapped ``ValueError``.
-* **H1-M2** — mid-flight server disconnects / connection resets / truncated
-  bodies were neither retried nor mapped to a :class:`restgdf.errors.RestgdfError`.
+* **H1-M2** — dispatch-time server disconnects / connection resets were neither
+  retried nor mapped to a :class:`restgdf.errors.RestgdfError`. The retry
+  wrapper covers dispatch through *headers received* only, so a failure raised
+  while the response **body** is read stays out of scope — pinned below as a
+  known limitation rather than assumed away by a fixture that raises from
+  ``session.get()`` (which is not where aiohttp raises payload errors).
 * **H1-N2** — ``CooldownRegistry.wait_if_cooling`` could erase a concurrently-set
   *fresher* 429 cooldown deadline.
 * **H1-N4** — the ``restgdf.retry`` logger was dead; no retry/cooldown/mapping
@@ -132,7 +136,7 @@ class TestSubOneRateLimit:
 
 
 # ---------------------------------------------------------------------------
-# H1-M2 — mid-flight transport errors must be retried and mapped
+# H1-M2 — dispatch-time transport errors must be retried and mapped
 # ---------------------------------------------------------------------------
 
 
@@ -152,12 +156,36 @@ def _payload_error() -> aiohttp.ClientPayloadError:
     return aiohttp.ClientPayloadError("response payload was not fully received")
 
 
+# Failures a real aiohttp session raises from the request await itself, i.e.
+# inside the retry wrapper's scope. ``ClientPayloadError`` is deliberately NOT
+# here: aiohttp raises it on the payload stream, so it is covered separately.
 _TRANSPORT_FACTORIES: list[tuple[str, Callable[[], Exception]]] = [
     ("server_disconnected", _server_disconnected),
     ("client_os_error_econnreset", _conn_reset_oserror),
     ("client_connection_reset", _conn_reset),
-    ("client_payload_error", _payload_error),
 ]
+
+
+class _BodyFailingResponse(_FakeResponse):
+    """Response whose headers arrive fine but whose BODY read raises.
+
+    This is the shape aiohttp actually produces for a truncated / malformed
+    chunked / short-content-length body: the request await resolves once
+    headers are in, and ``ClientPayloadError`` is set on the payload stream
+    (``aiohttp/client_proto.py`` ``set_exception(self._payload, ...)``), so it
+    surfaces at ``resp.json()`` / ``resp.read()`` — after the retry wrapper has
+    already returned.
+    """
+
+    def __init__(self, exc: Exception, status: int = 200) -> None:
+        super().__init__(status)
+        self._exc = exc
+
+    async def read(self) -> bytes:
+        raise self._exc
+
+    async def json(self, *args: Any, **kwargs: Any) -> Any:
+        raise self._exc
 
 
 class TestTransportErrorRetryAndMapping:
@@ -178,9 +206,26 @@ class TestTransportErrorRetryAndMapping:
         with pytest.raises(RestgdfError) as exc_info:
             async with session.get(_SVC_URL) as resp:
                 await resp.read()
-        # Connection-shaped and payload/truncated-body failures both surface as
-        # TransportError (isinstance RestgdfError) after retrying to exhaustion.
+        # Connection-shaped dispatch failures surface as TransportError
+        # (isinstance RestgdfError) after retrying to exhaustion.
         assert isinstance(exc_info.value, TransportError)
+        assert stub._call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_payload_error_from_dispatch_is_mapped(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        """Defensive branch: an inner session that raises the payload error from
+        dispatch (a wrapping session, or aiohttp draining a redirect body) is
+        still retried and mapped. This is NOT the common truncated-body shape —
+        see ``TestPayloadErrorIsOutOfRetryScope`` for that.
+        """
+        stub = StubSession([_payload_error()] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(TransportError):
+            async with session.get(_SVC_URL) as resp:
+                await resp.read()
         assert stub._call_count == 5
 
     @pytest.mark.asyncio
@@ -196,6 +241,55 @@ class TestTransportErrorRetryAndMapping:
         with pytest.raises(RestgdfResponseError):
             async with session.get(_SVC_URL) as resp:
                 await resp.read()
+        assert stub._call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# H1-M2 (scope) — body-read failures are OUTSIDE the retry wrapper
+# ---------------------------------------------------------------------------
+
+_META_URL = "http://host/rest/services/X/FeatureServer/0"
+
+
+class TestPayloadErrorIsOutOfRetryScope:
+    """Pin the TRUE current behaviour of a mid-body transport failure.
+
+    ``_do_retried_request`` wraps ``dispatch(url, **kwargs)`` only, so it
+    returns once headers are received; every restgdf call site then reads the
+    body outside that scope (``restgdf.utils._query.get_metadata`` awaits
+    ``response.json(...)``). A failure raised there is therefore neither
+    retried nor mapped to a :class:`restgdf.errors.RestgdfError` — a known
+    limitation, documented in CHANGELOG and pinned here so it cannot silently
+    change (or silently be claimed fixed).
+    """
+
+    @pytest.mark.asyncio
+    async def test_payload_error_at_body_read_surfaces_raw_and_unretried(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        from restgdf.utils._query import get_metadata
+
+        stub = StubSession([_BodyFailingResponse(_payload_error())] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(aiohttp.ClientPayloadError) as exc_info:
+            await get_metadata(_META_URL, session)
+        # Raw aiohttp exception: unmapped ...
+        assert not isinstance(exc_info.value, RestgdfError)
+        # ... and unretried (one dispatch, not max_attempts).
+        assert stub._call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_mid_body_disconnect_also_surfaces_raw_and_unretried(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        from restgdf.utils._query import get_metadata
+
+        stub = StubSession([_BodyFailingResponse(_server_disconnected())] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(aiohttp.ServerDisconnectedError):
+            await get_metadata(_META_URL, session)
         assert stub._call_count == 1
 
 
@@ -318,6 +412,34 @@ class TestRetryLogging:
             await resp.read()
         msgs = _retry_messages(caplog)
         assert any("cooldown set" in m for m in msgs), msgs
+
+    @pytest.mark.asyncio
+    async def test_log_extra_uses_limit_key_not_service_root(
+        self,
+        _fast_sleep: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        # Under limiter_key="host" the emitted key is a bare host, so it rides
+        # the dedicated ``limit_key`` extra rather than mislabelling itself as
+        # ``service_root`` (V1-M6).
+        caplog.set_level(logging.DEBUG, logger="restgdf.retry")
+        stub = StubSession(
+            [_FakeResponse(429, {"Retry-After": "0"}), _FakeResponse(200)],
+        )
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(enabled=True, limiter_key="host"),
+        )
+        async with session.get(_SVC_URL) as resp:
+            await resp.read()
+        records = [
+            r
+            for r in caplog.records
+            if r.name == "restgdf.retry" and "cooldown set" in r.getMessage()
+        ]
+        assert records, [r.getMessage() for r in caplog.records]
+        assert records[0].limit_key == "http://host"
+        assert not hasattr(records[0], "service_root")
 
     @pytest.mark.asyncio
     async def test_exhaustion_mapping_emits_debug_log(

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -17,15 +17,11 @@ per the repo's red-first rule.
 
 from __future__ import annotations
 
-import errno
-import logging
 from typing import Any
 
-import aiohttp
 import pytest
 
 from restgdf._config import ResilienceConfig
-from restgdf.errors import RestgdfError, TransportError
 from restgdf.resilience import ResilientSession
 from restgdf.resilience._limiter import LimiterRegistry
 
@@ -55,7 +51,10 @@ class _FakeResponse:
 class StubSession:
     """AsyncHTTPSession stub replaying queued responses/exceptions."""
 
-    def __init__(self, responses: list[_FakeResponse | Exception] | None = None) -> None:
+    def __init__(
+        self,
+        responses: list[_FakeResponse | Exception] | None = None,
+    ) -> None:
         self._responses = list(responses or [])
         self._call_count = 0
         self._closed = False
@@ -106,14 +105,12 @@ class TestSubOneRateLimit:
         assert lim.max_rate == 5.0
         assert lim.time_period == 1
 
-    @pytest.mark.xfail(strict=True, reason="H1-M1: fixed in next commit")
     def test_sub_one_rate_construction_uses_stretched_period(self) -> None:
         # 0.5 req/s => 1 token every 2 seconds, not AsyncLimiter(0.5, 1).
         lim = LimiterRegistry(rate_per_second=0.5).get("svc")
         assert lim.max_rate == 1
         assert lim.time_period == pytest.approx(2.0)
 
-    @pytest.mark.xfail(strict=True, reason="H1-M1: fixed in next commit")
     @pytest.mark.asyncio
     async def test_sub_one_rate_request_succeeds(self, _fast_sleep: None) -> None:
         stub = StubSession([_FakeResponse(200)])

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -17,11 +17,15 @@ per the repo's red-first rule.
 
 from __future__ import annotations
 
+import errno
+from collections.abc import Callable
 from typing import Any
 
+import aiohttp
 import pytest
 
 from restgdf._config import ResilienceConfig
+from restgdf.errors import RestgdfError, TransportError
 from restgdf.resilience import ResilientSession
 from restgdf.resilience._limiter import LimiterRegistry
 
@@ -123,4 +127,73 @@ class TestSubOneRateLimit:
         )
         async with session.get(_SVC_URL) as resp:
             assert resp.status == 200
+        assert stub._call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# H1-M2 — mid-flight transport errors must be retried and mapped
+# ---------------------------------------------------------------------------
+
+
+def _server_disconnected() -> aiohttp.ServerDisconnectedError:
+    return aiohttp.ServerDisconnectedError("server dropped the connection")
+
+
+def _conn_reset_oserror() -> aiohttp.ClientOSError:
+    return aiohttp.ClientOSError(errno.ECONNRESET, "connection reset by peer")
+
+
+def _conn_reset() -> aiohttp.ClientConnectionResetError:
+    return aiohttp.ClientConnectionResetError("cannot write to closing transport")
+
+
+def _payload_error() -> aiohttp.ClientPayloadError:
+    return aiohttp.ClientPayloadError("response payload was not fully received")
+
+
+_TRANSPORT_FACTORIES: list[tuple[str, Callable[[], Exception]]] = [
+    ("server_disconnected", _server_disconnected),
+    ("client_os_error_econnreset", _conn_reset_oserror),
+    ("client_connection_reset", _conn_reset),
+    ("client_payload_error", _payload_error),
+]
+
+
+class TestTransportErrorRetryAndMapping:
+    @pytest.mark.xfail(strict=True, reason="H1-M2: fixed in next commit")
+    @pytest.mark.parametrize(
+        ("_id", "make_exc"),
+        _TRANSPORT_FACTORIES,
+        ids=[c[0] for c in _TRANSPORT_FACTORIES],
+    )
+    @pytest.mark.asyncio
+    async def test_transport_error_retried_to_exhaustion_and_mapped(
+        self,
+        _fast_sleep: None,
+        _id: str,
+        make_exc: Callable[[], Exception],
+    ) -> None:
+        stub = StubSession([make_exc()] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(RestgdfError) as exc_info:
+            async with session.get(_SVC_URL) as resp:
+                await resp.read()
+        # Connection-shaped and payload/truncated-body failures both surface as
+        # TransportError (isinstance RestgdfError) after retrying to exhaustion.
+        assert isinstance(exc_info.value, TransportError)
+        assert stub._call_count == 5
+
+    @pytest.mark.asyncio
+    async def test_deterministic_4xx_still_not_retried(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        # Behaviour-preservation guard: a non-429 4xx must never retry.
+        from restgdf.errors import RestgdfResponseError
+
+        stub = StubSession([_FakeResponse(404)])
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(RestgdfResponseError):
+            async with session.get(_SVC_URL) as resp:
+                await resp.read()
         assert stub._call_count == 1

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -1,0 +1,129 @@
+"""Correctness tests for resilience core (3.3.0 lane IMPL-1).
+
+Covers four defects surfaced by the H1 adversarial health review, all latent
+behind the pre-3.3 all-green suite:
+
+* **H1-M1** — a sub-1.0 rate limit crashed with a raw, unmapped ``ValueError``.
+* **H1-M2** — mid-flight server disconnects / connection resets / truncated
+  bodies were neither retried nor mapped to a :class:`restgdf.errors.RestgdfError`.
+* **H1-N2** — ``CooldownRegistry.wait_if_cooling`` could erase a concurrently-set
+  *fresher* 429 cooldown deadline.
+* **H1-N4** — the ``restgdf.retry`` logger was dead; no retry/cooldown/mapping
+  logging existed despite the tracing recipe promising it.
+
+Red tests land first (``xfail(strict=True)``) then flip green in the fix commit
+per the repo's red-first rule.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+from typing import Any
+
+import aiohttp
+import pytest
+
+from restgdf._config import ResilienceConfig
+from restgdf.errors import RestgdfError, TransportError
+from restgdf.resilience import ResilientSession
+from restgdf.resilience._limiter import LimiterRegistry
+
+
+# ---------------------------------------------------------------------------
+# Shared stubs (mirror tests/test_resilience_retry.py's harness)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal response stub supporting async-context use."""
+
+    def __init__(self, status: int, headers: dict[str, str] | None = None) -> None:
+        self.status = status
+        self.headers = headers or {}
+
+    async def read(self) -> bytes:
+        return b"ok"
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+
+class StubSession:
+    """AsyncHTTPSession stub replaying queued responses/exceptions."""
+
+    def __init__(self, responses: list[_FakeResponse | Exception] | None = None) -> None:
+        self._responses = list(responses or [])
+        self._call_count = 0
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        return self._dispatch()
+
+    def post(self, url: str, **kwargs: Any) -> Any:
+        return self._dispatch()
+
+    def _dispatch(self) -> Any:
+        self._call_count += 1
+        idx = min(self._call_count - 1, len(self._responses) - 1)
+        resp = self._responses[idx]
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+@pytest.fixture()
+def _fast_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``asyncio.sleep`` so retry tests do not actually wait."""
+
+    async def _instant_sleep(_d: float, *a: Any, **kw: Any) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+
+# ---------------------------------------------------------------------------
+# H1-M1 — sub-1.0 rate must not crash
+# ---------------------------------------------------------------------------
+
+_SVC_URL = "http://host/rest/services/X/FeatureServer/0/query"
+
+
+class TestSubOneRateLimit:
+    def test_rate_ge_one_construction_unchanged(self) -> None:
+        # Behaviour-preservation guard: rate >= 1 keeps AsyncLimiter(rate, 1).
+        lim = LimiterRegistry(rate_per_second=5.0).get("svc")
+        assert lim.max_rate == 5.0
+        assert lim.time_period == 1
+
+    @pytest.mark.xfail(strict=True, reason="H1-M1: fixed in next commit")
+    def test_sub_one_rate_construction_uses_stretched_period(self) -> None:
+        # 0.5 req/s => 1 token every 2 seconds, not AsyncLimiter(0.5, 1).
+        lim = LimiterRegistry(rate_per_second=0.5).get("svc")
+        assert lim.max_rate == 1
+        assert lim.time_period == pytest.approx(2.0)
+
+    @pytest.mark.xfail(strict=True, reason="H1-M1: fixed in next commit")
+    @pytest.mark.asyncio
+    async def test_sub_one_rate_request_succeeds(self, _fast_sleep: None) -> None:
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(
+                enabled=True,
+                rate_per_service_root_per_second=0.5,
+            ),
+        )
+        async with session.get(_SVC_URL) as resp:
+            assert resp.status == 200
+        assert stub._call_count == 1

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -204,7 +204,6 @@ class TestTransportErrorRetryAndMapping:
 
 
 class TestCooldownRaceSafety:
-    @pytest.mark.xfail(strict=True, reason="H1-N2: fixed in next commit")
     @pytest.mark.asyncio
     async def test_wait_preserves_fresher_concurrent_deadline(
         self,

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -216,10 +216,14 @@ class TestTransportErrorRetryAndMapping:
         self,
         _fast_sleep: None,
     ) -> None:
-        """Defensive branch: an inner session that raises the payload error from
-        dispatch (a wrapping session, or aiohttp draining a redirect body) is
-        still retried and mapped. This is NOT the common truncated-body shape —
-        see ``TestPayloadErrorIsOutOfRetryScope`` for that.
+        """Defensive branch: an inner session implementation (e.g. a wrapping
+        adapter) that surfaces ``ClientPayloadError`` from dispatch itself is
+        still retried and mapped. Plain aiohttp has no known dispatch-time
+        path that raises it (R2 verified: redirect-body draining converts to
+        ``ClientConnectionError`` internally); this keeps the ``retry_on``
+        entry and its exhaustion mapping covered for non-aiohttp inners. NOT
+        the common truncated-body shape — see
+        ``TestPayloadErrorIsOutOfRetryScope`` for that.
         """
         stub = StubSession([_payload_error()] * 10)
         session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -18,6 +18,7 @@ per the repo's red-first rule.
 from __future__ import annotations
 
 import errno
+import logging
 from collections.abc import Callable
 from typing import Any
 
@@ -252,3 +253,66 @@ class TestCooldownRaceSafety:
         monkeypatch.setattr("asyncio.sleep", fake_sleep)
         await reg.wait_if_cooling(key)
         assert key not in reg._deadlines
+
+
+# ---------------------------------------------------------------------------
+# H1-N4 — the restgdf.retry logger must actually emit (dead-logger fix)
+# ---------------------------------------------------------------------------
+
+
+def _retry_messages(caplog: pytest.LogCaptureFixture) -> list[str]:
+    return [r.getMessage() for r in caplog.records if r.name == "restgdf.retry"]
+
+
+class TestRetryLogging:
+    @pytest.mark.xfail(strict=True, reason="H1-N4: fixed in next commit")
+    @pytest.mark.asyncio
+    async def test_retry_scheduled_emits_debug_log(
+        self,
+        _fast_sleep: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="restgdf.retry")
+        stub = StubSession(
+            [_server_disconnected(), _server_disconnected(), _FakeResponse(200)],
+        )
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        async with session.get(_SVC_URL) as resp:
+            await resp.read()
+        msgs = _retry_messages(caplog)
+        assert any(
+            "retry scheduled" in m and "attempt=" in m and "wait=" in m for m in msgs
+        ), msgs
+
+    @pytest.mark.xfail(strict=True, reason="H1-N4: fixed in next commit")
+    @pytest.mark.asyncio
+    async def test_429_cooldown_set_emits_debug_log(
+        self,
+        _fast_sleep: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="restgdf.retry")
+        stub = StubSession(
+            [_FakeResponse(429, {"Retry-After": "0"}), _FakeResponse(200)],
+        )
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        async with session.get(_SVC_URL) as resp:
+            await resp.read()
+        msgs = _retry_messages(caplog)
+        assert any("cooldown set" in m for m in msgs), msgs
+
+    @pytest.mark.xfail(strict=True, reason="H1-N4: fixed in next commit")
+    @pytest.mark.asyncio
+    async def test_exhaustion_mapping_emits_debug_log(
+        self,
+        _fast_sleep: None,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="restgdf.retry")
+        stub = StubSession([_server_disconnected()] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(TransportError):
+            async with session.get(_SVC_URL) as resp:
+                await resp.read()
+        msgs = _retry_messages(caplog)
+        assert any("exhaust" in m.lower() and "TransportError" in m for m in msgs), msgs

--- a/tests/test_resilience_correctness.py
+++ b/tests/test_resilience_correctness.py
@@ -196,3 +196,60 @@ class TestTransportErrorRetryAndMapping:
             async with session.get(_SVC_URL) as resp:
                 await resp.read()
         assert stub._call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# H1-N2 — cooldown wait must not erase a concurrently-set fresher deadline
+# ---------------------------------------------------------------------------
+
+
+class TestCooldownRaceSafety:
+    @pytest.mark.xfail(strict=True, reason="H1-N2: fixed in next commit")
+    @pytest.mark.asyncio
+    async def test_wait_preserves_fresher_concurrent_deadline(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from restgdf.resilience._limiter import CooldownRegistry
+
+        reg = CooldownRegistry()
+        key = "https://example.com/arcgis/rest/services/X/FeatureServer"
+        reg.set_cooldown(key, 0.05)  # short initial deadline
+
+        sleeps: list[float] = []
+
+        async def fake_sleep(d: float, *a: Any, **kw: Any) -> None:
+            sleeps.append(d)
+            if len(sleeps) == 1:
+                # Simulate a concurrent 429 installing a *fresher* (longer)
+                # deadline while this waiter is asleep on the original one.
+                reg.set_cooldown(key, 100.0)
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        await reg.wait_if_cooling(key)
+
+        # Buggy code slept once on the 0.05s deadline then unconditionally
+        # popped, erasing the fresher 100s cooldown. The fix re-reads the
+        # deadline after sleeping and honours the newer one (a second sleep).
+        assert len(sleeps) >= 2
+        assert max(sleeps) > 1.0
+
+    @pytest.mark.asyncio
+    async def test_wait_clears_own_deadline_when_unchanged(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Behaviour-preservation guard: with no concurrent set, the waiter
+        # still clears its own (expired) deadline exactly once.
+        from restgdf.resilience._limiter import CooldownRegistry
+
+        reg = CooldownRegistry()
+        key = "https://example.com/arcgis/rest/services/Y/FeatureServer"
+        reg.set_cooldown(key, 0.05)
+
+        async def fake_sleep(_d: float, *a: Any, **kw: Any) -> None:
+            return None
+
+        monkeypatch.setattr("asyncio.sleep", fake_sleep)
+        await reg.wait_if_cooling(key)
+        assert key not in reg._deadlines

--- a/tests/test_resilience_wiring.py
+++ b/tests/test_resilience_wiring.py
@@ -1,0 +1,319 @@
+"""Config-wiring tests for the resilience executor (3.3.0 lane IMPL-2).
+
+Covers the two additive, default-preserving wirings that finish restgdf's
+declared "wire ResilienceConfig fully" debt:
+
+* **R1** — ``ResilienceConfig.limiter_key`` selects the rate-limit / 429-cooldown
+  key granularity (``"service_root"`` default vs ``"host"``); the token bucket
+  and the cooldown share the SAME selected key (politeness decision D1).
+* **R2** — the stamina executor reads ``max_attempts`` / ``retry_budget_s`` /
+  ``wait_initial_s`` / ``wait_max_s`` / ``wait_jitter_s`` from the config it
+  already receives, instead of hardcoded literals. Defaults preserve the old
+  policy byte-for-byte and ``ResilienceConfig.enabled`` stays the sole gate.
+
+These are additive with behaviour-preserving defaults, so tests ship alongside
+the code (no red-first flip required).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aiohttp
+import pytest
+import stamina
+
+from restgdf._config import ResilienceConfig
+from restgdf.errors import TransportError
+from restgdf.resilience import ResilientSession
+from restgdf.resilience._limiter import CooldownRegistry
+from restgdf.resilience._retry import _do_retried_request
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Minimal response stub supporting async-context use."""
+
+    def __init__(self, status: int, headers: dict[str, str] | None = None) -> None:
+        self.status = status
+        self.headers = headers or {}
+
+    async def read(self) -> bytes:
+        return b"ok"
+
+    async def __aenter__(self) -> _FakeResponse:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+
+class StubSession:
+    """AsyncHTTPSession stub replaying queued responses/exceptions."""
+
+    def __init__(
+        self,
+        responses: list[_FakeResponse | Exception] | None = None,
+    ) -> None:
+        self._responses = list(responses or [])
+        self._call_count = 0
+        self._closed = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    async def close(self) -> None:
+        self._closed = True
+
+    def get(self, url: str, **kwargs: Any) -> Any:
+        return self._dispatch()
+
+    def post(self, url: str, **kwargs: Any) -> Any:
+        return self._dispatch()
+
+    def _dispatch(self) -> Any:
+        self._call_count += 1
+        idx = min(self._call_count - 1, len(self._responses) - 1)
+        resp = self._responses[idx]
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+class _CooldownSpy(CooldownRegistry):
+    """Records the keys passed to wait/set without doing real waits."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.wait_keys: list[str] = []
+        self.set_calls: list[tuple[str, float]] = []
+
+    async def wait_if_cooling(self, key: str) -> None:
+        self.wait_keys.append(key)
+
+    def set_cooldown(self, key: str, seconds: float) -> None:
+        self.set_calls.append((key, seconds))
+
+
+@pytest.fixture()
+def _fast_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch ``asyncio.sleep`` so retry tests do not actually wait."""
+
+    async def _instant_sleep(_d: float, *a: Any, **kw: Any) -> None:
+        return None
+
+    monkeypatch.setattr("asyncio.sleep", _instant_sleep)
+
+
+_URL_A = "http://host/rest/services/A/FeatureServer/0/query"
+_URL_B = "http://host/rest/services/B/FeatureServer/0/query"
+
+
+# ---------------------------------------------------------------------------
+# R1 — limiter_key granularity: token-bucket keying
+# ---------------------------------------------------------------------------
+
+
+class TestLimiterKeyBucketing:
+    @pytest.mark.asyncio
+    async def test_service_root_default_keys_per_service(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession([_FakeResponse(200)] * 4)
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(
+                enabled=True,
+                rate_per_service_root_per_second=100.0,
+            ),
+        )
+        for url in (_URL_A, _URL_B):
+            async with session.get(url) as resp:
+                await resp.read()
+        assert session._limiter is not None
+        assert set(session._limiter._limiters) == {
+            "http://host/rest/services/A/FeatureServer",
+            "http://host/rest/services/B/FeatureServer",
+        }
+
+    @pytest.mark.asyncio
+    async def test_host_granularity_shares_one_bucket_across_services(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession([_FakeResponse(200)] * 4)
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(
+                enabled=True,
+                rate_per_service_root_per_second=100.0,
+                limiter_key="host",
+            ),
+        )
+        for url in (_URL_A, _URL_B):
+            async with session.get(url) as resp:
+                await resp.read()
+        assert session._limiter is not None
+        # Both services on the same host collapse to a single host bucket.
+        assert set(session._limiter._limiters) == {"http://host"}
+
+
+# ---------------------------------------------------------------------------
+# R1 — limiter_key granularity: 429 cooldown keying follows the same selector
+# ---------------------------------------------------------------------------
+
+
+class TestCooldownKeyGranularity:
+    @pytest.mark.asyncio
+    async def test_service_root_default_cools_per_service(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession(
+            [_FakeResponse(429, {"Retry-After": "1"}), _FakeResponse(200)],
+        )
+        cooldown = _CooldownSpy()
+        ctx, resp = await _do_retried_request(
+            stub,
+            ResilienceConfig(enabled=True),
+            "get",
+            _URL_A,
+            {},
+            cooldown=cooldown,
+        )
+        assert resp.status == 200
+        assert cooldown.set_calls == [
+            ("http://host/rest/services/A/FeatureServer", 1.0),
+        ]
+        assert (
+            cooldown.wait_keys
+            == [
+                "http://host/rest/services/A/FeatureServer",
+            ]
+            * 2
+        )
+        await ctx.__aexit__(None, None, None)
+
+    @pytest.mark.asyncio
+    async def test_host_granularity_cools_per_host(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        stub = StubSession(
+            [_FakeResponse(429, {"Retry-After": "1"}), _FakeResponse(200)],
+        )
+        cooldown = _CooldownSpy()
+        ctx, resp = await _do_retried_request(
+            stub,
+            ResilienceConfig(enabled=True, limiter_key="host"),
+            "get",
+            _URL_A,
+            {},
+            cooldown=cooldown,
+        )
+        assert resp.status == 200
+        # Cooldown keys on the host, matching the bucket granularity (D1).
+        assert cooldown.set_calls == [("http://host", 1.0)]
+        assert cooldown.wait_keys == ["http://host"] * 2
+        await ctx.__aexit__(None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# R2 — retry knobs read from config
+# ---------------------------------------------------------------------------
+
+
+def _capture_retry_context(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Spy on ``stamina.retry_context`` kwargs while keeping real behaviour."""
+    captured: dict[str, Any] = {}
+    real = stamina.retry_context
+
+    def _spy(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return real(**kwargs)
+
+    monkeypatch.setattr(stamina, "retry_context", _spy)
+    return captured
+
+
+class TestRetryKnobsFromConfig:
+    @pytest.mark.asyncio
+    async def test_defaults_preserve_hardcoded_policy_byte_for_byte(
+        self,
+        _fast_sleep: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = _capture_retry_context(monkeypatch)
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        async with session.get(_URL_A) as resp:
+            await resp.read()
+        assert captured["attempts"] == 5
+        assert captured["timeout"] == 60.0
+        assert captured["wait_initial"] == 0.5
+        assert captured["wait_max"] == 10.0
+        assert captured["wait_jitter"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_config_values_flow_into_stamina(
+        self,
+        _fast_sleep: None,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        captured = _capture_retry_context(monkeypatch)
+        stub = StubSession([_FakeResponse(200)])
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(
+                enabled=True,
+                max_attempts=2,
+                retry_budget_s=30.0,
+                wait_initial_s=0.1,
+                wait_max_s=2.0,
+                wait_jitter_s=0.0,
+            ),
+        )
+        async with session.get(_URL_A) as resp:
+            await resp.read()
+        assert captured["attempts"] == 2
+        assert captured["timeout"] == 30.0
+        assert captured["wait_initial"] == 0.1
+        assert captured["wait_max"] == 2.0
+        assert captured["wait_jitter"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_raised_max_attempts_limits_dispatch_count(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        # A behaviour proof (not just kwargs): max_attempts=2 => exactly two
+        # dispatches to the inner session before exhaustion maps to TransportError.
+        stub = StubSession([aiohttp.ServerDisconnectedError("drop")] * 10)
+        session = ResilientSession(
+            inner=stub,
+            config=ResilienceConfig(enabled=True, max_attempts=2),
+        )
+        with pytest.raises(TransportError):
+            async with session.get(_URL_A) as resp:
+                await resp.read()
+        assert stub._call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_default_max_attempts_still_five(
+        self,
+        _fast_sleep: None,
+    ) -> None:
+        # Behaviour-preservation guard: unset max_attempts keeps the historical
+        # 5-attempt exhaustion count.
+        stub = StubSession([aiohttp.ServerDisconnectedError("drop")] * 10)
+        session = ResilientSession(inner=stub, config=ResilienceConfig(enabled=True))
+        with pytest.raises(TransportError):
+            async with session.get(_URL_A) as resp:
+                await resp.read()
+        assert stub._call_count == 5


### PR DESCRIPTION
# feat: resilience correctness + config wiring (3.3.0)

Closes the warn-now/wire-later resilience debt (W2-13 / TRANSPORT-01 path (a)) and the
correctness defects surfaced by the 2026-07-24 govgis-crawl review + health check
(`scratch/govgis-crawl-review/response.md`, not in this diff). 26 commits, red-first
throughout, every commit gate-green.

## Correctness (Fixed)
- **Sub-1.0 `rate_per_service_root_per_second` no longer crashes** — polite fractional rates
  (0.5 = one request per 2s) now pace correctly instead of raising a raw `ValueError` on the
  first request (H1-M1).
- **Dispatch-time transport failures are retried and mapped** — `ServerDisconnectedError`,
  `ClientOSError`/ECONNRESET, dispatch-time `ClientPayloadError` now retry and surface as
  `TransportError` on exhaustion. *Known limitation (documented): mid-body payload errors
  occur outside the retry scope and surface raw; body-read retry is a recorded design item.*
- **429 cooldown honors concurrently-set fresher deadlines without unbounded chaining** —
  a single in-attempt wait is bounded by the deadline observed at entry (H1-N2 + V1-M2).
- **One failing layer no longer discards its whole service's metadata** — per-layer failures
  are contained as `layer_error` markers with a `restgdf.crawl` WARNING per contained layer;
  configuration/programming errors still fail loudly (H2-1 + V2-M1/M3).

## Config wiring (Added)
- **`ResilienceConfig.limiter_key: "service_root" | "host"`** — limiter + 429-cooldown
  granularity selector (per the recorded politeness decision; default preserves behavior).
- **`ResilienceConfig.max_attempts / retry_budget_s / wait_initial_s / wait_max_s /
  wait_jitter_s`** — the retry executor now reads the config it receives; defaults are
  byte-for-byte the previous hardcoded policy (verified by diffing effective stamina kwargs).
  `ResilienceConfig.enabled` remains the sole gate.
- **`restgdf.retry` DEBUG logging is now real** (retry scheduled / cooldown set / exhaustion
  mapping) with a `limit_key` structured extra.

## Deprecations
- `RetryConfig.max_attempts/.max_delay_s`, `LimiterConfig.rate_per_host` (inert; live
  replacements on `ResilienceConfig`; removal in 4.0). `RESTGDF_RESILIENCE_BACKEND` now warns
  (`DeprecationWarning`; field removed in 4.0). InertConfigWarning text now names the live
  replacement knobs.

## Docs
- New `docs/recipes/bulk_crawl.md` — the polite-bulk-crawl composition (wrapping, granularity
  incl. multi-tenant SaaS shard guidance, UA etiquette via the one lever that actually reaches
  the wire, concurrency + timeout caveats, live-vs-inert-vs-deprecated knob table). Every code
  block executed against a stubbed transport; UA asserted at the WIRE, not the config field.
- `docs/resilience.rst` no longer implies the extra self-applies; README surfaces
  `[resilience]` in Installation; CHANGELOG footer links repaired (were 404s three ways) and
  now enforced by a release gate; 3.2.0 UA "per-request override" claim scoped to the
  feature/query surfaces.

## Verification
Built and fixed via staged agent workflows with two adversarial verify rounds (reports under
`scratch/impl-3.3/`, git-excluded): round 1 killed a fixture-fiction test, a concurrency
regression in the first cooldown fix, a docs example whose UA never reached the wire, and a
monitoring blind spot; round 2 re-ran the original breaking probes green. Final: pytest 1400
passed offline · coverage 98% (floor 97) · pre-commit clean · sphinx -n -W clean · build +
twine --strict clean · compat suite green.

## Release checklist (3.3.0)
- [ ] Support-floor review (runbook: due at each minor)
- [ ] CHANGELOG: rename `## [Unreleased]` → `## [3.3.0] - <date>` + add `[3.3.0]:` footer link
      (both release gates check this)
- [ ] bumpver dispatch (minor) → env approval → verify PyPI + attestation (rerun attestation
      if it races the index)

Deferred with named triggers: body-read retry (design item); per-request `headers=` threading
(non-UA need); H2-3 folder-fetch concurrency (needs ordering test); `layer["id"]` KeyError
residual (3.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012c7DbkZwTrxHy4HSoCM9Sg
